### PR TITLE
Adds smoke test for notebook validation

### DIFF
--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,0 +1,16 @@
+# Standard
+import glob
+import json
+
+# Third Party
+import pytest
+
+
+# This loads each notebook and attempts to parse the JSON that is contained
+# within it in order to validate that it is well-formed JSON. This is intended
+# to be a smoke test for notebooks until there is a better defined test story
+# for them.
+@pytest.mark.parametrize("path", glob.glob("**/*.ipynb"))
+def test_notebooks(path):
+    with open(path, encoding="utf-8") as notebook_file:
+        json.load(notebook_file)


### PR DESCRIPTION
The `notebooks/Training_a_LoRA_With_Instruct_Lab.ipynb` notebook had some malformed JSON within it, which prevented it from being displayed in the GitHub UI as well as being loaded into Jupyter notebooks. It looked like this:

![Screenshot 2024-03-11 at 12 11 58](https://github.com/instruct-lab/cli/assets/1221263/7c4c7779-4652-4529-822e-fcdd0f76724f)

The quoting was fixed here: https://github.com/instruct-lab/cli/pull/522. This PR adds a simple smoke test to guard against this in the future by validating that any notebooks found in this repository can be parsed as JSON (which is what they are under the hood). There are more advanced tests that we can do with tooling such as [nbval](https://github.com/computationalmodelling/nbval) though I thought that might be beyond the scope of this PR.

This could be considered a first-pass of https://github.com/instruct-lab/cli/issues/523.