### PR TITLE
Fixing --repo tag to --repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ command:
   
   To initialize the Taxonomy from a private repository source, please use the git SSH endpoint of the private repository:
   ```shell
-  lab init --repo git@github.com:open-labrador/taxonomy.git
+  lab init --repository git@github.com:open-labrador/taxonomy.git
   ```
 
   It will clone the `git@github.com:open-labrador/taxonomy.git` repository.


### PR DESCRIPTION
**Description**: Doc bug in in README -> Initialize environment section, shows `--repo` when it should be `--repository` 

**Section:** [README.md](https://github.com/open-labrador/cli/blob/main/README.md?plain=1#L112)

<img width="693" alt="Screenshot 2024-02-29 at 11 34 20 AM" src="https://github.com/open-labrador/cli/assets/86735520/efd392fc-fd67-4b8d-a908-fce8af7f4306">
