### PR TITLE
Fix `lab generate` when no --endpoint-url is passed

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -298,7 +298,7 @@ def generate(
     api_key,
 ):
     """Generates synthetic data to enhance your example data"""
-    api_base = endpoint_url if endpoint_url != "" else ctx.obj.config.serve.api_base()
+    api_base = endpoint_url if endpoint_url else ctx.obj.config.serve.api_base()
     try:
         ctx.obj.logger.info(
             f"Generating model '{model}' using {num_cpus} cpus, taxonomy: '{taxonomy_path}' and seed '{seed_file}' against {api_base} server"


### PR DESCRIPTION
When it's not passed, endpoint_url is None. But we check that it's != "". Since None != "", it will use None value as the endpoint and attempt to connect to the server using this "address" (which will fail).