### PR TITLE
feat(cli init): Add init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,14 @@ Using the Labrador 🐶 method involves a number of steps, supported by various 
 ## 🏗️ 1. Initial setup
 
 ### Initialize environment
-- Initialize a local environment to use Labrador 🐶 via the **init**
+- Create an empty directory `project_dir` and change the current directory into `project_dir`. Initialize a local environment to use Labrador 🐶 via the **init**
 command:
 
-  ```ShellSession
-  mkdir proj && cd proj
+  ```shell
   lab init
   ```
 
-  It will clone the `git@github.com:open-labrador/taxonomy.git` repository and create the `config.yml` in the local directory.
+  It will clone the `git@github.com:open-labrador/taxonomy.git` repository.
 
 ### Download model
 

--- a/cli/download.py
+++ b/cli/download.py
@@ -24,7 +24,7 @@ def download_model(gh_repo='https://github.com/open-labrador/cli.git', gh_releas
     click.secho('\nMake sure the local environment has the "gh" cli. https://cli.github.com', fg="blue")
     click.echo("\nDownloading Models from %s with version %s to local directory %s ...\n" % (gh_repo, gh_release, dir))
 
-    # Download Github release
+    # Download GitHub release
     download_commands = ['gh', 'release', 'download', gh_release, '--repo', gh_repo, '--dir', dir]
     if pattern != '':
         download_commands.extend(['--pattern', pattern])
@@ -84,7 +84,7 @@ def clone_taxonomy(gh_repo='https://github.com/open-labrador/taxonomy.git',
 
     Parameters:
     - gh_repo (str): The URL of the taxonomy Git repository. Default is the Open Labrador taxonomy repository.
-    - gh_branch (str): The Github branch of the taxonomy repository. Default is main
+    - gh_branch (str): The GitHub branch of the taxonomy repository. Default is main
     - git_filter_spec(str): Optional path to the git filter spec for git partial clone
 
     Returns:
@@ -96,7 +96,7 @@ def clone_taxonomy(gh_repo='https://github.com/open-labrador/taxonomy.git',
     # Clone taxonomy repo
     git_clone_commands = ['git', 'clone', gh_repo]
     if git_filter_spec != '' and os.path.exists(git_filter_spec):
-        # TODO: Add gitfilterspec to sparse clone github repo
+        # TODO: Add gitfilterspec to sparse clone GitHub repo
         git_filter_arg = ''.join(['--filter=sparse:oid=', gh_branch, ':', git_filter_spec])
         git_sparse_clone_flags = ['--sparse', git_filter_arg]
         git_clone_commands.extend(git_sparse_clone_flags)
@@ -109,7 +109,7 @@ def clone_taxonomy(gh_repo='https://github.com/open-labrador/taxonomy.git',
     click.echo('Git clone completed.')
 
 
-def create_config_file(config_path='.'):
+def create_config_file(config_file_name='./config.yml'):
     """
     Create default config file. 
     TODO: Remove this function after config class is updated.
@@ -162,13 +162,14 @@ def create_config_file(config_path='.'):
       n_gpu_layers: -1
     """
     )
-    config_file_path = os.path.normpath(config_path) + '/config.yml'
-    if os.path.isfile(config_file_path):
-        click.echo('Skip config file generation because it already exists at %s' % config_file_path)
+    if os.path.isfile(config_file_name):
+        click.echo('Skip config file generation because it already exists at %s' % config_file_name)
     else:
-        with open(config_file_path, "w") as model_file:
+        if os.path.dirname(config_file_name) != '':
+            os.makedirs(os.path.dirname(config_file_name), exist_ok=True)
+        with open(config_file_name, "w") as model_file:
             model_file.write(config_yml_txt)
-        click.echo('Config file is created at %s' % config_file_path)
+        click.echo('Config file is created at %s' % config_file_name)
 
 def create_subprocess(commands):
     return subprocess.run(commands, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -25,6 +25,7 @@ class Lab(object):
 
 
 def configure(ctx, param, filename):
+    create_config_file(filename)
     ctx.obj = Lab(filename)
     default_map = dict()
     # options in default_map must match the names of variables
@@ -62,19 +63,18 @@ def cli(ctx, config):
     "--repo",
     default="https://github.com/open-labrador/taxonomy.git",
     show_default=True,
-    help="Labrador Taxonomy Github repository"
+    help="Labrador Taxonomy GitHub repository"
 )
 @click.option(
     "--branch",
     default="main",
     show_default=True,
-    help="The Github branch of the taxonomy repository."
+    help="The GitHub branch of the taxonomy repository."
 )
 @click.pass_context
 def init(ctx, repo, branch):
     """Initializes environment for labrador"""
     clone_taxonomy(repo, branch)
-    create_config_file()
 
 
 @cli.command()
@@ -170,13 +170,13 @@ def chat(ctx, question, model, context, session, qq):
     "--repo",
     default="https://github.com/open-labrador/cli.git",
     show_default=True,
-    help="Github repository of the hosted models."
+    help="GitHub repository of the hosted models."
 )
 @click.option(
     "--release",
     default="latest",
     show_default=True,
-    help="Github release version of the hosted models."
+    help="GitHub release version of the hosted models."
 )
 @click.option(
     "--dir",


### PR DESCRIPTION
fixes #42 

Add basic functionality for the cli init command. Will follow up with #62 when I understand the requirements in more details.

Usage:
```
% python -m cli init --help
Usage: python -m cli init [OPTIONS]

  Initializes environment for labrador

Options:
  --repo TEXT      Labrador Taxonomy Github repository  [default:
                   https://github.com/open-labrador/taxonomy.git]
  --branch TEXT    The Github branch of the taxonomy repository.  [default:
                   main]
  --help           Show this message and exit.
```

```
% python -m cli init

Cloning repository https://github.com/open-labrador/taxonomy.git with branch "main" to taxonomy ...

Cloning into 'taxonomy'...

Git clone completed.
Config file is created at ./config.yml
```