### PR TITLE
fix: make testrun.sh work on linux

### DIFF
--- a/testrun.sh
+++ b/testrun.sh
@@ -14,7 +14,7 @@ fi
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Use mktemp for unique name, but we'll keep the dir
-TEMP_DIR=`mktemp -d -p "$HERE" -t test_run_` || exit 1
+TEMP_DIR=`mktemp -d -p "$HERE" -t test_run_XXXXXXXX` || exit 1
 echo "test run in: $TEMP_DIR"
 cd $TEMP_DIR
 


### PR DESCRIPTION
The mktemp version on Linux requires a template with at least a few X keyword. Otherwise we get the following error:

```
mktemp: too few X's in template
```

Signed-off-by: Sébastien Han <seb@redhat.com>