### PR TITLE
install: Only install mlx for mac with arm64

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -4,6 +4,7 @@ from os.path import basename, dirname, exists, splitext
 import json
 import logging
 import os
+import platform
 import shutil
 import sys
 
@@ -21,7 +22,7 @@ from .generator.generate_data import generate_data, get_taxonomy_diff, read_taxo
 from .generator.utils import GenerateException
 from .server import ServerException, ensure_server, server
 
-if sys.platform == "darwin":  # mlx requires macOS
+if sys.platform == "darwin" and platform.machine() == "arm64":  # mlx requires macOS
     # Local
     from .mlx_explore import utils as mlx_utils
 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ tokenizers>=0.15.2,<0.16.0
 wandb>=0.16.4,<0.17.0
 GitPython>=3.1.42,<4.0.0
 gguf>=0.6.0,<0.7.0
-mlx>=0.5.1,<0.6.0; sys_platform == 'darwin'
+mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 transformers>=4.38.2,<5.0.0
 numpy>=1.26.4,<2.0.0
 torch>=2.2.1,<3.0.0


### PR DESCRIPTION
PR #467 updated requirements.txt and the code to only install and load
mlx for mac, but the check needs to be a bit more specific. It needs
to mac with `arm64`. It should still be skipped for older intel macs.

Closes #570 

Signed-off-by: Russell Bryant <rbryant@redhat.com>