### PR TITLE
typo: removed extra . from cat / rm command

### DIFF
--- a/cli/download_model.py
+++ b/cli/download_model.py
@@ -8,5 +8,5 @@ def download_model():
     click.echo("\n1. You can download the files manually from the latest release on GitHub or use the `gh` command line tool:")
     click.secho('\ngh release download v0.0.0 --repo "https://github.com/open-labrador/cli.git"', fg="blue")
     click.echo("\n2. Once the files are downloaded, use `cat` to combine them:")
-    click.secho('\ncat ggml-labrador13B-model-Q4_K_M.gguf.split.* > ggml-labrador13B-model-Q4_K_M.gguf && rm ggml-labrador13B-model-Q4_K_M..gguf.split.*', fg="blue")
+    click.secho('\ncat ggml-labrador13B-model-Q4_K_M.gguf.split.* > ggml-labrador13B-model-Q4_K_M.gguf && rm ggml-labrador13B-model-Q4_K_M.gguf.split.*', fg="blue")
     click.echo("\nThe resulting ggml-labrador13B-model-Q4_K_M.gguf file is the model, ready to be trained, tested, or served.")


### PR DESCRIPTION
Small typo in the `download` PR that keeps the `rm` portion of the command from running.