### PR TITLE
lab generate: Test for missing data

### DIFF
--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -629,8 +629,8 @@ def read_taxonomy_file(logger, file_path, yaml_rules: Optional[str] = None):
             task_description = contents.get("task_description")
             document = contents.get("document")
             for t in get_seed_examples(contents):
-                q = t["question"]
-                a = t["answer"]
+                q = t.get("question")
+                a = t.get("answer")
                 c = t.get("context")
                 if not q:
                     logger.warn(


### PR DESCRIPTION
Use entry.get to retrieve questions and answers
to avoid throwing an KeyError. Then report the
problem.

Bump the warnings about missing keys to "Error"s
so that the generate exits early.

The current behaviour is maintained with more
readable error messages, one message per entry.

Fixes #434


We now always return 0 warnings (everything is an error) but
I left the warnings in place incase some are added in future