### PR TITLE
fix: reuse generate.taxonomy_path config

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -55,11 +55,6 @@ class _generate:
 
 
 @dataclass
-class _list:
-    taxonomy_path: str
-
-
-@dataclass
 class _serve:
     model_path: str
     gpu_layers: int
@@ -70,7 +65,6 @@ class Config:
     general: _general
     chat: _chat
     generate: _generate
-    list: _list
     serve: _serve
 
     def __post_init__(self):
@@ -81,7 +75,6 @@ class Config:
         self.general = _general(**self.general)
         self.chat = _chat(**self.chat)
         self.generate = _generate(**self.generate)
-        self.list = _list(**self.list)
         self.serve = _serve(**self.serve)
 
 
@@ -127,6 +120,5 @@ def get_default_config():
         seed_file=DEFAULT_SEED_FILE,
     )
     # pylint: disable=redefined-builtin
-    list = _list(taxonomy_path=DEFAULT_TAXONOMY_PATH)
     serve = _serve(model_path=DEFAULT_MODEL_PATH, gpu_layers=-1)
-    return Config(general=general, chat=chat, generate=generate, list=list, serve=serve)
+    return Config(general=general, chat=chat, generate=generate, serve=serve)

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -158,7 +158,6 @@ def init(ctx, interactive, model_path, taxonomy_path, repository, min_taxonomy):
     cfg.generate.model = model
     cfg.serve.model_path = model_path
     cfg.generate.taxonomy_path = taxonomy_path
-    cfg.list.taxonomy_path = taxonomy_path
     config.write_config(cfg)
 
     click.echo(
@@ -179,6 +178,8 @@ def list(ctx, taxonomy_path):
     Lists taxonomy files that have changed since last commit.
     Similar to 'git diff'
     """
+    if not taxonomy_path:
+        taxonomy_path = ctx.obj.config.generate.taxonomy_path
     updated_taxonomy_files = get_taxonomy_diff(taxonomy_path)
     for f in updated_taxonomy_files:
         if splitext(f)[1] != ".yaml":


### PR DESCRIPTION
The current list command unnecessarily uses a separate config element for taxonomy_path when no one will ever want to use different taxonomy_path values for list and generate. This fixes this by using the generate.taxonomy_path config for the list command.
