### PR TITLE
Propogate some more errors in chat specifically

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -18,6 +18,7 @@ from . import config
 from .chat.chat import chat_cli
 from .download import DownloadException, clone_taxonomy, download_model
 from .generator.generate_data import GenerateException, generate_data, get_taxonomy_diff
+from .chat.chat import ChatException
 
 
 # pylint: disable=unused-argument
@@ -205,12 +206,17 @@ def serve(ctx, model_path, gpu_layers):
             f"Creating App using model failed with following value error: {err}",
             fg="red",
         )
-
-    llama_app._llama_proxy._current_model.chat_handler = llama_chat_format.Jinja2ChatFormatter(
-        template="{% for message in messages %}\n{% if message['role'] == 'user' %}\n{{ '<|user|>\n' + message['content'] }}\n{% elif message['role'] == 'system' %}\n{{ '<|system|>\n' + message['content'] }}\n{% elif message['role'] == 'assistant' %}\n{{ '<|assistant|>\n' + message['content'] + eos_token }}\n{% endif %}\n{% if loop.last and add_generation_prompt %}\n{{ '<|assistant|>' }}\n{% endif %}\n{% endfor %}",
-        eos_token="<|endoftext|>",
-        bos_token="",
-    ).to_chat_handler()
+    try:
+        llama_app._llama_proxy._current_model.chat_handler = llama_chat_format.Jinja2ChatFormatter(
+            template="{% for message in messages %}\n{% if message['role'] == 'user' %}\n{{ '<|user|>\n' + message['content'] }}\n{% elif message['role'] == 'system' %}\n{{ '<|system|>\n' + message['content'] }}\n{% elif message['role'] == 'assistant' %}\n{{ '<|assistant|>\n' + message['content'] + eos_token }}\n{% endif %}\n{% if loop.last and add_generation_prompt %}\n{{ '<|assistant|>' }}\n{% endif %}\n{% endfor %}",
+            eos_token="<|endoftext|>",
+            bos_token="",
+        ).to_chat_handler()
+    except Exception as e:
+        click.secho(
+            f"Error creating chat handler: {e}",
+            fg="red",
+        )
     click.echo("Starting server process")
     click.echo(
         "After application startup complete see http://127.0.0.1:8000/docs for API."
@@ -313,7 +319,13 @@ def test(ctx):
 @click.pass_context
 def chat(ctx, question, model, context, session, quick_question):
     """Run a chat using the modified model"""
-    chat_cli(question, model, context, session, quick_question)
+    try:
+        chat_cli(question, model, context, session, quick_question)
+    except ChatException as e:
+        click.secho(
+            f"Executing chat failed with: {e.__cause__}",
+            fg="red",
+        )       
 
 
 @cli.command()

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,18 @@
+chat:
+  context: default
+  model: ggml-malachite-7b-0226-Q4_K_M
+  session: null
+general:
+  log_level: INFO
+generate:
+  model: ggml-malachite-7b-0226-Q4_K_M
+  num_cpus: 10
+  num_instructions: 100
+  prompt_file: prompt.txt
+  seed_file: seed_tasks.json
+  taxonomy_path: taxonomy
+list:
+  taxonomy_path: taxonomy
+serve:
+  gpu_layers: -1
+  model_path: models/ggml-malachite-7b-0226-Q4_K_M.gguf


### PR DESCRIPTION
currently we log some errors and raise exceptions that we do not handle. Add handling for those and introduce ChatException

This changes chat a bit. If the error is API rate limit, API key error, or other we hard error. If it is a connection error we stay in the loop and ask the user to try again. Open to changes to this workflow. I do think we should somehow propagate this stuff though since currently we throw away the errors and return EOF or Keyboard error.