### PR TITLE
ci: Add GitHub Action to begin auto-labeling Pull Requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,10 @@
+documentation:
+- CODE_OF_CONDUCT.md
+- README.md
+- TROUBLESHOOTING.md
+- CONTRIBUTING/**/*
+- docs/**/*
+
+testing:
+- tests/**/*
+- scripts/functional-tests.sh

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,13 @@
+name: labeler
+
+on:
+- pull_request_target
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #552 

**Description of your changes:**
This PR is designed to add rules that will auto-label PRs editing certain files defined in `labeler.yml`

Goal is to make it easier for maintainers to sort through Pull Requests, can be further enhanced/refined by adding new labels and files to the config

You can read more about this action here: https://github.com/actions/labeler