### PR TITLE
chore: Limit python versions in CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,7 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.9"
-          - "3.10"
           - "3.11"
-          - "3.12"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This is to help with GH actions limits for now. We will re-open once limit is no longer an issue.