### PR TITLE
yaml: Add initial support for version element

### DIFF
--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -155,6 +155,17 @@ def get_seed_examples(contents):
     return contents
 
 
+def get_version(contents):
+    if "version" in contents:
+        version = contents["version"]
+        try:
+            version = int(version)
+        except ValueError:
+            pass
+        return version
+    return 1
+
+
 def generate_data(
     logger,
     api_base,
@@ -400,6 +411,13 @@ def read_taxonomy_file(logger, file_path):
             contents = yaml.safe_load(file)
             if not contents:
                 logger.warn(f"Skipping {file_path} because it is empty!")
+                warnings += 1
+                return None, warnings, errors
+            version = get_version(contents)
+            if version != 1:
+                logger.warn(
+                    f"Skipping {file_path} because its version, {version}, is not understood. You may need a newer version of this command."
+                )
                 warnings += 1
                 return None, warnings, errors
             tax_path = "->".join(file_path.split(os.sep)[1:-1])


### PR DESCRIPTION
If the version element is missing or has the value 1, then parsing continues as it currently does. If the value is not 1, then a warning is issued.

In the future different version values can be supported for changes in the schema.

Fixes https://github.com/instruct-lab/cli/issues/410