### PR TITLE
Provide current date time in the default context

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -38,8 +38,8 @@ Press Meta+Enter or Esc Enter to end multiline input.
 """
 
 CONTEXTS = {
-    "default": "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior.",
-    "cli_helper": "You are an expert for command line interface and know all common commands. Answer the command to execute as it without any explanation.",
+    "default": f"You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior.\nCurrent date is {datetime.datetime.now().astimezone()}",
+    "cli_helper": f"You are an expert for command line interface and know all common commands. Answer the command to execute as it without any explanation.\nCurrent date is {datetime.datetime.now().astimezone()}",
 }
 
 PROMPT_HISTORY_FILEPATH = os.path.expanduser("~/.local/chat-cli.history")


### PR DESCRIPTION
Providing current date in the default context helps the model to provide more relevant information for historical events.

### Before:
> How many days until the next US Elections ?

To determine the number of days until the next US Elections, we first need to know when the upcoming election is scheduled to take place. The United States holds elections every two years for Congress,
with the Presidential election occurring every four years. The most recent Presidential election was held on November 3, 2020, while the 2022 election will be for Congressional seats.

Given that it is currently March 30, 2022, let's calculate the number of days until the next election:

1. First, we need to find out when the next election is taking place. In this case, it is on November 8, 2022 (Tuesday).
2. Now, we subtract the current date from the election date to find out how many days are left:
   November 8, 2022 - March 30, 2022 = 240 days
3. Therefore, there are 240 days until the next US Elections.

### Now:
> How many days until the next US Elections ?                                                                                                                                   

To determine the number of days until the next US Elections, we first need to know the election date, which is November 8, 2024. To calculate the number of days between the current date, March 12, 2024,
and the election day, we can use the following steps:

1. Convert both dates into Unix timestamps (number of seconds since January 1, 1970, 00:00:00 UTC).
   - Current date (March 12, 2024): 1647079693.484949
   - Election day (November 8, 2024): 1676798000 (approximately)

2. Subtract the current date's Unix timestamp from the election day's Unix timestamp.
   - Difference in seconds: 1676798000 - 1647079693.484949 = 297195555.515051

3. Convert the difference in seconds into days by dividing it by the number of seconds in a day (86400).
   - Number of days: 297195555.515051 / 86400 ≈ 344.76

Since there are no days with a fraction of a day in a countdown, we can round the result to the nearest whole number. In this case, there are 345 days until the next US Elections. Keep in mind that this
calculation assumes a consistent number of days in each month, which may not be entirely accurate due to leap years or other factors. However, this method provides a close estimate for the number of days
until the next US Elections.