### PR TITLE
feat: add initial HF support for download

### DIFF
--- a/cli/download.py
+++ b/cli/download.py
@@ -2,6 +2,7 @@
 import os
 import re
 import subprocess
+from huggingface_hub import snapshot_download
 
 
 class DownloadException(Exception):
@@ -13,6 +14,9 @@ def download_model(
     gh_release="latest",
     model_dir=".",
     pattern="",
+    hf=False,
+    repo_id="ibm/merlinite-7b-GGUF",
+    revision="main",
 ):
     """
     Download and combine the model file from a GitHub repository source.
@@ -28,6 +32,14 @@ def download_model(
     Returns:
     - a list of downloaded models
     """
+    if hf:
+        model_path = snapshot_download(
+            repo_id=repo_id,
+            revision=revision,
+            local_dir=model_dir,
+            allow_patterns=["merlinite-7b-Q4_K_M.gguf"],
+        )
+        return
 
     model_file_split_keyword = ".split."
 

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -367,8 +367,9 @@ def chat(ctx, question, model, context, session, quick_question):
     help="Download only assets that match a glob pattern.",
 )
 @click.option("--pattern", help="Download only assets that match a glob pattern.")
+@click.option("--hf", is_flag=True, help="Download the model from HuggingFace.")
 @click.pass_context
-def download(ctx, repository, release, model_dir, pattern):
+def download(ctx, repository, release, model_dir, pattern, hf):
     """Download the model(s) to train"""
     # Use the serve model path to get the right models in the right place, if needed
     serve_model_path = ctx.obj.config.serve.model_path
@@ -382,7 +383,7 @@ def download(ctx, repository, release, model_dir, pattern):
     )
     click.echo(f"Downloading models from {repository}@{release} to {model_dir}...")
     try:
-        download_model(repository, release, model_dir, pattern)
+        download_model(repository, release, model_dir, pattern, hf=hf)
     except DownloadException as exc:
         click.secho(
             f"Downloading models failed with the following error: {exc}",


### PR DESCRIPTION
just to put the code there which will trigger when pass `--hf` when running download so people can start testing and building upon it
stuff like naming (i.e. the name of the HF one can be different from the default used by `lab serve`) are not in the scope of this PR