### PR TITLE
Make directory for chat log without log filename

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -83,7 +83,7 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
 
         self.input = None
         if prompt:
-            os.makedirs(PROMPT_HISTORY_FILEPATH, exist_ok=True)
+            os.makedirs(os.path.dirname(PROMPT_HISTORY_FILEPATH), exist_ok=True)
             self.input = PromptSession(history=FileHistory(PROMPT_HISTORY_FILEPATH))
         self.multiline = False
         self.multiline_mode = 0


### PR DESCRIPTION
The `makedirs` call for chat log file shouldn't include the filename itself to prevent this error:

```
>>> ERROR 2024-03-08 21:13:19,926 buffer.py:422 Loading history failed                                                                                                                                                            [S][default]
Traceback (most recent call last):
  File "/root/instruct-lab/v/lib/python3.10/site-packages/prompt_toolkit/buffer.py", line 409, in load_history_done
    f.result()
  File "/root/instruct-lab/v/lib/python3.10/site-packages/prompt_toolkit/buffer.py", line 397, in load_history
    async for item in self.history.load():
  File "/root/instruct-lab/v/lib/python3.10/site-packages/prompt_toolkit/history.py", line 59, in load
    self._loaded_strings = list(self.load_history_strings())
  File "/root/instruct-lab/v/lib/python3.10/site-packages/prompt_toolkit/history.py", line 278, in load_history_strings
    with open(self.filename, "rb") as f:
IsADirectoryError: [Errno 21] Is a directory: '/root/.local/chat-cli.history'
```