### PR TITLE
generate: Fix API params for default use case

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -274,12 +274,13 @@ def serve(ctx, model_path, gpu_layers):
 @click.option(
     "--endpoint-url",
     type=click.STRING,
+    default="",
     help="Custom URL endpoint for OpenAI-compatible API. Defaults to the `lab serve` endpoint.",
 )
 @click.option(
     "--api-key",
     type=click.STRING,
-    default="",
+    default="no_api_key",
     help="API key for API endpoint.",
 )
 @click.pass_context


### PR DESCRIPTION
Default endpoint-url to an empty string as this is was the generate function tests for. Set the default key to "no_api_key" as a blank string causes problems.

Fixes #487