### PR TITLE
adds port option to `lab serve` and `lab chat`

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -59,6 +59,7 @@ PRICING_RATE = {
 
 PROMPT_PREFIX = ">>> "
 
+
 # TODO Autosave chat history
 class ConsoleChatBot:
     def __init__(
@@ -341,7 +342,7 @@ class ConsoleChatBot:
         self._update_conversation(response_content.plain, "assistant")
 
 
-def chat_cli(question, model, context, session, qq) -> None:
+def chat_cli(question, model, context, session, qq, port=None) -> None:
     assert (context is None) or (
         session is None
     ), "Cannot load context and session in the same time"
@@ -363,7 +364,11 @@ def chat_cli(question, model, context, session, qq) -> None:
 
     # Read API key
     api_key = os.environ.get("OAI_SECRET_KEY", config.get("api_key", "no-api-key"))
+
+    # TODO shimming this is pulls config into codebase. Should update config requirement.
     base_url = config.get("api_base")
+    if port:
+        base_url = f"http://localhost:{port}/v1"
 
     if api_key is None:
         print(

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -209,7 +209,7 @@ def serve(ctx, model_path, gpu_layers, port):
     ).to_chat_handler()
     click.echo("Starting server process")
     click.echo(
-        "After application startup complete see http://127.0.0.1:8000/docs for API."
+        f"After application startup complete see http://127.0.0.1:{port}/docs for API."
     )
     click.echo("Press CTRL+C to shutdown server.")
     uvicorn.run(app, port=port, log_level=logging.ERROR)  # TODO: host params, etc...
@@ -306,10 +306,17 @@ def test(ctx):
     is_flag=True,
     help="Exit after answering question",
 )
+@click.option(
+    "--port",
+    default=8000,
+    show_default=True,
+    type=click.INT,
+    help="Specifies which port expect model API. Defaults to 8000",
+)
 @click.pass_context
-def chat(ctx, question, model, context, session, quick_question):
+def chat(ctx, question, model, context, session, quick_question, port):
     """Run a chat using the modified model"""
-    chat_cli(question, model, context, session, quick_question)
+    chat_cli(question, model, context, session, quick_question, port)
 
 
 @cli.command()


### PR DESCRIPTION
I had something running on localhost:8000. This lets you specify target service port for model via `uvicorn`.