### PR TITLE
README.md: lab generate files in taxonomy dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ taxonomy: '/home/username/instruct-lab/taxonomy' and seed 'seed_tasks.json'
 98%|##########| 98/100 INFO 2024-02-29 20:49:27,582 generate_data.py:428 Generation took 5978.78s
 ```
 
-The synthetic data set will be three files in the newly created `generated` directory that are named like: `generated*.json`, `test*.jsonl`, and `train*.jsonl`:
+The synthetic data set will be three files in the `taxonomy` directory that are named like: `generated*.json`, `test*.jsonl`, and `train*.jsonl`:
 ```
-(venv) $ ls generated/
+(venv) $ ls taxonomy/*.json*
  'generated_ggml-malachite-7b-0226-Q4_K_M_2024-02-29T19 09 48.json'   'train_ggml-malachite-7b-0226-Q4_K_M_2024-02-29T19 09 48.jsonl'
  'test_ggml-malachite-7b-0226-Q4_K_M_2024-02-29T19 09 48.jsonl'
 ```


### PR DESCRIPTION
The lab generate command is creating files in the taxonomy directory. This patch is to update the README.md to reflect this.

**Which issue is resolved by this Pull Request:** 
Resolves #555

**Description of your changes:**

README.md changes to point reader to the `taxonomy` directory for the `lab generate` files instead of `generated`.