### PR TITLE
ci: Add flake8 for additional linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,3 +78,10 @@ jobs:
             -x testenv:lint.system_site_packages=True \
             -x testenv:lint.skip_install=True \
             -e lint
+
+      - name: Run flake8
+        run: |
+          tox \
+            -x testenv:flake8.system_site_packages=True \
+            -x testenv:flake8.skip_install=True \
+            -e flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+flake8
 pre-commit>=3.0.4,<4.0
 pydantic_yaml
 pydantic

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = fmt, lint, unit
+envlist = fmt, lint, unit, flake8
 
 [testenv]
 deps = -r requirements-dev.txt
@@ -15,3 +15,19 @@ allowlist_externals = pylint
 description = format with pre-commit
 commands = ./scripts/fmt.sh
 allowlist_externals = ./scripts/fmt.sh
+
+[testenv:flake8]
+description = check for errors with flake8
+# E203 whitespace before ':'
+# E302 expected 2 blank lines, found 1
+# E501 line too long (87 > 79 characters)
+# E722 do not use bare 'except'
+# E741 ambiguous variable name ...
+# W291 trailing whitespace
+# W503 line break before binary operator
+# F401 ... imported but unused
+# F541 f-string is missing placeholders
+# F811 redefinition of unused ... from line ...
+# F841 local variable ... is assigned to but never used
+commands = flake8 . --ignore=E203,E302,E501,E722,E741,W291,W503,F401,F541,F811,F841
+allowlist_externames = flake8


### PR DESCRIPTION
Add a new tox environment for running `flake8` on the code. It can
enforce common Python formatting standards, but also catch many real
errors, as well.

To start, the command is configured to ignore every rule that is
currently hit. Each one disabled is documented in tox.ini. Future PRs
can clean some of them up.

When future changes trigger other rules, they will have to be fixed or
added to the ignore list, depending on the issue.

The new environment is also added to the linting github action.

Signed-off-by: Russell Bryant <rbryant@redhat.com>