### PR TITLE
ux: Handle outdated config file more gracefully

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -28,6 +28,15 @@ class ConfigException(Exception):
         )
 
 
+class ConfigOutdated(Exception):
+    """Config parsing failed due to use of an outdated format."""
+
+    def __init__(self, filename):
+        super().__init__(
+            f"Configuration file {filename} is using an outdated format. Run `lab init` again."
+        )
+
+
 @dataclass
 class _general:
     log_level: str
@@ -84,8 +93,12 @@ def read_config(config_file=DEFAULT_CONFIG):
     try:
         with open(config_file, "r", encoding="utf-8") as yamlfile:
             cfg = yaml.safe_load(yamlfile)
+            if "list" in cfg and "taxonomy_path" in cfg["list"]:
+                raise ConfigOutdated(config_file)
             return Config(**cfg)
     except Exception as exc:
+        if isinstance(exc, ConfigOutdated):
+            raise
         raise ConfigException(config_file) from exc
 
 

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -54,7 +54,11 @@ def configure(ctx, param, filename):
             f"`{filename}` does not exists, please run `lab init` or point to a valid configuration file using `--config=<path>`."
         )
 
-    ctx.obj = Lab(filename)
+    try:
+        ctx.obj = Lab(filename)
+    except config.ConfigOutdated as exc:
+        raise click.ClickException(str(exc))
+
     # default_map holds a dictionary with default values for each command parameters
     ctx.default_map = config.get_dict(ctx.obj.config)
 


### PR DESCRIPTION
Commit 31b64f475a9ae0571e5903f776b9fbd00bc71dde dropped
`list.taxonomy_path` from the config file. This change handles the
config parsing error more gracefully.  Previously, you'd get a stack
trace that ends with something like:

```
  File "/Users/rbryant/src/instructlab/cli/cli/lab.py", line 57, in configure
    ctx.obj = Lab(filename)
  File "/Users/rbryant/src/instructlab/cli/cli/lab.py", line 40, in __init__
    self.config = config.read_config(filename)
  File "/Users/rbryant/src/instructlab/cli/cli/config.py", line 99, in read_config
    raise ConfigException(config_file) from exc
cli.config.ConfigException: Configuration file config.yaml does not exist or contains invalid YAML.

```

The new behavior is:

```
Error: Configuration file config.yaml is using an outdated format. Run `lab init` again.
```

Signed-off-by: Russell Bryant <rbryant@redhat.com>