### PR TITLE
Add the link to the model being downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can override this behavior for any `lab` command with the `--config` paramet
 lab download
 ```
 
-`lab download` will download a pre-trained model from HuggingFace and store it in a `models` directory:
+`lab download` will download a pre-trained [model](https://huggingface.co/ibm/) (~4.4G) from HuggingFace and store it in a `models` directory:
 
 ```
 (venv) $ lab download


### PR DESCRIPTION
Add a link so people can get a feel for HF in case they have never been there to see how and where models are served. Also, for those on limited bandwidth, they can see the size of the model to get a feel for how long the download will take. ty!