### PR TITLE
docs: Sync markdown formatting across the repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,19 +71,19 @@ The following tools are required:
 
 You can setup your dev environment using [tox](https://tox.wiki/en/latest/), an environment orchestrator which allows for setting up environments for and invoking builds, unit tests, formatting, linting, etc. Install tox with:
 
-```sh
+```shell
 pip install -r requirements-dev.txt
 ```
 
 Install project requirements with:
 
-```sh
+```shell
 pip install -r requirements.txt
 ```
 
 If you want to manage your own virtual environment instead of using `tox`, you can install `cli` and all dependencies with:
 
-```sh
+```shell
 pip install .
 ```
 
@@ -93,13 +93,13 @@ Unit tests are enforced by the CI system. When making changes, run the tests bef
 
 Running unit tests against all supported Python versions is as simple as:
 
-```sh
+```shell
 tox
 ```
 
 Running tests against a single Python version can be done with:
 
-```sh
+```shell
 tox -e py
 ```-->
 
@@ -111,7 +111,7 @@ We use [pre-commit](https://pre-commit.com/) to enforce coding style using [blac
 
 You can invoke formatting with:
 
-```sh
+```shell
 tox -e fmt
 ```
 
@@ -119,7 +119,7 @@ In addition, we use [pylint](https://www.pylint.org) to perform static code anal
 
 You can invoke the linting with the following command
 
-```sh
+```shell
 tox -e lint
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Let's start at an example folder `~/Documents/github` on your computer.
 
 We'll create a new directory called `labrador` to store the files that this CLI needs when it runs.
 
-```ShellSession
+```shell
 mkdir labrador
 cd labrador
 python3 -m venv venv
@@ -108,7 +108,7 @@ Go to the [contributors guide]( CONTRIBUTING.md ) for more details on contributi
 
 In order for `lab` to run correctly in your terminal (or shell) window, you'll always need the Python virtual environment, where `lab` was installed in to be turned on. You can check if it is enabled as it will show virtual env name (e.g. `venv` ) at the terminal prompt prefix or at the end depending on your shell. If you start a new terminal or its not initialised then run:
 
-```ShellSession
+```shell
 source venv/bin/activate
 ```
 

--- a/README.snippets.md
+++ b/README.snippets.md
@@ -1,6 +1,6 @@
 ### From source
 
-```ShellSession
+```shell
 git clone https://github.com/open-labrador/cli.git
 cd cli
 python3 -m venv venv

--- a/cli/chat/README.md
+++ b/cli/chat/README.md
@@ -9,8 +9,8 @@
 
 ### Command line interface
 
-```sh
-❯ python -m cli chat --help
+```shell
+python -m cli chat --help
 ```
 
 ```
@@ -26,8 +26,8 @@ Options:
 
 ### Start chatting
 
-```sh
-❯ python -m cli chat
+```shell
+python -m cli chat
 ```
 
 ```
@@ -66,7 +66,7 @@ Options:
 1. Make `./bin/chat` and `./bin/ask-cl` avaiable from your PATH (e.g. by making symlinks)
 2. `ask-cl some natural langauge` will convert the natural language to the command line
 3. Optionally, if you are using the Fish shell, add below to your config file
-```fish
+```shell
 function acl
     if isatty stdin
         set cmd (ask-cl $argv)
@@ -79,7 +79,7 @@ end
 ```
 and you can use `acl some natural langauge` which will do the same *AND* copy paste the command to your shell for you.
 4. Both `ask-cl` or `acl` accepts stdin so you can pipe commands to them, e.g.
-``` fish
+```shell
 ls | acl back up the TOML file with a prefix "old"
 ```
 


### PR DESCRIPTION
Noticed that many different formatting across the repo including the main README. Aligning them for some consistency. 