### PR TITLE
README: Update lab build depednencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ After that is done you can:
 ## 📋 Requirements
 
 - **🍎 Apple M1/M2/M3 Mac or 🐧 Linux system** (tested on Fedora). We anticipate support for more operating systems in the future.
+- The GNU C++ compiler
 - 🐍 Python 3.9 or later, including the development headers.
 - `gh` cli: Install [Github command cli](https://cli.github.com/) for downloading models from Github
 
 On Fedora Linux this means installing:
 ```
 $ sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-$ sudo yum install gh python3 python3-devel
+$ sudo yum install g++ gh python3 python3-devel
 ```
 
 ## 🧰 Installing `lab`


### PR DESCRIPTION
The python3 development headers and library are required, or else llama-cpp-python fails to build.

        × Building wheel for llama-cpp-python (pyproject.toml) did not run successfully.
        │ exit code: 1
        ╰─> [23 lines of output]
            *** scikit-build-core 0.8.2 using CMake 3.28.3 (wheel)
            *** Configuring CMake...
            2024-03-05 11:42:14,297 - scikit_build_core - WARNING - libdir/ldlibrary: /usr/lib64/libpython3.12.so is not a real file!
            2024-03-05 11:42:14,297 - scikit_build_core - WARNING - Can't find a Python library, got libdir=/usr/lib64, ldlibrary=libpython3.12.so, multiarch=x86_64-linux-gnu, masd=None

Add the command to install the g++ compiler on Fedora Linux. Otherwise
we get an error similar to the following when building llama-cpp-python
    
        × Building wheel for llama-cpp-python (pyproject.toml) did not run successfully.
        │ exit code: 1
        ╰─> [21 lines of output]
            *** scikit-build-core 0.8.2 using CMake 3.28.3 (wheel)
            *** Configuring CMake...
            loading initial cache file /tmp/tmppdxr1vom/build/CMakeInit.txt
            -- The C compiler identification is GNU 14.0.1
            -- The CXX compiler identification is unknown
            -- Detecting C compiler ABI info
            -- Detecting C compiler ABI info - done
            -- Check for working C compiler: /usr/bin/cc - skipped
            -- Detecting C compile features
            -- Detecting C compile features - done
            CMake Error at CMakeLists.txt:3 (project):
              No CMAKE_CXX_COMPILER could be found.

Lastly also add the command to install the gh tool.