### PR TITLE
Enable configuration for generate command

### DIFF
--- a/cli/config/config.py
+++ b/cli/config/config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 from typing import Any, Optional
 import yaml
 
@@ -26,6 +27,9 @@ _DEF_NUM_GPUS = 10
 _DEF_NUM_GPU_LAYERS = -1
 _DEF_SESSION = ""
 _DEF_CONTEXT = ""
+_DEF_NUM_INSTRS = 100
+_DEF_SEED_TASK_PATH = "./cli/generator/seed_tasks.jsonl"
+_DEF_PROMPT_FILE_PATH = "./cli/generator/prompt.txt"
 _CHAT_CATEGORY = "chat"
 _GENERATE_CATEGORY = "generate"
 _LIST_CATEGORY = "list"
@@ -39,6 +43,9 @@ _PATH_TO_TAX_SETTING = "path_to_taxonomy"
 _NUM_CPUS_SETTING = "num_cpus"
 _LEVEL_SETTING = "level"
 _NUM_GPUS_LAY_SETTING = "num_gpu_layers"
+_NUM_INSTS_SETTING = "num_instructions_to_generate"
+_SEED_TASK_PATH_SETTING = "seed_tasks_path"
+_PROMPT_FILE_PATH = "prompt_file_path"
 
 
 class Config(object):
@@ -49,6 +56,9 @@ class Config(object):
             cfg_file = config_yml_path
         else:
             cfg_file = _DEF_CFG_FILE
+
+        if not os.path.exists(cfg_file):
+            raise ValueError("Config file doesn't exist: ", cfg_file)
 
         with open(cfg_file, "r") as yamlfile:
             self.cfg = yaml.load(yamlfile, Loader=yaml.FullLoader)
@@ -77,7 +87,16 @@ class Config(object):
     
     def get_generate_taxonomy(self) -> str:
         return self._get_setting(_GENERATE_CATEGORY, _PATH_TO_TAX_SETTING, _DEF_TAXONOMY_PATH)
-    
+
+    def get_generate_num_instructions(self) -> int:
+        return self._get_setting(_GENERATE_CATEGORY, _NUM_INSTS_SETTING, _DEF_NUM_INSTRS)
+
+    def get_generate_seed_task_path(self) -> str:
+        return self._get_setting(_GENERATE_CATEGORY, _SEED_TASK_PATH_SETTING, _DEF_SEED_TASK_PATH)
+
+    def get_generate_prompt_file_path(self) -> str:
+        return self._get_setting(_GENERATE_CATEGORY, _PROMPT_FILE_PATH, _DEF_PROMPT_FILE_PATH)
+
     def get_list_taxonomy(self) -> str:
         return self._get_setting(_LIST_CATEGORY, _PATH_TO_TAX_SETTING, _DEF_TAXONOMY_PATH)
     

--- a/cli/config/config.yml
+++ b/cli/config/config.yml
@@ -20,7 +20,10 @@ chat:
 generate:
   model: "ggml-malachite-7b-Q4_K_M"
   num_cpus: 10
+  num_instructions_to_generate: 100
   path_to_taxonomy: "./taxonomy"
+  prompt_file_path: "./cli/generator/prompt.txt"
+  seed_tasks_path: "./cli/generator/seed_tasks.jsonl"
 
 list:
   path_to_taxonomy: "./taxonomy"

--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import time
+from typing import Optional
 import json
 import os
 from os.path import splitext
@@ -16,11 +17,12 @@ import tqdm
 from rouge_score import rouge_scorer
 
 from . import utils
+from ..config.config import Config
 
 
-def encode_prompt(prompt_instructions):
+def encode_prompt(prompt_instructions, prompt_file):
     """Encode multiple prompt instructions into a single string."""
-    prompt = open("cli/generator/prompt.txt").read() + "\n"
+    prompt = open(prompt_file).read() + "\n"
 
     for idx, task_dict in enumerate(prompt_instructions):
         (instruction, input, output) = task_dict["instruction"], task_dict["input"], task_dict["output"]
