### PR TITLE
Update README.md for installation issue on Fedora CSB

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ After that is done you can:
 
 To start we'll create a new directory called `instruct-lab` to store the files that this CLI needs when it runs.
 
+Note 
+While running on Fedora , please make sure ` Development Tools ` and ` cmake`  is present on the machine and also ensure ` gcc-c++ ` is present with the path set .
+
 ```
 mkdir instruct-lab
 cd instruct-lab


### PR DESCRIPTION
Error while running `pip install git+ssh://git@github.com/instruct-lab/cli.git@stable` as shown 


```
Building wheel for llama-cpp-python (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for llama-cpp-python (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [26 lines of output]
      *** scikit-build-core 0.8.2 using CMake 3.28.3 (wheel)
      *** Configuring CMake...
      2024-03-04 15:43:43,027 - scikit_build_core - WARNING - libdir/ldlibrary: /usr/lib64/libpython3.12.so is not a real file!
      2024-03-04 15:43:43,027 - scikit_build_core - WARNING - Can't find a Python library, got libdir=/usr/lib64, ldlibrary=libpython3.12.so, multiarch=x86_64-linux-gnu, masd=None
      loading initial cache file /tmp/tmpx95po8ft/build/CMakeInit.txt
      -- The C compiler identification is unknown
      -- The CXX compiler identification is unknown
      CMake Error at CMakeLists.txt:3 (project):
        No CMAKE_C_COMPILER could be found.
      
        Tell CMake where to find the compiler by setting either the environment
        variable "CC" or the CMake cache entry CMAKE_C_COMPILER to the full path to
        the compiler, or to the compiler name if it is in the PATH.
      
      
      CMake Error at CMakeLists.txt:3 (project):
        No CMAKE_CXX_COMPILER could be found.
      
        Tell CMake where to find the compiler by setting either the environment
        variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
        to the compiler, or to the compiler name if it is in the PATH.
      
      
      -- Configuring incomplete, errors occurred!
      
      *** CMake configuration failed
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for llama-cpp-python
Successfully built cli rouge-score
Failed to build llama-cpp-python
ERROR: Could not build wheels for llama-cpp-python, which is required to install pyproject.toml-based projects
```