### PR TITLE
Move default taxonomy branch default to config.

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -14,6 +14,7 @@ DEFAULT_VI_MODE = False
 DEFAULT_VISIBLE_OVERFLOW = True
 DEFAULT_TAXONOMY_REPO = "git@github.com:open-labrador/taxonomy.git"
 DEFAULT_TAXONOMY_PATH = "taxonomy"
+DEFAULT_TAXONOMY_BRANCH = "main"
 DEFAULT_PROMPT_FILE = "prompt.txt"
 DEFAULT_SEED_FILE = "seed_tasks.json"
 

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -126,7 +126,7 @@ def init(ctx, interactive, model_path, taxonomy_path, repository, min_taxonomy):
             if do_clone:
                 click.echo(f"Cloning {repository}...")
                 try:
-                    clone_taxonomy(repository, "main", taxonomy_path, min_taxonomy)
+                    clone_taxonomy(repository, config.DEFAULT_TAXONOMY_BRANCH, taxonomy_path, min_taxonomy)
                 except DownloadException as exc:
                     click.secho(
                         f"Cloning {repository} failed with the following error: {exc}",


### PR DESCRIPTION
It was hard-coded "main".
But in releases, we've been setting the default to a version-compatible taxonomy branch in config.  Let's make main use config too.