### PR TITLE
Allow keyboard interrupt while getting and parsing response

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -314,6 +314,8 @@ class ConsoleChatBot:
             self.console.print("Connection error, try again...", style="red bold")
             self.info["messages"].pop()
             raise KeyboardInterrupt
+        except KeyboardInterrupt as e:
+            raise e
         except:
             self.console.print("Unknown error", style="bold red")
             raise ChatException(f"Unknown error: {sys.exc_info()[0]}")


### PR DESCRIPTION
Allow user to CTRL+C while getting a response.  Sometimes the API is non-responsive or the response is taking a long time.  Allow the request to be canceled without exiting chat.

This can be seen when the API is not serving content correctly and user tries to cancel a request.  Or if you quickly type CTRL+C after typing in a prompt.  An example of the behavior before this change:

```
>>> sing a song
^CUnknown error
Executing chat failed with: API issue found while executing chat:
Unknown error: <class 'KeyboardInterrupt'>
```
And the client exits.

After the change in this PR:

```
>>> sing a song
^C>>>
```
And the client is able to take additional prompts.

Note this does not have an impact of cancel while the response output is
being created.  Canceling that already works.