### PR TITLE
Pin cli release-v0.3.1 to taxonomy branch cli_v0.3.1.

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -14,6 +14,7 @@ DEFAULT_VI_MODE = False
 DEFAULT_VISIBLE_OVERFLOW = True
 DEFAULT_TAXONOMY_REPO = "git@github.com:open-labrador/taxonomy.git"
 DEFAULT_TAXONOMY_PATH = "taxonomy"
+DEFAULT_TAXONOMY_BRANCH = "cli_v0.3.1"
 DEFAULT_PROMPT_FILE = "prompt.txt"
 DEFAULT_SEED_FILE = "seed_tasks.json"
 

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -126,7 +126,7 @@ def init(ctx, interactive, model_path, taxonomy_path, repository, min_taxonomy):
             if do_clone:
                 click.echo(f"Cloning {repository}...")
                 try:
-                    clone_taxonomy(repository, "main", taxonomy_path, min_taxonomy)
+                    clone_taxonomy(repository, config.DEFAULT_TAXONOMY_BRANCH, taxonomy_path, min_taxonomy)
                 except DownloadException as exc:
                     click.secho(
                         f"Cloning {repository} failed with the following error: {exc}",


### PR DESCRIPTION
This sets the default to the branch we expect to work with before taxonomy changes that are not compatible with cli 0.3.1 might be made in the taxonomy repo.