### PR TITLE
skip config check for lab init with params

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -35,7 +35,7 @@ class Lab:
 
 def configure(ctx, param, filename):
     # skip configuration reading when invoked command is `init`
-    if len(sys.argv) > 0 and sys.argv[-1] == "init":
+    if len(sys.argv) > 0 and sys.argv[1] == "init":
         return
 
     if not exists(filename):


### PR DESCRIPTION
Fixes https://github.com/open-labrador/cli/issues/151 and https://github.com/open-labrador/cli/issues/142

Previously, if you run `lab init --help` (or with any parameters), and no config.yaml is present, an error is returned, because the config file check is not skipped. This makes is so you can `lab init` with parameters, and it will also skip the config file check. This matches the behavior of just running `lab init`