### PR TITLE
Don't include deleted skills in lab commands

### DIFF
--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -470,7 +470,7 @@ def get_taxonomy_diff(repo="taxonomy", base="origin/main"):
     modified_files = [
         d.a_path
         for d in head_commit.diff(None)
-        if splitext(d.a_path)[1].lower() == ".yaml" and d.change_type != "D"
+        if splitext(d.a_path)[1].lower() == ".yaml" and not d.deleted_file
     ]
 
     updated_taxonomy_files = list(set(untracked_files + modified_files))


### PR DESCRIPTION
This excludes deleted files from the `lab list` and `lab generate` commands.

**Which issue is resolved by this Pull Request:** 
Resolves #587 

**Description of your changes:**
This ignores deleted files when diffing the taxonomy repo changes. Otherwise, `lab list` would list those deleted files and `lab generate` would try to use non-existent skill files.