### PR TITLE
add positional arg for workspace

### DIFF
--- a/cli/download.py
+++ b/cli/download.py
@@ -113,6 +113,7 @@ def clone_taxonomy(
     gh_repo="https://github.com/open-labrador/taxonomy.git",
     gh_branch="main",
     git_filter_spec="",
+    dir='taxonomy'
 ):
     """
     Clone the taxonomy repository from a Git repository source.
@@ -122,6 +123,7 @@ def clone_taxonomy(
         Default is the Open Labrador taxonomy repository.
     - gh_branch (str): The GitHub branch of the taxonomy repository. Default is main
     - git_filter_spec(str): Optional path to the git filter spec for git partial clone
+    - dir(str): Optional path to clone the repo into. Defaults to taxonomy in your current working directory.
 
     Returns:
     - None
@@ -130,7 +132,7 @@ def clone_taxonomy(
     click.echo('\nCloning repository %s with branch "%s" ...' % (gh_repo, gh_branch))
 
     # Clone taxonomy repo
-    git_clone_commands = ["git", "clone", gh_repo]
+    git_clone_commands = ['git', 'clone', gh_repo, dir]
     if git_filter_spec != "" and os.path.exists(git_filter_spec):
         # TODO: Add gitfilterspec to sparse clone GitHub repo
         git_filter_arg = "".join(

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -87,10 +87,17 @@ def cli(ctx, config):
     show_default=True,
     help="The GitHub branch of the taxonomy repository.",
 )
+@click.argument(
+    'dir', 
+    required=False,
+    type=click.Path(exists=False)
+)
 @click.pass_context
-def init(ctx, repo, branch):
+def init(ctx, repo, branch, dir):
+    if dir == None:
+        dir = 'taxonomy'
     """Initializes environment for labrador"""
-    clone_taxonomy(repo, branch)
+    clone_taxonomy(repo, branch, '', dir)
 
 
 @cli.command()


### PR DESCRIPTION
set up a click.argument that defaults to './taxonomy' so that users can specify a non-existent dir to clone into when using lab init.

usage: lab init <dir>

resolves #109