### PR TITLE
Allow users to specify the number of CPU threads on lab serve

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -242,14 +242,17 @@ def check(ctx, taxonomy_path, taxonomy_base):
     type=click.INT,
     help="The number of layers to put on the GPU. The rest will be on the CPU. Defaults to -1 to move all to GPU.",
 )
+@click.option("--num-threads", type=click.INT, help="The number of CPU threads to use")
 @click.pass_context
-def serve(ctx, model_path, gpu_layers):
+def serve(ctx, model_path, gpu_layers, num_threads):
     """Start a local server"""
     ctx.obj.logger.info(f"Using model '{model_path}' with {gpu_layers} gpu-layers")
+
     try:
         host = ctx.obj.config.serve.host_port.split(":")[0]
         port = int(ctx.obj.config.serve.host_port.split(":")[1])
-        server(ctx.obj.logger, model_path, gpu_layers, host, port)
+        server(ctx.obj.logger, model_path, gpu_layers, num_threads, host, port)
+
     except ServerException as exc:
         click.secho(f"Error creating server: {exc}", fg="red")
         raise click.exceptions.Exit(1)

--- a/cli/server.py
+++ b/cli/server.py
@@ -50,7 +50,7 @@ def ensure_server(logger, serve_config):
         return (server_process, temp_api_base)
 
 
-def server(logger, model_path, gpu_layers, host="localhost", port=8000):
+def server(logger, model_path, gpu_layers, threads, host="localhost", port=8000):
     """Start OpenAI-compatible server"""
     settings = Settings(
         host=host,
@@ -60,6 +60,8 @@ def server(logger, model_path, gpu_layers, host="localhost", port=8000):
         n_gpu_layers=gpu_layers,
         verbose=logger.level == logging.DEBUG,
     )
+    if threads is not None:
+        settings.n_threads = threads
     try:
         app = create_app(settings=settings)
     except ValueError as exc:


### PR DESCRIPTION
The underlying llama-cpp-python.server tooling defaults to using the number of CPUs on the system divided by 2.  For GPU accelerated inferencing, this is more than sufficient.  However, machines that lack a capable GPU and must rely on only the CPU are limited by this default.  This adds a --nr-threads option that allows the user to specify how many CPU threads llama.cpp should use when starting the server.

In local testing, this reduced the time for a default lab generate run on a 16 thread AMD Ryzen CPU with 64GB of RAM from 7:51:33 to 6:48:46 with --nr-threads 14.  Any small bit helps.