### PR TITLE
generate: Add support for a custom API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,13 @@ The synthetic data set will be three files in the newly created `generated` dire
 
 > **NOTE:** ⏳ This can take over **1 hour+** to complete depending on your computing resources.
 
+It is also possible to run the generate step against a different model via an
+OpenAI compatible API. For example, the one spawned by `lab serve` or any remote or locally hosted LLM (e.g. via [ollama](ollama.ai/), [LM Studio](https://lmstudio.ai), etc.)
+
+```
+lab generate --endpoint-url http://localhost:8000/v1
+```
+
 ### 👩‍🏫 Train the model
 
 There are currently two options to train the model on your synthetic data-enhanced dataset.

--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -218,6 +218,7 @@ def generate_data(
     rouge_threshold: Optional[float] = None,
     console_output=True,
     has_document=False,
+    api_key: Optional[str] = None,
 ):
     seed_instruction_data = []
     generate_start = time.time()
@@ -332,6 +333,7 @@ def generate_data(
         request_start = time.time()
         results = utils.openai_completion(
             api_base=api_base,
+            api_key=api_key,
             prompts=batch_inputs,
             model_name=model_name,
             batch_size=request_batch_size,

--- a/cli/generator/utils.py
+++ b/cli/generator/utils.py
@@ -44,6 +44,7 @@ def openai_completion(
     max_instances=sys.maxsize,
     max_batches=sys.maxsize,
     return_text=False,
+    api_key="no_api_key",
     **decoding_kwargs,
 ) -> Union[
     Union[StrOrOpenAIObject],
@@ -101,7 +102,7 @@ def openai_completion(
             **decoding_kwargs,
         }
 
-        client = OpenAI(base_url=api_base, api_key="no_api_key")
+        client = OpenAI(base_url=api_base, api_key=api_key)
 
         messages = [
             {"role": "system", "content": SYSTEM_PROMPT},

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -271,6 +271,17 @@ def serve(ctx, model_path, gpu_layers):
     is_flag=True,
     help="Whether or not the examples contain the document field",
 )
+@click.option(
+    "--endpoint-url",
+    type=click.STRING,
+    help="Custom URL endpoint for OpenAI-compatible API. Defaults to the `lab serve` endpoint.",
+)
+@click.option(
+    "--api-key",
+    type=click.STRING,
+    default="",
+    help="API key for API endpoint.",
+)
 @click.pass_context
 def generate(
     ctx,
@@ -283,9 +294,11 @@ def generate(
     rouge_threshold,
     quiet,
     has_document,
+    endpoint_url,
+    api_key,
 ):
     """Generates synthetic data to enhance your example data"""
-    api_base = ctx.obj.config.serve.api_base()
+    api_base = endpoint_url if endpoint_url != "" else ctx.obj.config.serve.api_base()
     try:
         ctx.obj.logger.info(
             f"Generating model '{model}' using {num_cpus} cpus, taxonomy: '{taxonomy_path}' and seed '{seed_file}' against {api_base} server"
@@ -293,6 +306,7 @@ def generate(
         generate_data(
             logger=ctx.obj.logger,
             api_base=api_base,
+            api_key=api_key,
             model_name=model,
             num_cpus=num_cpus,
             num_instructions_to_generate=num_instructions,


### PR DESCRIPTION
Add the ability to run `lab generate` against a custom OpenAI
compatible API endpoint. For example:

```
lab generate --openai-url https://api.openai.com/v1 --openai-api-key "${OPENAI_API_KEY}" --model gpt-3.5-turbo
```

Closes #345

Signed-off-by: Russell Bryant <rbryant@redhat.com>