### PR TITLE
Fix error when filepath specifed does not exist

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -244,6 +244,13 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
             )
             raise KeyboardInterrupt
         filepath = cs[1]
+        if not os.path.exists(filepath):
+            self._sys_print(
+                Markdown(
+                    f"**WARNING**: File `{filepath}` specified in the `/l filepath` or `/L filepath` command does not exist."
+                )
+            )
+            raise KeyboardInterrupt
         with open(filepath, "r") as session:
             messages = json.loads(session.read())
         if content[:2] == "/L":


### PR DESCRIPTION
In a `lab chat` session using /l non-existing-file or /L non-existing-file results in an exception

Traceback (most recent call last):
  File "/home/ubuntu/instruct-lab/venv/bin/lab", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/ubuntu/instruct-lab/venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/instruct-lab/venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/ubuntu/instruct-lab/venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/instruct-lab/venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/instruct-lab/venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/instruct-lab/venv/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/instruct-lab/venv/lib/python3.11/site-packages/cli/lab.py", line 330, in chat
    chat_cli(
  File "/home/ubuntu/instruct-lab/venv/lib/python3.11/site-packages/cli/chat/chat.py", line 420, in chat_cli
    ccb.start_prompt()
  File "/home/ubuntu/instruct-lab/venv/lib/python3.11/site-packages/cli/chat/chat.py", line 293, in start_prompt
    handler(content)
  File "/home/ubuntu/instruct-lab/venv/lib/python3.11/site-packages/cli/chat/chat.py", line 240, in _handle_load_session
    with open(filepath, "r") as session:
         ^^^^^^^^^^^^^^^^^^^


Signed-off-by: Abhishek Kekane <akekane@redhat.com>