### PR TITLE
Pin download asset release to v0.2.0 (won't be in latest soon)

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -11,6 +11,7 @@ DEFAULT_MODEL_PATH = "models/ggml-malachite-7b-0226-Q4_K_M.gguf"
 DEFAULT_API_BASE = "http://localhost:8000/v1"
 DEFAULT_API_KEY = "no_api_key"
 DEFAULT_MODEL = "ggml-malachite-7b-0226-Q4_K_M"
+DEFAULT_DOWNLOAD_TAG = "v0.2.0"
 DEFAULT_VI_MODE = False
 DEFAULT_VISIBLE_OVERFLOW = True
 DEFAULT_TAXONOMY_REPO = "git@github.com:open-labrador/taxonomy.git"

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -325,7 +325,7 @@ def chat(ctx, question, model, context, session, quick_question):
 )
 @click.option(
     "--release",
-    default="latest",
+    default=config.DEFAULT_DOWNLOAD_TAG,
     show_default=True,
     help="GitHub release version of the hosted models.",
 )


### PR DESCRIPTION
* We have the model in release v0.2.0.  We probably won't put one in the next release.