### PR TITLE
allow to specify a different port

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 # Standard
-import atexit
 import json
 import os
 import sys
@@ -310,7 +309,7 @@ class ConsoleChatBot:
             )
             self.info["messages"].pop()
             raise ChatException("Rate limit exceeded") from e
-        except openai.APIConnectionError as e:
+        except openai.APIConnectionError:
             self.console.print("Connection error, try again...", style="red bold")
             self.info["messages"].pop()
             raise KeyboardInterrupt
@@ -356,7 +355,8 @@ def chat_cli(config, logger, question, model, context, session, qq) -> None:
     # TODO: The 'openai.proxy' option isn't read in the client API. You will need to pass it when you instantiate the client, e.g. 'OpenAI(proxy={"http": proxy, "https": proxy})'
     # openai.proxy = {"http": proxy, "https": proxy}
 
-    client = OpenAI(base_url=config.api_base, api_key=config.api_key)
+    api_base = f"http://{config.api_host_port}/v1"
+    client = OpenAI(base_url=api_base, api_key=config.api_key)
 
     # Load context/session
     loaded = {}

--- a/cli/config.py
+++ b/cli/config.py
@@ -7,7 +7,7 @@ import yaml
 DEFAULT_CONFIG = "config.yaml"
 DEFAULT_MODEL = "merlinite-7b-Q4_K_M"
 DEFAULT_MODEL_PATH = f"models/{DEFAULT_MODEL}.gguf"
-DEFAULT_API_BASE = "http://localhost:8000/v1"
+DEFAULT_API_HOST_PORT = "localhost:8000"
 DEFAULT_API_KEY = "no_api_key"
 DEFAULT_VI_MODE = False
 DEFAULT_VISIBLE_OVERFLOW = True
@@ -34,7 +34,7 @@ class _general:
 
 @dataclass
 class _chat:
-    api_base: str
+    api_host_port: str
     api_key: str
     model: str
     vi_mode: bool
@@ -102,7 +102,7 @@ def get_default_config():
     """Generates default configuration for CLI"""
     general = _general(log_level="INFO")
     chat = _chat(
-        api_base=DEFAULT_API_BASE,
+        api_host_port=DEFAULT_API_HOST_PORT,
         api_key=DEFAULT_API_KEY,
         model=DEFAULT_MODEL,
         vi_mode=DEFAULT_VI_MODE,

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -235,10 +235,11 @@ def serve(ctx, model_path, gpu_layers):
         )
     click.echo("Starting server process")
     click.echo(
-        "After application startup complete see http://127.0.0.1:8000/docs for API."
+        f"After application startup complete see http://{ctx.obj.config.chat.api_host_port}/docs for API."
     )
     click.echo("Press CTRL+C to shutdown server.")
-    uvicorn.run(app, port=8000, log_level=logging.ERROR)  # TODO: host params, etc...
+    port = int(ctx.obj.config.chat.api_host_port.split(":")[-1])
+    uvicorn.run(app, port=port, log_level=logging.ERROR)  # TODO: host params, etc...
 
 
 @cli.command()


### PR DESCRIPTION
Instead of specifying api_base in the configuration file, specify:

```yaml
chat:
  api_host_port: localhost:8889
```