### PR TITLE
Remove hard-coded logit_bias token (fix Mistral)

### DIFF
--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -159,7 +159,6 @@ def generate_data(
             model_name=model_name,
             batch_size=request_batch_size,
             decoding_args=decoding_args,
-            logit_bias={"50256": -100},  # prevent the <|endoftext|> token from being generated
         )
         request_duration = time.time() - request_start
 


### PR DESCRIPTION
This is out-of-range for Mistral.  Cannot hardcode a token like this.