@@ -103,17 +105,33 @@ def find_word_in_string(w, s):
 
 def generate_data(
     logger,
-    output_dir=None,
-    taxonomy="../taxonomy",
-    seed_tasks_path="",  # "./cli/generator/seed_tasks.jsonl",
-    model_name="ggml-labrador13B-model-Q4_K_M",
+    config: Config,
+    output_dir: Optional[str] = None,
+    taxonomy: Optional[str] = None,
+    seed_tasks_path: Optional[str] = None,
+    prompt_file_path: Optional[str] = None,
+    model_name: Optional[str] = None,
+    num_cpus: Optional[int] = None,
+    num_instructions_to_generate: Optional[int] = None,
     num_prompt_instructions=2,
     request_batch_size=5,
     temperature=1.0,
     top_p=1.0,
-    num_cpus=10,
-    num_instructions_to_generate=100,
 ):
+    # Load generate configuration from config file unless already overwritten by the CLI
+    if not taxonomy:
+        taxonomy = config.get_generate_taxonomy()
+    if not seed_tasks_path:
+        seed_tasks_path = config.get_generate_seed_task_path()
+    if not prompt_file_path:
+        prompt_file_path = config.get_generate_prompt_file_path()
+    if not model_name:
+        model_name = config.get_generate_model()
+    if not num_cpus:
+        num_cpus = config.get_generate_num_cpus()
+    if not num_instructions_to_generate:
+        num_instructions_to_generate = config.get_generate_num_instructions()
+
     seed_instruction_data = []
     generate_start = time.time()
 
@@ -214,7 +232,7 @@ def generate_data(
         for _ in range(request_batch_size):
             # only sampling from the seed tasks
             prompt_instructions = random.sample(seed_instruction_data, num_prompt_instructions)
-            prompt = encode_prompt(prompt_instructions)
+            prompt = encode_prompt(prompt_instructions, prompt_file_path)
             batch_inputs.append(prompt)
         decoding_args = utils.OpenAIDecodingArguments(
             temperature=temperature,

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -76,16 +76,16 @@ def serve(ctx, model, gpu_layers):
 
 
 @cli.command()
-@click.option("--model", default="ggml-malachite-7b-Q4_K_M", show_default=True)
-@click.option("--num-cpus", default=10, show_default=True)
-@click.option("--num-instructions", default=100, show_default=True)
-@click.option("--taxonomy", default="taxonomy", show_default=True, type=click.Path())
-@click.option("--seed-file", default="./cli/generator/seed_tasks.jsonl", show_default=True, type=click.Path())
+@click.option("--model")
+@click.option("--num-cpus")
+@click.option("--num-instructions")
+@click.option("--taxonomy")
+@click.option("--seed-file", type=click.Path())
 @click.pass_context
 def generate(ctx, model, num_cpus, num_instructions, taxonomy, seed_file):
     """Generates synthetic data to enhance your example data"""
     ctx.obj.logger.debug(f"Generating model '{model}' using {num_cpus} cpus, taxonomy: '{taxonomy}' and seed '{seed_file}'")
-    generate_data(logger=ctx.obj.logger, model_name=model, num_cpus=num_cpus,
+    generate_data(logger=ctx.obj.logger, config=ctx.obj.config, model_name=model, num_cpus=num_cpus,
                   num_instructions_to_generate=num_instructions, taxonomy=taxonomy, seed_tasks_path=seed_file)
 
 


### PR DESCRIPTION
Partial-fix: #47 

**Note for reviewers:**
- Adds `prompt file` configuration setting
- Does not remove `seed file` as #65 needs to be merged to replace it
- Needed to disable `click.option` default values so that they would be loaded from config file if not set from CLI. We need to revisit this to that the description is improved for usability overall.