### PR TITLE
Fix error when switching to missing context

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -170,11 +170,11 @@ class ConsoleChatBot:
             raise KeyboardInterrupt
         context = cs[1]
         if context not in CONTEXTS:
-            available_contexts = ', '.join(CONTEXTS.keys())
+            available_contexts = ", ".join(CONTEXTS.keys())
             self._sys_print(
                 Markdown(
                     f"**WARNING**: Context `{context}` not found. "
-                    f"Avaliable contexts: `{available_contexts}`"
+                    f"Available contexts: `{available_contexts}`"
                 )
             )
             raise KeyboardInterrupt


### PR DESCRIPTION
In a `lab chat` session, using the `/c` command with a non existing context results in an exception:


```
>>> /c my_context                                                                                                                                 [S][default]
Traceback (most recent call last):
  File "/home/jairamir/dev/instruct-lab/cli/.venv/bin/lab", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/jairamir/dev/instruct-lab/cli/.venv/lib64/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jairamir/dev/instruct-lab/cli/.venv/lib64/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/jairamir/dev/instruct-lab/cli/.venv/lib64/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jairamir/dev/instruct-lab/cli/.venv/lib64/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jairamir/dev/instruct-lab/cli/.venv/lib64/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jairamir/dev/instruct-lab/cli/.venv/lib64/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jairamir/dev/instruct-lab/cli/cli/lab.py", line 376, in chat
    chat_cli(
  File "/home/jairamir/dev/instruct-lab/cli/cli/chat/chat.py", line 413, in chat_cli
    ccb.start_prompt()
  File "/home/jairamir/dev/instruct-lab/cli/cli/chat/chat.py", line 284, in start_prompt
    handler(content)
  File "/home/jairamir/dev/instruct-lab/cli/cli/chat/chat.py", line 173, in _handle_context
    self.loaded["messages"] = [{"role": "system", "content": CONTEXTS[context]}]
                                                             ~~~~~~~~^^^^^^^^^
KeyError: 'my_context'
```

This PR adds a condition to verify that the context is one of the keys of the `CONTEXTS` dictionary. Otherwise, it prints a warning message.

```
>>> /c my_context                                                                                                                                 [S][default]
╭────────────────────────────────────────────────────────────────────────── system ──────────────────────────────────────────────────────────────────────────╮
│ WARNING: Context my_context not found. Avaliable contexts: default, cli_helper                                                                             │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
>>>    
```