### PR TITLE
adds a Containerfile for AMD ROCm GPUs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+containers/*
+*.md

--- a/containers/Containerfile.toolbox-rocm
+++ b/containers/Containerfile.toolbox-rocm
@@ -1,0 +1,33 @@
+FROM registry.fedoraproject.org/fedora-toolbox:40 AS build-base
+RUN dnf install -y llvm clang-tools-extra lld rocblas-devel hip-devel python3-pip git make gcc hipblas-devel
+
+FROM build-base AS pytorch
+RUN pip3 install torch --force-reinstall --no-cache-dir --index-url https://download.pytorch.org/whl/rocm5.7
+
+FROM build-base AS llama-cpp-python
+ARG AMDGPU_TARGETS
+RUN CMAKE_ARGS="-DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_PREFIX_PATH=/opt/rocm -DAMDGPU_TARGETS=$AMDGPU_TARGETS" FORCE_CMAKE=1 pip install llama-cpp-python --force-reinstall --no-cache-dir -v
+
+FROM llama-cpp-python AS instructlab-install
+COPY . /instructlab
+RUN pip3 install git+file:///instructlab@stable
+
+# Cleans up __pycache__ directories and removes unneeded dependencies.
+FROM instructlab-install AS cleanup
+RUN pip3 freeze | grep "^nvidia" | sed 's/==.*$//g' | xargs pip3 uninstall -y && \
+    find /usr -type d -name "__pycache__" | xargs rm -rf -v
+
+FROM registry.fedoraproject.org/fedora-toolbox:40 AS final
+RUN dnf install -y gh nvtop lld rocm-runtime hipblas && \
+    dnf clean all && \
+    rm -rf /var/cache/yum
+COPY --from=cleanup /usr/lib/python3.12/site-packages /usr/lib/python3.12/site-packages
+COPY --from=cleanup /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=cleanup /usr/local/lib64/python3.12/site-packages /usr/local/lib64/python3.12/site-packages
+COPY --from=cleanup /usr/local/bin/lab /usr/local/bin/lab
+
+ENV HSA_OVERRIDE_GFX_VERSION=10.3.0
+LABEL com.github.containers.toolbox="true" \
+      name="instructlab-rocm" \
+      usage="This image is meant to be used with the toolbox(1) command" \
+      summary="Image for creating Fedora Toolbx containers"

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,20 @@
+# Containers
+
+This directory contains Containerfiles which can be used to easily bring up a development environment for use with this repository.
+
+`Containerfile.toolbox-rocm` is suitable for use with hosts equipped with AMD ROCm GPUs. This Containerfile is intended for use with [Toolbox](https://containertoolbx.org/install/).
+
+## Building
+
+With this repository cloned and in the root of this repository:
+
+1. Identify which AMD GPU you have on your machine. See: [GPU
+   acceleration](../docs/gpu-acceleration.md) for what this is and how to
+   figure it out.
+2. Build the image: `podman build --build-arg=AMDGPU_TARGETS=<your GPU identifier> -t instructlab:rocm --file=./containers/Containerfile.toolbox-rocm .`
+
+## Running
+
+1. Create a new toolbox container using this image: `toolbox create --image localhost/instructlab:rocm instructlab`
+2. Enter your toolbox container: `toolbox enter instructlab`
+3. Create your work directory: `mkdir instructlab`


### PR DESCRIPTION
To make the overall experience a bit better for those who have AMD GPUs, I wrote a Containerfile suitable for use with [Toolbox](https://github.com/containers/toolbox) that one can use to quickly and easily bring up an environment to use the contents of this repository in. The eventual goal is that we could also provide similar Containerfiles for NVIDIA GPUs as well as potentially pre-building these.

The one caveat I have with providing pre-built containers is that the image this Containerfile produces takes ~26 GB.