### PR TITLE
generate from taxonomy

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -42,9 +42,11 @@ def serve(model, n_gpu_layers):
 @cli.command()
 @click.option("--model", default="ggml-labrador13B-model-Q4_K_M", show_default=True)
 @click.option("--num_cpus", default=10, show_default=True)
-def generate(model, num_cpus):
+@click.option("--taxonomy", default="../taxonomy", show_default=True, type=click.Path())
+@click.option("--seed_file", default="./cli/generator/seed_tasks.jsonl", show_default=True, type=click.Path())
+def generate(model, num_cpus, taxonomy, seed_file):
     """Generates synthetic data to enhance your example data"""
-    generate_data(model_name=model, num_cpus=num_cpus)
+    generate_data(model_name=model, num_cpus=num_cpus, taxonomy=taxonomy, seed_tasks_path=seed_file)
 
 
 @cli.command()


### PR DESCRIPTION
* generate takes a --taxonomy "../taxonomy" param (with that default) and walks the dir to read in .yaml or .yml files as input. Use --taxonomy "" to skip this.
* The old seed file is still there and also used by default. I think this should be removed (at least by default) but first step is just a param with default behavoir like now.
* If both are used, both are used.
* If both are "", there is no work to do.

Also,

* Turned down the number of instructions per batch to reduce token limit errors.
* Commented out some extra info that we might not want in the output.