### PR TITLE
Some fixes to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The full process is described graphically in the [workflow diagram](./docs/workf
 
 On Fedora Linux this means installing:
 ```shell
-$ sudo dnf install g++ gcc make pip python3 python3-devel python3-GitPython
+$ sudo dnf install gcc-c++ gcc make pip python3 python3-devel python3-GitPython
 ```
 
 ## ✅ Getting started


### PR DESCRIPTION
```
commit 2e8634b12a2c6640aaaf8d0313336b45af91e103
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Mar 11 11:56:09 2024 +0100

    Fix typo in README.md
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 15397fba0862eb8f6a2aa2eadbc1c08236b3b2ff
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Mar 11 11:56:33 2024 +0100

    Update Fedora package installation instructions
    
    - YUM was replaced with DNF in Fedora 22.
    - Use the canonical package name for the C++ compiler.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```