### PR TITLE
Update the readme to point to git+ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ mkdir <project_dir>
 cd <project_dir>
 python3 -m venv venv
 source venv/bin/activate
-pip install git+https://github.com/open-labrador/cli.git
+pip install git+ssh://git@github.com/open-labrador/cli.git
 ```
 
 ## 🚀 Running `lab`


### PR DESCRIPTION
This repo is private. So using pip install git+https to install as
detailed in the " From GitHub " section of the README installation
instructions, will never work because GitHub deprecated git+https auth in
2021.

We need to update the readme to point to git+ssh.
Fixes #130 