### PR TITLE
output error from gh command

### DIFF
--- a/cli/download.py
+++ b/cli/download.py
@@ -55,7 +55,9 @@ def download_model(
     except FileNotFoundError as exc:
         raise DownloadException("`gh` binary not found") from exc
     except subprocess.CalledProcessError as exc:
-        raise DownloadException(f"error invoking `gh` command: {exc}") from exc
+        raise DownloadException(
+            f"error invoking `gh` command: {exc}:\n  {exc.stderr}"
+        ) from exc
 
     # Get the list of local files
     ls_commands = ["ls", model_dir]


### PR DESCRIPTION
changes output to 

```
(venv) [derekh@u07 instruct-lab]$ lab download
Make sure the local environment has the `gh` cli: https://cli.github.com
Downloading models from https://github.com/instruct-lab/cli.git@v0.4.0 to models...
Downloading models failed with the following error: error invoking `gh` command: Command '['gh', 'release', 'download', 'v0.4.0', '--repo', 'https://github.com/instruct-lab/cli.git', '--dir', 'models', '--pattern', 'ggml-merlinite-7b-0302-Q4_K_M.*']' returned non-zero exit status 4.:
  b'To get started with GitHub CLI, please run:  gh auth login\nAlternatively, populate the GH_TOKEN environment variable with a GitHub API authentication token.\n'

```


Fixes https://github.com/instruct-lab/cli/issues/329