### PR TITLE
Make the base taxonomy git ref configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Commands:
   download  Download the model(s) to train
   generate  Generates synthetic data to enhance your example data
   init      Initializes environment for InstructLab
-  list      Lists taxonomy files that have changed since last commit
+  list      Lists taxonomy files that have changed since a reference commit (default origin/main)
   serve     Start a local server
   test      Perform rudimentary tests of the model
   train     Trains model

--- a/cli/config.py
+++ b/cli/config.py
@@ -15,6 +15,7 @@ DEFAULT_VISIBLE_OVERFLOW = True
 DEFAULT_TAXONOMY_REPO = "git@github.com:instruct-lab/taxonomy.git"
 DEFAULT_TAXONOMY_PATH = "taxonomy"
 DEFAULT_TAXONOMY_BRANCH = "main"
+DEFAULT_TAXONOMY_BASE = "origin/main"
 DEFAULT_PROMPT_FILE = "prompt.txt"
 DEFAULT_SEED_FILE = "seed_tasks.json"
 DEFAULT_GENERATED_FILES_OUTPUT_DIR = "generated"
@@ -53,6 +54,7 @@ class _generate:
     num_cpus: int
     num_instructions: int
     taxonomy_path: str
+    taxonomy_base: str
     output_dir: str
     prompt_file: str
     seed_file: str
@@ -155,6 +157,7 @@ def get_default_config():
         num_cpus=10,
         num_instructions=100,
         taxonomy_path=DEFAULT_TAXONOMY_PATH,
+        taxonomy_base=DEFAULT_TAXONOMY_BASE,
         output_dir=DEFAULT_GENERATED_FILES_OUTPUT_DIR,
         prompt_file=DEFAULT_PROMPT_FILE,
         seed_file=DEFAULT_SEED_FILE,

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -32,6 +32,7 @@ class Generate(BaseModel):
     prompt_file: str
     seed_file: str
     taxonomy_path: str
+    taxonomy_base: str
 
 
 class Serve(BaseModel):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,6 +22,7 @@ generate:
   prompt_file: prompt.txt
   seed_file: seed_tasks.json
   taxonomy_path: /tmp/instruct-lab-taxonomy
+  taxonomy_base: origin/main
   output_dir: /tmp
 serve:
   gpu_layers: -1
@@ -49,6 +50,7 @@ generate:
   prompt_file: prompt.txt
   seed_file: seed_tasks.json
   taxonomy_path: /tmp/instruct-lab-taxonomy
+  taxonomy_base: origin/main
   output_dir: /tmp
 serve:
   gpu_layers: -1
@@ -85,6 +87,7 @@ class TestConfig(unittest.TestCase):
         assert cfg.generate.prompt_file == "prompt.txt"
         assert cfg.generate.seed_file == "seed_tasks.json"
         assert cfg.generate.taxonomy_path == "/tmp/instruct-lab-taxonomy"
+        assert cfg.generate.taxonomy_base == "origin/main"
 
     # Tests that additional lines in the config do not cause errors
     def test_config_unexpected_arguments(self):


### PR DESCRIPTION
Default the list of modified taxonomy from "origin/master" instead of HEAD, to allow users to commit changes locally and still run "list" and "generate" on locally modified files.

Also make it configurable.

Fixes #304