### PR TITLE
ci: Use cached system site-packages for tox environments

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,9 @@ on:
     branches: 
       - "main"
 
+env:
+  PYTHON_VERSION: 3.9
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -29,13 +32,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Free up disk space
-        uses: ./.github/actions/free-up-disk-space
-
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -54,7 +54,7 @@ jobs:
           python -m pip install -r requirements-dev.txt
 
       - name: Run formatting
-        run: tox -e fmt
+        run: tox -x testenv:fmt.system_site_packages=True -e fmt
 
       - name: Run linting
-        run: tox -e lint
+        run: tox -x testenv:lint.system_site_packages=True -e lint


### PR DESCRIPTION
Speed up the PR checks for linting and formatting by (re)using cached Python system site packages for `tox` environments.

This builds on improvements of caching installed Python packages from earlier [commits](https://github.com/instruct-lab/cli/commit/775e419b52338d5411821f694478fd9bec522f7b) and PR #281

The average time for `lint` and `fmt` should be around **2 min** now, down from around **10 min** yesterday.


<img width="740" alt="image" src="https://github.com/instruct-lab/cli/assets/12246093/2baa0a77-6985-41f2-bd5f-011a87adc54a">

---

**Summary of the problem(s) and improvements:**

- Yesterday the `lint` and `fmt` PR checks failed with a `"No space left on device error"`
- A first attempt to fix it was to free up additional disk space on the GitHub action runner PR [#281](https://github.com/instruct-lab/cli/pull/281) which allowed the checks to proceed
- The real problem was that the same set of Python dependencies was installed 3 times in 3 different places for each of the steps `Install dependencies`, `Run formatting`,  and `Run linting`
- Since `tox` uses it's own isolated virtual environment, the packages installed into the system Python package directory were not used. And each `tox` environment is separate from one another.
- Using 3 separate Python (virtual) environments requires a lot of unnecessary download and install time as well as disk space
- One more optimization was done in [#775e419](https://github.com/instruct-lab/cli/commit/775e419) to cache the system Python package directory
- This PR further optimizes the workflow by forcing `tox` to use the cached system Python instead of 2 new separate virtual environments that replicate the same