### PR TITLE
Context is not required for knowledge taxonomy

### DIFF
--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -406,7 +406,7 @@ def read_taxonomy_file(logger, file_path):
             for t in get_seed_examples(contents):
                 q = t["question"]
                 a = t["answer"]
-                c = t["context"]
+                c = t.get("context")
                 if not q:
                     logger.warn(
                         f"Skipping entry in {file_path} " + "because question is empty!"


### PR DESCRIPTION
I tried adding the Taylor Swift example form the instruct-lab/taxonomy repo and received the following. I believe that the `context` field is not required for knowledge data, correct? 

```
(v) [rbost@fedora instruct-lab]$ lab generate 
INFO 2024-03-07 14:50:14,742 lab.py:288 Generating model 'merlinite-7b-Q4_K_M' using 10 cpus, taxonomy: 'taxonomy' and seed 'seed_tasks.json' against http://localhost:8000/v1 server
<method-wrapper '__repr__' of KeyError object at 0x7f31d73b7e20>  in  taxonomy/knowledge/textbook/culture/music/pop/taylor swift/qna.yaml
ERROR 2024-03-07 14:50:14,750 generate_data.py:433 'context'
1 taxonomy files with errors! Exiting.
```

Using `.get` instead of direct access will return None if `context` not present.