### PR TITLE
ci: Speed up lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,9 +18,13 @@ on:
   push:
     branches: 
       - "main"
+    paths:
+      - '**.py'
   pull_request:
     branches: 
       - "main"
+    paths:
+      - '**.py'
 
 env:
   PYTHON_VERSION: 3.9


### PR DESCRIPTION
Tell tox to skip reinstalling existing site packages

Shaving off about 20 to 30 seconds of total linting time (from ~ 1min 50s to ~ 1min 20s). Preserving some GH action quota and giving quicker feedback to contributors.

I also added a comment explaining all the tweaks :-)

Future improvements could be to only run lint and fmt on `*.py` files -- until we add linting for Markdown and other files.

@markstur