### PR TITLE
Use CPU PyTorch in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,11 @@
 [tox]
 envlist = fmt, lint, unit, functional
 
+[testenv]
+# use CPU build of Torch in testenvs. CUDA bindings are huge.
+setenv =
+    PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
+
 [testenv:unit]
 deps = -r requirements-dev.txt
 description = run unit tests


### PR DESCRIPTION
The default CUDA bindings of PyTorch are huge and take a lot of disk space. Instead install a CPU build of PyTorch for testing from PyTorch's repository.