### PR TITLE
feat: add ability to change model host server context size

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Once the model is served and ready, you'll see the following output:
 
 ```
 (venv) $ lab serve
-INFO 2024-03-02 02:21:11,352 lab.py:201 Using model 'models/ggml-merlinite-7b-0302-Q4_K_M.gguf' with -1 gpu-layers
+INFO 2024-03-02 02:21:11,352 lab.py:201 Using model 'models/ggml-merlinite-7b-0302-Q4_K_M.gguf' with -1 gpu-layers and 4096 max context size.
 Starting server process
 After application startup complete see http://127.0.0.1:8000/docs for API.
 Press CTRL+C to shutdown server.

--- a/cli/config.py
+++ b/cli/config.py
@@ -65,6 +65,7 @@ class _serve:
     host_port: str
     model_path: str
     gpu_layers: int
+    max_ctx_size: int
 
     def api_base(self):
         """Returns server API URL, based on the configured host and port"""
@@ -167,6 +168,7 @@ def get_default_config():
         host_port=DEFAULT_HOST_PORT,
         model_path=DEFAULT_MODEL_PATH,
         gpu_layers=-1,
+        max_ctx_size=4096,
     )
     return Config(general=general, chat=chat, generate=generate, serve=serve)
 

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -248,16 +248,30 @@ def check(ctx, taxonomy_path, taxonomy_base):
     help="The number of layers to put on the GPU. The rest will be on the CPU. Defaults to -1 to move all to GPU.",
 )
 @click.option("--num-threads", type=click.INT, help="The number of CPU threads to use")
+@click.option(
+    "--max-ctx-size",
+    type=click.INT,
+    help="The context size is the maximum number of tokens considered by the model, for both the prompt and response. Defaults to 4096.",
+)
 @click.pass_context
-def serve(ctx, model_path, gpu_layers, num_threads):
+def serve(ctx, model_path, gpu_layers, num_threads, max_ctx_size):
     """Start a local server"""
-    ctx.obj.logger.info(f"Using model '{model_path}' with {gpu_layers} gpu-layers")
+    ctx.obj.logger.info(
+        f"Using model '{model_path}' with {gpu_layers} gpu-layers and {max_ctx_size} max context size."
+    )
 
     try:
         host = ctx.obj.config.serve.host_port.split(":")[0]
         port = int(ctx.obj.config.serve.host_port.split(":")[1])
-        server(ctx.obj.logger, model_path, gpu_layers, num_threads, host, port)
-
+        server(
+            ctx.obj.logger,
+            model_path,
+            gpu_layers,
+            max_ctx_size,
+            num_threads,
+            host,
+            port,
+        )
     except ServerException as exc:
         click.secho(f"Error creating server: {exc}", fg="red")
         raise click.exceptions.Exit(1)

--- a/cli/server.py
+++ b/cli/server.py
@@ -42,6 +42,7 @@ def ensure_server(logger, serve_config):
                 "logger": logger,
                 "model_path": serve_config.model_path,
                 "gpu_layers": serve_config.gpu_layers,
+                "max_ctx_size": serve_config.max_ctx_size,
                 "port": port,
             },
             daemon=True,
@@ -50,13 +51,21 @@ def ensure_server(logger, serve_config):
         return (server_process, temp_api_base)
 
 
-def server(logger, model_path, gpu_layers, threads=None, host="localhost", port=8000):
+def server(
+    logger,
+    model_path,
+    gpu_layers,
+    max_ctx_size,
+    threads=None,
+    host="localhost",
+    port=8000,
+):
     """Start OpenAI-compatible server"""
     settings = Settings(
         host=host,
         port=port,
         model=model_path,
-        n_ctx=4096,
+        n_ctx=max_ctx_size,
         n_gpu_layers=gpu_layers,
         verbose=logger.level == logging.DEBUG,
     )

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -37,6 +37,7 @@ class Generate(BaseModel):
 
 class Serve(BaseModel):
     gpu_layers: int
+    max_ctx_size: int
     model_path: str
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,7 @@ generate:
   output_dir: /tmp
 serve:
   gpu_layers: -1
+  max_ctx_size: 4096
   model_path: models/ggml-merlinite-7b-0302-Q4_K_M.gguf
   host_port: localhost:8000
 """
@@ -54,6 +55,7 @@ generate:
   output_dir: /tmp
 serve:
   gpu_layers: -1
+  max_ctx_size: 4096
   model_path: models/ggml-merlinite-7b-0302-Q4_K_M.gguf
 """
 
@@ -74,6 +76,7 @@ class TestConfig(unittest.TestCase):
         assert cfg is not None
         assert cfg.serve is not None
         assert cfg.serve.gpu_layers == -1
+        assert cfg.serve.max_ctx_size == 4096
         assert cfg.serve.model_path == "models/ggml-merlinite-7b-0302-Q4_K_M.gguf"
         assert cfg.chat.context == "default"
         assert cfg.chat.model == "ggml-merlinite-7b-0302-Q4_K_M"


### PR DESCRIPTION
We can now change the context size using --max-ctx-size when running the server. The default of 4096 remains unchanged.

Signed-off-by: Sébastien Han <seb@redhat.com>