### PR TITLE
Fix README that `lab generate` needs `serve`

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ compositional_skills/writing/freeform/foo-lang/foo-lang.yaml
 ```
 
 ### 🚀 Generate a synthetic dataset
+You need to have running `lab serve` in order to make the following command work.
 
 ```
 lab generate


### PR DESCRIPTION
It's easy to miss that `lab generate` have requirement to have running `lab serve` in the README. Let's improve that here.