### PR TITLE
Fix backtrace via `lab chat` `ensure_server()` call

### DIFF
--- a/cli/server.py
+++ b/cli/server.py
@@ -50,7 +50,7 @@ def ensure_server(logger, serve_config):
         return (server_process, temp_api_base)
 
 
-def server(logger, model_path, gpu_layers, threads, host="localhost", port=8000):
+def server(logger, model_path, gpu_layers, threads=None, host="localhost", port=8000):
     """Start OpenAI-compatible server"""
     settings = Settings(
         host=host,


### PR DESCRIPTION
PR #423 missed adding a `threads` argument to the `server()` call from `ensure_server()`. The latter is called when `lab chat` is used before a `lab serve`:

```
$ lab chat
...

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib64/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
TypeError: server() missing 1 required positional argument: 'threads'
```

Make the `threads` argument to `server()` optional. That will probably be easier for plugging in future `threads` config file support too

Resolves: https://github.com/instruct-lab/cli/issues/566