### PR TITLE
more README cleanup around serve and generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ Python bindings for llama.cpp):
   ```
   cd cli
   source venv/bin/activate
-  python -m cli generate
+  python -m cli generate --seed_file '' --taxonomy taxonomy
   ```
 
+  ⚠️  **Note:** The `--seed_file` argument will go away; the `--taxonomy` flag will point the command at the `taxonomy` checkout.
   📋 **Note:** This takes about **~45 minutes** to complete on an M1 mac with 16 GB RAM. The synthetic data set will be a file starting with the name `regen` ending in a `.jsonl` file extension in the root `cli/` directory of the `cli` git checkout.
 
 - Train the model on your synthetic data-enhanced dataset using **train**:


### PR DESCRIPTION
- some spacing / formatting cleanup
- adding up-front note under 'how to use' section that all subsequent commands in the instructions assume being in the root directory of the cli git repo checkout
- adding a note about the default model with M1 time estimate and information about the `--model` argument on both serve and generate
- adding note under the serve section about time estimate to complete and the file name and location of the generated synthetic data
- removing a timestamp i had put in the previous version of the doc because it shouldn't have made it into the file lol
- updating model link from labradorite to malachite
- updating info around the `init` command
- fixing broken links in the how to convert + quantize models section
- adding the `--taxonomy taxonomy` argument to the `generate` command so it works; right now `generate` assumes the taxonomy checkout dir is a peer dir of the cli checkout dir instead of a subdir... let's just be explicit about the taxonomy dir location for now to minimize error.