### PR TITLE
utils: close files properly

### DIFF
--- a/cli/generator/utils.py
+++ b/cli/generator/utils.py
@@ -163,19 +163,16 @@ def jdump(obj, f, mode="w", indent=4, default=str):
         indent: Indent for storing json dictionaries.
         default: A function to handle non-serializable entries; defaults to `str`.
     """
-    f = _make_w_io_base(f, mode)
-    if isinstance(obj, (dict, list)):
-        json.dump(obj, f, indent=indent, default=default)
-    elif isinstance(obj, str):
-        f.write(obj)
-    else:
-        raise ValueError(f"Unexpected type: {type(obj)}")
-    f.close()
+    with _make_w_io_base(f, mode) as f_:
+        if isinstance(obj, (dict, list)):
+            json.dump(obj, f_, indent=indent, default=default)
+        elif isinstance(obj, str):
+            f_.write(obj)
+        else:
+            raise ValueError(f"Unexpected type: {type(obj)}")
 
 
 def jload(f, mode="r"):
     """Load a .json file into a dictionary."""
-    f = _make_r_io_base(f, mode)
-    jdict = json.load(f)
-    f.close()
-    return jdict
+    with _make_r_io_base(f, mode) as f_:
+        return json.load(f_)


### PR DESCRIPTION
Before the patch, if we raise an exception in jdump, the file will never close. jload may also leave a file handler open if .load() fails.