### PR TITLE
RFC: support dynamic taxonomies

### DIFF
--- a/docs/qna.md
+++ b/docs/qna.md
@@ -1,0 +1,30 @@
+# Taxonomy input formats
+
+## Static `qna.yaml`
+
+The CLI supports a number of formats for taxonomy definitions. The default mode
+is a static `qna.yaml` file, populated by contributors of a new taxonomy with
+the question-answer pairs.
+
+The exact format of the file should be negotiated between the `cli` and
+`taxonomy` repositories.
+
+## Dynamic `qna.yaml` generation
+
+Alternatively, dynamic taxonomies can be used to generate question-answer pairs
+(and the rest of the `qna.yaml` file) programmatically. This mode can be useful
+when generating a large number of seed samples using some basic rule that can
+be better expressed with a program than by having humans manually type them in.
+
+The general idea here is to run a containerized program that would spit out the
+`qna.yaml` file when executed. Then the file is picked up by the CLI for sample
+generation purposes, same way as it would do with a statically defined
+`qna.yaml` file.
+
+To define a dynamic taxonomy, put a `Containerfile` (or `Dockerfile`) in a
+taxonomy directory. The container definition will be built by CLI and executed
+with a temporary directory mounted into it under `/out` location. The container
+command (`CMD`) is then expected to put a complete `qna.yaml` file with the
+intended question-answer pairs and full metadata under `/out/qna.yaml`, from
+where the CLI will pick the file up and pass it as seed samples for further
+generation steps.

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ mlx>=0.2.0,!=0.3.*,!=0.4.*,!=0.5.0,<0.6.0 # allowing 0.2.x for CI (not on MacOS)
 transformers>=4.38.2,<5.0.0
 numpy>=1.26.4,<2.0.0
 torch>=2.2.1,<3.0.0
+podman>=4.9.0,<5.0.0
 peft
 datasets
 trl


### PR DESCRIPTION
For some taxonomies, it makes more sense to generate them programmatically, which allows to generate a larger number of samples as well as control their correctness without relying on humans.

For example, generating samples of simple rule application to an input, that can be expressed as a simple pure function, e.g. transliteration rules, is more robust and correct when taxonomies are not human written. Some other taxonomies that lean more into knowledge territory may also benefit from this.

This patch implements dynamic taxonomies as Containerfile definitions that can generate the seed on invocation.