### PR TITLE
Catch APIConnectionError and output orig error

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -16,6 +16,7 @@ from llama_cpp.server.app import create_app
 from llama_cpp.server.settings import Settings
 import click
 import llama_cpp.server.app as llama_app
+import openai
 import uvicorn
 
 # Local
@@ -292,6 +293,11 @@ def generate(
     except GenerateException as exc:
         click.secho(
             f"Generating dataset failed with the following error: {exc}",
+            fg="red",
+        )
+    except openai.APIConnectionError as exc:
+        click.secho(
+            f"Error connecting to the server: {exc.__cause__}",
             fg="red",
         )
 


### PR DESCRIPTION
Catch APIConnectionError from openai and output
its cause so it isn't lost in a chain for exceptions.

instead of the chain of 3 tracebacks currently output if a user forgets to start the server , output

```
(venv) [derekh@u07 instruct-lab]$ lab generate 
INFO 2024-03-05 23:44:15,690 lab.py:276 Generating model 'ggml-merlinite-7b-0302-Q4_K_M' using 10 cpus, taxonomy: 'taxonomy' and seed 'seed_tasks.json'
DEBUG 2024-03-05 23:44:15,724 generate_data.py:283 Loaded 7 human-written seed instructions from taxonomy
DEBUG 2024-03-05 23:44:15,724 generate_data.py:313 Generating to: /home/derekh/instruct-lab/taxonomy/generated_ggml-merlinite-7b-0302-Q4_K_M_2024-03-05T23:44:15.json
  0%|                                                                                                                                                                                                                   | 0/1 [00:00<?, ?it/s]Cannot find prompt.txt. Using default prompt.
Error connecting to the API: [Errno 111] Connection refused
  0%|                                   
```

Fixes https://github.com/instruct-lab/cli/issues/327