### PR TITLE
Remove : from the generated filenames

### DIFF
--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -224,15 +224,10 @@ def generate_data(
         )
 
     name = Path(model_name).stem  # Just in case it is a file path
-    output_file = (
-        f"generated_{name}_{datetime.now().replace(microsecond=0).isoformat()}.json"
-    )
-    output_file_train = (
-        f"train_{name}_{datetime.now().replace(microsecond=0).isoformat()}.jsonl"
-    )
-    output_file_test = (
-        f"test_{name}_{datetime.now().replace(microsecond=0).isoformat()}.jsonl"
-    )
+    date_suffix = datetime.now().replace(microsecond=0).isoformat().replace(":", "_")
+    output_file = f"generated_{name}_{date_suffix}.json"
+    output_file_train = f"train_{name}_{date_suffix}.jsonl"
+    output_file_test = f"test_{name}_{date_suffix}.jsonl"
     logger.debug(f"Generating to: {os.path.join(output_dir, output_file)}")
 
     request_idx = 0


### PR DESCRIPTION
Windows does not allow to have : (and few other characters) in the filenames. This is particularly enforced in HuggingFace API (in datasets.BuilderConfig class).

Use underscore instead of : in the filenames.