### PR TITLE
Reduces number of epochs in google colab from 10 to 5

### DIFF
--- a/notebooks/Training_a_LoRA_With_Instruct_Lab.ipynb
+++ b/notebooks/Training_a_LoRA_With_Instruct_Lab.ipynb
@@ -621,7 +621,7 @@
     "\n",
     "training_arguments = TrainingArguments(\n",
     "    output_dir=output_dir,\n",
-    "    num_train_epochs=5, # changing this from 10 to 5 to reduce the chance of Colab to kick out your session\n",
+    "    num_train_epochs=5,\n",
     "    per_device_train_batch_size=per_device_train_batch_size,\n",
     "    fp16=True,\n",
     "    report_to=\"none\"\n",


### PR DESCRIPTION
Reduces number of epochs in google colab from 10 to 5

This should train the model well enough, and reduce the chances of google colab to kick people out from the session

I've recreated a "cleaner" PR for https://github.com/instruct-lab/cli/pull/557 -- that got out of hand with branch syncs.