### PR TITLE
Add the ability to list and get basic information about skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
   - [📥 Download the model](#-download-the-model)
   - [🍴 Serving the model](#-serving-the-model)
   - [📣 Chat with the model (Optional)](#-chat-with-the-model-optional)
+- [🔎 Getting information about existing skills](#🔎-getting-information-about-existing-skills)
+  - [📜 Listing Skills](#listing-skills)
+  - [Getting information about a specific skill](#getting-information-about-a-specific-skill)
 - [💻 Creating new knowledge or skills and training the model](#-creating-new-knowledge-or-skills-and-training-the-model)
   - [🎁 Contribute knowledge or compositional skills](#-contribute-knowledge-or-compositional-skills)
   - [📜 List your new data](#-list-your-new-data)
@@ -90,6 +93,7 @@ Commands:
   init      Initializes environment for InstructLab
   list      Lists taxonomy files that have changed since a reference commit (default origin/main)
   serve     Start a local server
+  skills    Get information about the skills in the taxonomy.
   test      Runs basic test to ensure model correctness
   train     Takes synthetic data generated locally with `lab generate`...
 ```
@@ -180,6 +184,32 @@ Before you start adding new skills and knowledge to your model, you can check ou
 ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 12.008 seconds ─╯
 >>>                                                                                                                                                                                                                               [S][default]
 ```
+
+## 🔎 Getting information about existing skills
+
+### Listing skills
+
+The lab cli allows you to see all of the skills that are curently in your taxonomy repo.
+Simply run:
+```
+lab skills list
+```
+And you will be presented with a table showing each skill along with a list of their tags.
+
+If you have changed a skill, or added a new one, those will annotated.
+
+You can then filter skills by `--tag, -t` or `--changed`.
+```
+lab skills list --tag freeform -t technical --changed
+```
+
+### Getting information about a specific skill
+
+If you want to know more about a specific skill, use this subcommand:
+```
+lab skills info <skill_name>
+```
+This will return some metadata found in the skill's definition.
 
 ## 💻 Creating new knowledge or skills and training the model
 

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -1,4 +1,5 @@
 # Standard
+from pathlib import Path
 import copy
 import functools
 import os
@@ -150,3 +151,38 @@ def get_taxonomy_diff(repo="taxonomy", base="origin/main"):
 
     updated_taxonomy_files = list(set(untracked_files + modified_files))
     return updated_taxonomy_files
+
+
+def skill_path_to_tags(skill_path, taxonomy_path):
+    """Converts a skill path to a tuple of tags"""
+    tags = skill_path.parent.parent.relative_to(taxonomy_path).as_posix().split("/")
+    return tuple(tags)
+
+
+def get_skills_dict(parent_dir, skills_dict=None, taxonomy_path=None):
+    """Recursively read the taxonomy directory.
+
+    returns a dictionary with the following structure:
+    {
+        "skill_name": {
+            "path": Path to the skill directory,
+            "tags": Tuple of tags
+        }
+    }
+    """
+    parent_dir = Path(parent_dir)
+    if skills_dict is None:
+        skills_dict = {}
+    if taxonomy_path is None:
+        taxonomy_path = parent_dir
+    for child in parent_dir.iterdir():
+        if child.is_dir():
+            get_skills_dict(child, skills_dict, taxonomy_path)
+        elif child.stem == "qna":
+            skills_dict[child.parent.name] = {
+                "path": child,
+                "tags": skill_path_to_tags(child, taxonomy_path),
+            }
+    # sort the dictionary by key
+    skills_dict = dict(sorted(skills_dict.items()))
+    return skills_dict

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,45 @@
+# Standard
+from pathlib import Path
+
+# Third Party
+import pytest
+
+# First Party
+from cli.utils import get_skills_dict, skill_path_to_tags
+
+
+@pytest.fixture
+def taxonomy_path(tmp_path):
+    p1 = Path(tmp_path / "taxonomy" / "tag1" / "tag2" / "skill1" / "qna.yml")
+    p1.parent.mkdir(parents=True)
+    p1.touch()
+    p2 = Path(tmp_path / "taxonomy" / "tag1" / "tag2" / "skill2" / "qna.yml")
+    p2.parent.mkdir(parents=True)
+    p2.touch()
+    return tmp_path / "taxonomy", p1, p2
+
+
+def test_skill_path_to_tags():
+    tax_path = Path("/home/user/taxonomy")
+    skill_path = Path("/home/user/taxonomy/tag1/tag2/skill/qna.yml")
+
+    assert skill_path_to_tags(skill_path, tax_path) == ("tag1", "tag2")
+
+    skill_path = Path("/home/user/taxonomy/tag3/tag4/tag5/skill/qna.yml")
+    assert skill_path_to_tags(skill_path, tax_path) == ("tag3", "tag4", "tag5")
+
+
+def test_get_skills_dict(taxonomy_path):
+    # pylint: disable=W0621  # Erroneous detection of redefined-outer-name
+    tax_path, p1, p2 = taxonomy_path
+    expected_output = {
+        "skill1": {
+            "path": p1,
+            "tags": ("tag1", "tag2"),
+        },
+        "skill2": {
+            "path": p2,
+            "tags": ("tag1", "tag2"),
+        },
+    }
+    assert get_skills_dict(tax_path) == expected_output


### PR DESCRIPTION
This change adds a new subcommand group "skills" and its initial children "list" and "info". The intent of this what I think "lab list" should have been, to inform the user about the kinds of skills available in the configured taxonomy.

A user can now get a list of known skills, by running: `lab skills list`

Then get some basic information about that skill by running: `lab skills info <skill_name>`

The initial list is pretty basic, but we can work on formatting if that is desired.

**Examples:**
new sub command group help
```
$  lab skills --help
Usage: lab skills [OPTIONS] COMMAND [ARGS]...

  Get information about the skills in the taxonomy.

Options:
  --help  Show this message and exit.

Commands:
  info  Get information about a specific skill.
  list  List all skills available in taxonomy.
```

listing all of the skills in the taxonomy repo
```
$ lab skills list
Showing skills in taxonomy_path='/home/jake/Programming/rh_llm/taxonomy':
abstract
action_items
...
verb
word_frequency
```

getting basic info about a specific skill
```
$ lab skills info tldr                                                                                                                
Skill: tldr
Contributor: jacobcallahan
Description: Create easily consumable short descriptions of how to use a command line tool.
Path: /home/jake/Programming/rh_llm/taxonomy/compositional_skills/writing/freeform/technical/tldr/qna.yaml
```