### PR TITLE
Fix package install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ lab = "cli.lab:cli"
 [tool.setuptools.packages.find]
 # defines where to look for sub-packages
 where = [""]
-include = ["cli", "cli.chat", "cli.generator", "cli.train", "cli.train.lora-mlx", "cli.train.lora-mlx.models", "cli.llamacpp"]
+include = ["cli", "cli.chat", "cli.generator", "cli.train", "cli.train.lora-mlx", "cli.train.lora-mlx.models", "cli.llamacpp", "cli.mlx_explore"]
 
 [tool.setuptools.package-data]
 "*" = ["quantize"]


### PR DESCRIPTION
```command
$ lab init

Traceback (most recent call last):
  File "/Users/Matt_1/Projects/instruct-lab/cli/venv/bin/lab", line 5, in <module>
    from cli.lab import cli
  File "/Users/Matt_1/Projects/instruct-lab/cli/venv/lib/python3.11/site-packages/cli/lab.py", line 22, in <module>
    from .mlx_explore import utils as mlx_utils
```