### PR TITLE
Make threads parameter optional for serve()

### DIFF
--- a/cli/server.py
+++ b/cli/server.py
@@ -50,7 +50,7 @@ def ensure_server(logger, serve_config):
         return (server_process, temp_api_base)
 
 
-def server(logger, model_path, gpu_layers, threads, host="localhost", port=8000):
+def server(logger, model_path, gpu_layers, threads=None, host="localhost", port=8000):
     """Start OpenAI-compatible server"""
     settings = Settings(
         host=host,


### PR DESCRIPTION
* New parameter was added without a default. Not all callers were updated.
* So we are getting: `TypeError: server() missing 1 required positional argument: 'threads'`
* Just adding a default fixes the problem

**Which issue is resolved by this Pull Request:** 
Resolves #575

**Description of your changes:**
Add default None value so calling without param is fine.  Code already understood None case.