### PR TITLE
Add paper link

### DIFF
--- a/notebooks/Training_a_LoRA_With_Instruct_Lab.ipynb
+++ b/notebooks/Training_a_LoRA_With_Instruct_Lab.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "`instruct lab` is a novel synthetic data-based alignment tuning method for Large Language Models (LLMs.) The \"lab\" in `instruct lab` stands for Large-scale Alignment for Chat Bots.\n",
     "\n",
-    "It is an outgrowth of the [paper](https://arxiv.org/abs/2403.01081).\n",
+    "It is an outgrowth of the [*LAB: Large-Scale Alignment for ChatBots*](https://arxiv.org/abs/2403.01081).\n",
     "\n",
     "### Getting Started\n",
     "\n",


### PR DESCRIPTION
Fixes #307 

Changed one line, but github gonna git. 

Line 13:
paper [To be Updated when Paper is Available]()
to 
"It is an outgrowth of the [paper](https://arxiv.org/abs/2403.01081).