### PR TITLE
Fix connection error in lab generate

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -17,6 +17,9 @@ from rich.panel import Panel
 from rich.text import Text
 import openai
 
+# Local
+from ..config import DEFAULT_API_KEY
+
 HELP_MD = """
 Help / TL;DR
 - `/q`: **q**uit
@@ -379,7 +382,7 @@ def chat_cli(
     logger, api_base, config, question, model, context, session, qq, greedy_mode
 ):
     """Starts a CLI-based chat with the server"""
-    client = OpenAI(base_url=api_base, api_key="no_api_key")
+    client = OpenAI(base_url=api_base, api_key=DEFAULT_API_KEY)
 
     # Load context/session
     loaded = {}

--- a/cli/client.py
+++ b/cli/client.py
@@ -1,15 +1,18 @@
 # Third Party
 from openai import OpenAI, OpenAIError
 
+# Local
+from .config import DEFAULT_API_KEY
+
 
 class ClientException(Exception):
     """An exception raised when invoking client operations."""
 
 
-def list_models(api_base):
+def list_models(api_base, api_key=DEFAULT_API_KEY):
     """List models from OpenAI-compatible server"""
     try:
-        client = OpenAI(base_url=api_base, api_key="no_api_key")
+        client = OpenAI(base_url=api_base, api_key=api_key)
         return client.models.list()
     except OpenAIError as exc:
         raise ClientException(f"Connection Error {exc}") from exc

--- a/cli/generator/utils.py
+++ b/cli/generator/utils.py
@@ -12,6 +12,9 @@ import sys
 # Third Party
 from openai import OpenAI, OpenAIError
 
+# Local
+from ..config import DEFAULT_API_KEY
+
 StrOrOpenAIObject = Union[str, object]
 
 SYSTEM_PROMPT = "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior."
@@ -44,7 +47,7 @@ def openai_completion(
     max_instances=sys.maxsize,
     max_batches=sys.maxsize,
     return_text=False,
-    api_key="no_api_key",
+    api_key=DEFAULT_API_KEY,
     **decoding_kwargs,
 ) -> Union[
     Union[StrOrOpenAIObject],

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -277,7 +277,7 @@ def serve(ctx, model_path, gpu_layers):
 @click.option(
     "--api-key",
     type=click.STRING,
-    default="",
+    default=config.DEFAULT_API_KEY,
     help="API key for API endpoint.",
 )
 @click.pass_context
@@ -296,12 +296,15 @@ def generate(
     api_key,
 ):
     """Generates synthetic data to enhance your example data"""
-    server_process, api_base = ensure_server(
-        ctx.obj.logger,
-        ctx.obj.config.serve,
-    )
-    if not api_base:
-        api_base = ctx.obj.config.serve.api_base()
+    if endpoint_url is None:
+        server_process, api_base = ensure_server(
+            ctx.obj.logger,
+            ctx.obj.config.serve,
+        )
+        if not api_base:
+            api_base = ctx.obj.config.serve.api_base()
+    else:
+        server_process, api_base = (None, endpoint_url)
     try:
         ctx.obj.logger.info(
             f"Generating model '{model}' using {num_cpus} cpus, taxonomy: '{taxonomy_path}' and seed '{seed_file}' against {api_base} server"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ lab = "cli.lab:cli"
 [tool.setuptools.packages.find]
 # defines where to look for sub-packages
 where = [""]
-include = ["cli", "cli.chat", "cli.generator", "cli.train", "cli.train.lora-mlx", "cli.train.lora-mlx.models", "cli.llamacpp"]
+include = ["cli", "cli.chat", "cli.generator", "cli.train", "cli.train.lora-mlx", "cli.train.lora-mlx.models", "cli.llamacpp", "cli.mlx_explore"]
 
 [tool.setuptools.package-data]
 "*" = ["quantize"]


### PR DESCRIPTION
Commit 09d72a1 introduces a regression in `lab generate`. The default `api_base` and `api_key` were no longer correct:

- The default value for `--endpoint-url` is `None`, not empty string.
- The default API key must be `"no_api_key"` instead of `""`

The PR also refactors code to use `cli.config.DEFAULT_API_KEY` instead of string `"no_api_key"`.

Closes: #513