### PR TITLE
feat: pass rouge threshold

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -53,6 +53,7 @@ class _generate:
     prompt_file: str
     seed_file: str
 
+
 @dataclass
 class _list:
     taxonomy_path: str

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -268,7 +268,9 @@ def serve(ctx, model_path, gpu_layers):
     help="Threshold of (max) Rouge score to keep samples; 1.0 means accept all samples.",
 )
 @click.pass_context
-def generate(ctx, model, num_cpus, num_instructions, taxonomy_path, seed_file, rouge_threshold):
+def generate(
+    ctx, model, num_cpus, num_instructions, taxonomy_path, seed_file, rouge_threshold
+):
     """Generates synthetic data to enhance your example data"""
     ctx.obj.logger.info(
         f"Generating model '{model}' using {num_cpus} cpus, taxonomy: '{taxonomy_path}' and seed '{seed_file}'"


### PR DESCRIPTION
this allows to do `lab generate --rouge-ths 1.0` which will avoid rejecting any samples, making the command much faster and predictable.