### PR TITLE
chore: add Kelly as doc owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,5 +11,5 @@
 * @soltysh @xukai92 @markstur @hickeyma @afrittoli @spzala @Tomcli @mrutkows
 
 /notebooks/ @rawkintrevo
-README.md @mairin
-/docs/ @mairin
+README.md @mairin @kelbrown20
+/docs/ @mairin @kelbrown20


### PR DESCRIPTION
still need to add `@kelbrown20` to the team though, which seems to hit a daily limit