### PR TITLE
ci: Add linting on github actions config

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,28 @@
+name: Lint GitHub Actions workflows
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - '.github/**'
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - '.github/**'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.6.27
+      - name: Check workflow files
+        run: PATH=".:$PATH" actionlint -color


### PR DESCRIPTION
Add a job that lints the github actions workflows. For more info on
the linter, see: https://github.com/rhysd/actionlint

Signed-off-by: Russell Bryant <rbryant@redhat.com>