### PR TITLE
[DOCS] Fixing some wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@
   - [📥 Download the model](#-download-the-model)
   - [🍴 Serving the model](#-serving-the-model)
   - [📣 Chat with the model (Optional)](#-chat-with-the-model-optional)
-- [💻 Creating new knowledge and training the model](#-creating-new-knowledge-and-training-the-model)
+- [💻 Creating new knowledge or skills and training the model](#-creating-new-knowledge-or-skills-and-training-the-model)
   - [🎁 Contribute knowledge or compositional skills](#-contribute-knowledge-or-compositional-skills)
-  - [📜 List your new knowledge](#-list-your-new-knowledge)
+  - [📜 List your new data](#-list-your-new-data)
   - [🚀 Generate a synthetic dataset](#-generate-a-synthetic-dataset)
   - [👩‍🏫 Train the model](#-train-the-model) 
   - [🍴 Serve the newly trained model](#-serve-the-newly-trained-model)
   - [📣 Chat with the new model (not optional this time)](#-chat-with-the-new-model-not-optional-this-time)
-- [🎁 Submit your new knowledge](#-submit-your-new-knowledge)
+- [🎁 Submit your new knowledge or skills](#-submit-your-new-knowledge-or-skills)
 - [📬 Contributing to Instruct-Lab CLI](#-contributing)
 
 ## ❓ What is `lab`
 
 `lab` is a Command-Line Interface (CLI) tool that allows you to:
 
-1. Download a pre-trained LLM (Large Language Model).
+1. Download a pre-trained Large Language Model (LLM).
 2. Chat with the LLM.
 
 To add new knowledge and skills to the pre-trained LLM you have to add new information to the companion [taxonomy](https://github.com/instruct-lab/taxonomy.git) repository.
@@ -170,20 +170,20 @@ Before you start adding new skills and knowledge to your model, you can check ou
 >>>                                                                                                                                                                                                                               [S][default]
 ```
 
-## 💻 Creating new knowledge and training the model
+## 💻 Creating new knowledge or skills and training the model
 ### 🎁 Contribute knowledge or compositional skills
 
 Locally contribute new knowledge or compositional skills to your local [taxonomy](https://github.com/instruct-lab/taxonomy.git) repository.
 
 Detailed contribution instructions can be found on the [taxonomy github](https://github.com/instruct-lab/taxonomy/blob/main/README.md).
 
-### 📜 List your new knowledge
+### 📜 List your new data
 
 ```
 lab list
 ```
 
-To ensure `lab` is registering your new knowledge, you can run `lab list`.
+To ensure `lab` is registering your new knowledge or skills, you can run `lab list`.
 
 The following is the expected result after adding the new compositional skill foo-lang:
 ```
@@ -197,7 +197,7 @@ compositional_skills/writing/freeform/foo-lang/foo-lang.yaml
 lab generate
 ```
 
-The next step is to generate a synthetic dataset based on your newly added knowledge set in the [taxonomy](https://github.com/instruct-lab/taxonomy.git) repository:
+The next step is to generate a synthetic dataset based on your newly added knowledge or skill set in the [taxonomy](https://github.com/instruct-lab/taxonomy.git) repository:
 
 ```
 (venv) $ lab generate
@@ -299,7 +299,7 @@ lab chat -m <New model name>
 
 If you are interested in optimizing the quality of the model's responses, please see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md#model-fine-tuning-and-response-optimization)
 
-## 🎁 Submit your new knowledge
+## 🎁 Submit your new knowledge or skills
 
 Of course the final step is, if you've improved the model, to open up a a pull-request in the [taxonomy repository](https://github.com/instruct-lab/taxonomy) that includes the `qna.yaml` files with your improved data. 
 


### PR DESCRIPTION
**Description:** There is a use of the word "knowledge" seems to have a double meaning in the CLI README, where knowledge can refer the type for this project as well as just another word for data/info. I've has some people come to me with the same confusion, trying to clarify it in this PR by referring it as the type 