### PR TITLE
Show generated instructions in output

### DIFF
--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -173,6 +173,7 @@ def generate_data(
     temperature=1.0,
     top_p=1.0,
     rouge_threshold: Optional[float] = None,
+    console_output=True,
 ):
     seed_instruction_data = []
     generate_start = time.time()
@@ -299,6 +300,10 @@ def generate_data(
     ]
 
     prompt_template = check_prompt_file(prompt_file_path)
+    if console_output:
+        print(
+            "Synthesizing new instructions. If you aren't satisfied with the generated instructions, interrupt training (Ctrl-C) and try adjusting your YAML files. Adding more examples may help."
+        )
     while len(machine_instruction_data) < num_instructions_to_generate:
         request_idx += 1
 
@@ -385,6 +390,8 @@ def generate_data(
                     "assistant": synth_example["output"],
                 }
             )
+            if console_output:
+                print(f"{user}\n{synth_example['output']}\n")
         # utils.jdump(train_data, os.path.join(output_dir, output_file_train))
         with open(
             os.path.join(output_dir, output_file_train), "w", encoding="utf-8"

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -272,9 +272,21 @@ def serve(ctx, model_path, gpu_layers):
     default=0.9,
     help="Threshold of (max) Rouge score to keep samples; 1.0 means accept all samples.",
 )
+@click.option(
+    "--quiet",
+    is_flag=True,
+    help="Suppress output of synthesized instructions",
+)
 @click.pass_context
 def generate(
-    ctx, model, num_cpus, num_instructions, taxonomy_path, seed_file, rouge_threshold
+    ctx,
+    model,
+    num_cpus,
+    num_instructions,
+    taxonomy_path,
+    seed_file,
+    rouge_threshold,
+    quiet,
 ):
     """Generates synthetic data to enhance your example data"""
     ctx.obj.logger.info(
@@ -290,6 +302,7 @@ def generate(
             prompt_file_path=ctx.obj.config.generate.prompt_file,
             seed_tasks_path=seed_file,
             rouge_threshold=rouge_threshold,
+            console_output=not quiet,
         )
     except GenerateException as exc:
         click.secho(


### PR DESCRIPTION
This adds an (on by default) option that logs the synthesized instructions to the console, along with context that instructs users to adjust their QnA if the synthesized instructions don't seem right:

`Synthesizing new instructions. If you aren't satisfied with the generated instructions, interrupt training (Ctrl-C) and try adjusting your qna.yaml. More examples in particular may help.`

There's also a new option to suppress the noisy output: `--quiet`.

I think "noisy by default" is good; that way, users don't waste time synthesizing instructions that don't work well. I'm open to adjusting this the other way, though.