### PR TITLE
utils: Simplify MacOS + arm check

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -3,7 +3,7 @@ import copy
 import functools
 import os
 import platform
-import subprocess
+import sys
 
 # Third Party
 import click
@@ -33,18 +33,8 @@ def macos_requirement(echo_func, exit_exception):
 
 
 def is_macos_with_m_chip():
-    """Checks if the OS is MacOS"""
-    if platform.system() != "Darwin":
-        return False
-
-    # Check for Apple Silicon (M1, M2, etc.)
-    try:
-        # Running 'sysctl -a' and searching for a specific line that indicates ARM architecture
-        result = subprocess.check_output(["sysctl", "-a"], text=True)
-        is_m_chip = "machdep.cpu.brand_string: Apple" in result
-        return is_m_chip
-    except subprocess.SubprocessError:
-        return False
+    """Checks if the OS is MacOS with an ARM processor"""
+    return sys.platform == "darwin" and platform.machine() == "arm64"
 
 
 def expand_path(path):


### PR DESCRIPTION
I hit an issue where apparently the `venv` setup or something similar didn't include `/usr/sbin` in `$PATH`, so the `sysctl` invocation failed.

Looking at the code here, I think we can simplify things to basically just checking MacOS + arm, no need to execute external binaries and scrape their output.

Maybe in some distant future MacOS could run e.g. virtualized on ARM chips from other vendors (possibly with external GPUs?) but looking at it our use cases of this function are basically "is this MacOS+arm or Linux" so we'd need to change things more anyways.
