### PR TITLE
feature: add parquet support in lab generate

### DIFF
--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -12,6 +12,9 @@ import re
 import string
 import time
 
+# Local
+from .storage import json_to_parquet
+
 try:
     # Third Party
     import git
@@ -175,6 +178,7 @@ def generate_data(
     top_p=1.0,
     rouge_threshold: Optional[float] = None,
     console_output=True,
+    parquet=False,
 ):
     seed_instruction_data = []
     generate_start = time.time()
@@ -370,6 +374,20 @@ def generate_data(
             for entry in test_data:
                 json.dump(entry, outfile)
                 outfile.write("\n")
+        # If parquet flag is enabled, also output all the JSON content in parquet format
+        if parquet:
+            json_to_parquet(
+                machine_instruction_data,
+                os.path.join(output_dir, os.path.splitext(output_file)[0]),
+            )
+            json_to_parquet(
+                train_data,
+                os.path.join(output_dir, os.path.splitext(output_file_train)[0]),
+            )
+            json_to_parquet(
+                test_data,
+                os.path.join(output_dir, os.path.splitext(output_file_test)[0]),
+            )
 
     generate_duration = time.time() - generate_start
     logger.info(f"Generation took {generate_duration:.2f}s")

--- a/cli/generator/storage.py
+++ b/cli/generator/storage.py
@@ -1,0 +1,41 @@
+# Standard
+import json
+
+# Third Party
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+def json_to_parquet(json_data, parquet_name):
+    """
+    Convert JSON data to Parquet format and save it to a Parquet file.
+
+    Parameters:
+    - json_data (list of dict): The JSON data to be converted.
+    - parquet_name (str): The name for the output Parquet file. The '.parquet' extension will be added.
+
+    Returns:
+    - None
+    """
+    df = pd.DataFrame(json_data)
+    table = pa.Table.from_pandas(df)
+    pq.write_table(table, parquet_name + ".parquet")
+
+
+def file_json_to_parquet(filename, parquet_name):
+    """
+    Convert JSON data from a local file to Parquet format and save it to a Parquet file.
+
+    Parameters:
+    - filename (str): Path to the JSON data.
+    - parquet_name (str): The name for the output Parquet file. The '.parquet' extension will be added.
+
+    Returns:
+    - None
+    """
+    with open(filename, "r", encoding="utf-8") as data_file:
+        file_data = data_file.read()
+
+    json_data = json.loads(file_data)
+    json_to_parquet(json_data, parquet_name)

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -306,6 +306,11 @@ def serve(ctx, model_path, gpu_layers):
     is_flag=True,
     help="Suppress output of synthesized instructions",
 )
+@click.option(
+    "--parquet",
+    is_flag=True,
+    help="Generate data in both JSON and parquet format",
+)
 @click.pass_context
 def generate(
     ctx,
@@ -317,6 +322,7 @@ def generate(
     seed_file,
     rouge_threshold,
     quiet,
+    parquet,
 ):
     """Generates synthetic data to enhance your example data"""
     ctx.obj.logger.info(
@@ -335,6 +341,7 @@ def generate(
             seed_tasks_path=seed_file,
             rouge_threshold=rouge_threshold,
             console_output=not quiet,
+            parquet=parquet,
         )
     except GenerateException as exc:
         click.secho(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ llama_cpp_python[server]
 numpy
 rouge_score
 openai
+pandas
 prompt-toolkit==3.0.38
+pyarrow
 pyyaml
 rich==13.3.1
 toml==0.10.2


### PR DESCRIPTION
Part of #203 

We want to add parquet for `lab generate` output. It's mainly used in our future CI and storage so we can compress data into smaller sizes. Instruct lab backend developers can also use this option to reduce their storage cost when storing their generated data for governance purpose.

The flag is false by default so no impact to the current lab generate flow.