### PR TITLE
New Streamline README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Labrador (`lab`)
+# InstructLab 🐶 (`lab`)
 
-## 🐶 What is `lab`
+## ❓ What is `lab`
 
 `lab` is a Command-Line Interface (CLI) tool that allows you to:
 
@@ -93,13 +93,13 @@ You can override this behavior for any `lab` command with the `--config` paramet
 
 ## 📥 Download the model
 
-Users should make sure they are logged in to their github accounts via the `gh` CLI and following the promths/instructions:
+Users should make sure they are logged in to their github accounts via the `gh` CLI and following the prompts/instructions:
 
 ```
 gh auth login
 ```
 
-Please review [lab-troubleshoot.md](./lab-troubleshoot.md) for troubleshooting tips related to `gh`.
+**⁉️  Something not working?**: Please review [lab-troubleshoot.md](./lab-troubleshoot.md) for troubleshooting tips related to `gh`.
 
 ```
 lab download
@@ -156,13 +156,13 @@ Before you start adding new skills and knowledge to your knowledge, you can chec
 >>>                                                                                                                                                                                                                               [S][default]
 ```
 
-## 📘 Contribute knowledge or compositional skills
+## 🎁 Contribute knowledge or compositional skills
 
 Locally contribute new knowledge or compositional skills to your local [taxonomy](https://github.com/open-labrador/taxonomy.git) repository.
 
 Detailed contribution instructions can be found on the [taxonomy github](https://github.com/open-labrador/taxonomy/blob/main/README.md).
 
-## 📰 List your new knowledge
+## 📜 List your new knowledge
 
 ```
 lab list
@@ -202,7 +202,7 @@ The synthetic data set will be three files in the `taxonomy` repository that are
 
 ⏳ This can take over **1 hour+** to complete depending on your computing resources.
 
-## 🚄 Train the model
+## 👩‍🏫 Train the model
 
 Train the model on your synthetic data-enhanced dataset by following the instructions in [Training](./notebooks/README.md)
 

--- a/lab-troubleshoot.md
+++ b/lab-troubleshoot.md
@@ -1,8 +1,8 @@
-# Lab Trouble Shooting
+# Lab Troubleshooting
 
 This document is for commonly found problems and their solutions when using `lab`.
 
-## `gh` Trouble Shooting
+## `gh` Troubleshooting
 
 This page has some troubleshooting techniques if you hit a github cli `gh` error described below.
 
@@ -64,7 +64,7 @@ gh auth login --with-token < mytoken.txt
 $ gh auth logout
 ```
 
-Raw steps:
+Always refer to (README.md)[README.md] for most/latest commands used during Installing lab:
 
 ```
 gh auth login --with-token < ~/Documents/mytoken.txt


### PR DESCRIPTION
I've created a `README-SIMPLE.md` with simplified instructions and explanations for the work flow.

This is the document I wish I had when I was starting out. One of my favorite bits of it is examples of what the `lab` commands look like when they run successfully so that the user knows they are on the right track.

If it was up to me, this document would get consideration to replace the `README.md` in the entirely but my README would need many revisions to get to that state.

`gh-troubleshoot.md` was contributed by Owen McGonagle and can be split out into a different PR if necessary.