### PR TITLE
ci: Don't build on doc changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,13 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - '**.py'
   pull_request:
     branches:
       - "main"
+    paths:
+      - '**.py'
 
 jobs:
   build:
@@ -39,7 +43,24 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      # tox creates (and reuses) a separate Python (virtual) environment for each context (fmt, lint, unit)
+      # tox requires (and will install, if not exists) all the packages listed in requirements.txt
+      # so we want to cache the entire Python environment, not just the pip cache as tox will not reuse that
+      # but caching tox environments is fickle and can cause weird errors
+      # tox does provide a legacy option to reuse the Python system wide site packages
+      # since GH action runners are one-and-done we can install all requirements into the system packages
+      # and cache and reuse all of the installed Python system packages
+      # tox can then reuse the system site packages with setting `-x testenv:unit.system_site_packages=True`
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
+          restore-keys:
+            ${{ env.pythonLocation }}-
       - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
@@ -47,4 +68,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          tox -e unit
+          tox \
+            -x testenv:unit.system_site_packages=True \
+            -x testenv:unit.skip_install=True \
+            -e unit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ on:
       - '**.py'
 
 env:
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: 3.11
 
 jobs:
   lint:

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 envlist = fmt, lint, unit
 
-[testenv]
+[testenv:unit]
 deps = -r requirements-dev.txt
 description = run unit tests
 commands = pytest tests
+allowlist_externals = pytest
 
 [testenv:lint]
 description = lint with pylint


### PR DESCRIPTION
Currently all PRs, even minor doc changes trigger the CI build action, which takes about 6 mins to complete, eating up our GH action minutes and is an unnecessary time burden for people making small document edits.

This PR makes the following changes:
- only run the build workflow when `*.py` files got changed
- make `tox` reuse the existing/pre-installed Python system environment (saves 2-3 mins)
- cache the Python build for subsequent builds (saves 2-3 mins)
- use Python 3.11 for the `lint` + `fmt` workflow as well to re-use the same cached Python environment

---
Screenshot of my 2  test builds which took 1 min 20 sec (green box) -- where as it took 6 mins prior to my changes (red box):

<img width="735" alt="image" src="https://github.com/instruct-lab/cli/assets/12246093/cd83186f-820a-4463-b0d1-e8153b91097d">


---

@markstur 