### PR TITLE
Use serve config to determine models dir and model prefix for download

### DIFF
--- a/cli/config/config.yml
+++ b/cli/config/config.yml
@@ -14,11 +14,12 @@
 
 chat:
   context: ""
-  model: "ggml-malachite-7b-Q4_K_M"
+  model: "ggml-malachite-7b-0226-Q4_K_M"
+
   session: ""
 
 generate:
-  model: "ggml-malachite-7b-Q4_K_M"
+  model: "ggml-malachite-7b-0226-Q4_K_M"
   num_cpus: 10
   num_instructions_to_generate: 100
   path_to_taxonomy: "./taxonomy"
@@ -32,5 +33,5 @@ log:
     level: info
 
 serve:
-  model_path: "./models/ggml-malachite-7b-Q4_K_M.gguf"
+  model_path: "./models/ggml-malachite-7b-0226-Q4_K_M.gguf"
   n_gpu_layers: -1

--- a/cli/download.py
+++ b/cli/download.py
@@ -164,9 +164,7 @@ def create_config_file(config_file_name='./config.yml'):
       n_gpu_layers: -1
     """
     )
-    if os.path.isfile(config_file_name):
-        click.echo('Skip config file generation because it already exists at %s' % config_file_name)
-    else:
+    if not os.path.isfile(config_file_name):
         if os.path.dirname(config_file_name) != '':
             os.makedirs(os.path.dirname(config_file_name), exist_ok=True)
         with open(config_file_name, "w") as model_file:

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -7,7 +7,7 @@ from llama_cpp.server.settings import Settings
 import uvicorn
 import logging
 from git import Repo
-from os.path import splitext
+from os.path import splitext, dirname, basename
 
 from .generator.generate_data import generate_data
 from .download import download_model, clone_taxonomy, create_config_file
@@ -189,17 +189,21 @@ def chat(ctx, question, model, context, session, qq):
 )
 @click.option(
     "--dir",
-    default=".",
-    show_default=True,
     help="The local directory to download the model files into."
 )
 @click.option(
     "--pattern",
-    default="",
-    show_default=True,
     help="Download only assets that match a glob pattern."
 )
 @click.pass_context
 def download(ctx, repo, release, dir, pattern):
     """Download the model(s) to train"""
+
+    # Use the serve model path to get the right models in the right place, if needed
+    serve_model_path = ctx.obj.config.get_serve_model_path()
+    if serve_model_path:  # if set in config
+        if not dir:  # --dir takes precedence
+            dir = dirname(serve_model_path)
+        if not pattern:  # --pattern takes precedence
+            pattern = basename(serve_model_path).replace(".gguf", ".*")
     download_model(repo, release, dir, pattern)


### PR DESCRIPTION
Update default config to the current model.
Config and defaults is still evolving, but this allows the flow to work. So models will be in the dir expected.
The .gguf is replaced with .* so we can download splits.

Closes: #95
Fixes: #92