### PR TITLE
fix: handling of --taxonomy argument

### DIFF
--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -168,7 +168,7 @@ def generate_data(
             # Default output_dir to taxonomy dir, using the dir not the parent
             output_dir = output_dir or os.path.abspath(taxonomy)
             # Gather the new or changed YAMLs using git diff
-            repo = Repo("taxonomy")
+            repo = Repo(taxonomy)
             updated_taxonomy_files = [u for u in repo.untracked_files if splitext(u)[1].lower() in [".yaml", ".yml"]] + \
                 [d.a_path for d in repo.index.diff(None) if splitext(d.a_path)[1].lower() in [".yaml", ".yml"]]
             errors = 0
@@ -177,7 +177,7 @@ def generate_data(
                 if splitext(f)[1] != ".yaml":
                     logger.warn(f"WARNING: Skipping {f}! Use lowercase '.yaml' extension instead.")
                     continue
-                file_path = os.path.join("taxonomy", f)
+                file_path = os.path.join(taxonomy, f)
                 try:
                     with open(file_path, 'r') as file:
                         contents = yaml.safe_load(file)

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -84,7 +84,7 @@ def init(ctx, repo, branch):
 @click.pass_context
 def list(ctx, taxonomy):
     """List taxonomy YAML files"""
-    repo = Repo("taxonomy")
+    repo = Repo(taxonomy)
     updated_taxonomy_files = [u for u in repo.untracked_files if splitext(u)[1].lower() in [".yaml", ".yml"]] + \
                 [d.a_path for d in repo.index.diff(None) if splitext(d.a_path)[1].lower() in [".yaml", ".yml"]]
     for f in updated_taxonomy_files:


### PR DESCRIPTION
The --taxonomy argument is currently essentially ignored with the path set in several places to "taxonomy".
This fixes this problem.

