### PR TITLE
fix: gentle error handling on server crash during chat response

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -15,6 +15,7 @@ from rich.live import Live
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.text import Text
+import httpx
 import openai
 
 # Local
@@ -389,6 +390,10 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
             raise KeyboardInterrupt
         except KeyboardInterrupt as e:
             raise e
+        except httpx.RemoteProtocolError as e:
+            self.console.print("Connection to the server was closed", style="bold red")
+            self.info["messages"].pop()
+            raise ChatException("Connection to the server was closed") from e
         except:
             self.console.print("Unknown error", style="bold red")
             raise ChatException(f"Unknown error: {sys.exc_info()[0]}")
@@ -505,3 +510,5 @@ def chat_cli(
             continue
         except ChatException as exc:
             raise ChatException(f"API issue found while executing chat: {exc}")
+        except httpx.RemoteProtocolError:
+            raise ChatException(f"Connection to the server was closed")

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ trl>=0.7.11,<0.8.0
 # Linux: 4-bit quantization with BitsAndBytes is not ready to use, yet.
 # see https://github.com/instruct-lab/cli/issues/579
 # bitsandbytes; sys_platform=='linux' and platform_machine=='x86_64'
+httpx

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -110,6 +110,26 @@ EOF
 '
 }
 
+test_server_shutdown_while_chatting(){
+    # we don't want to fall into the trap function since the failure is expected
+    # so we force the command to return 0
+    timeout 10 lab serve || true &
+
+    # add the pid to the list of PID to kill in case something fails before the 5s timeout
+    PID_SERVE=$!
+
+    expect -c '
+        set timeout 30
+        spawn lab chat
+        expect ">>>"
+        send "hello!\r"
+        expect {
+            "Connection to the server was closed" { exit 0 }
+            timeout { exit 1 }
+        }
+    '
+}
+
 wait_for_pid_to_disappear(){
     for i in $(seq 1 20); do
         if ! test -d /proc/$1; then
@@ -194,5 +214,6 @@ cleanup
 test_loading_session_history
 cleanup
 test_generate
+test_server_shutdown_while_chatting
 
 exit 0


### PR DESCRIPTION
The chat was abruptly failing with the following stack trace if the chat is answering and the server crashes during that time:

```
lab chat

╭──────────────────────────────────────────────────────────────────── system ────────────────────────────────────────────────────────────────────╮
│ Welcome to Chat CLI w/ MERLINITE-7B-Q4_K_M (type /h for help)                                                                                  │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
>>>                                                                                                                                   [S][default]
>>> hello                                                                                                                             [S][default]
╭───────────────────────────────────────────────────────────── merlinite-7b-Q4_K_M ──────────────────────────────────────────────────────────────╮
│ Hello! I'm here to                                                                                                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 1.031 seconds ─╯
Traceback (most recent call last):
  File "/home/leseb/cli/test_run_2Fv9yrYE/venv/lib64/python3.10/site-packages/httpx/_transports/default.py", line 69, in map_httpcore_exceptions
    yield
  File "/home/leseb/cli/test_run_2Fv9yrYE/venv/lib64/python3.10/site-packages/httpx/_transports/default.py", line 113, in __iter__
    for part in self._httpcore_stream:
  File "/home/leseb/cli/test_run_2Fv9yrYE/venv/lib64/python3.10/site-packages/httpcore/_sync/connection_pool.py", line 367, in __iter__
    raise exc from None
  File "/home/leseb/cli/test_run_2Fv9yrYE/venv/lib64/python3.10/site-packages/httpcore/_sync/connection_pool.py", line 363, in __iter__
    for part in self._stream:
  File "/home/leseb/cli/test_run_2Fv9yrYE/venv/lib64/python3.10/site-packages/httpcore/_sync/http11.py", line 349, in __iter__
    raise exc
  File "/home/leseb/cli/test_run_2Fv9yrYE/venv/lib64/python3.10/site-packages/httpcore/_sync/http11.py", line 341, in __iter__
    for chunk in self._connection._receive_response_body(**kwargs):
  File "/home/leseb/cli/test_run_2Fv9yrYE/venv/lib64/python3.10/site-packages/httpcore/_sync/http11.py", line 210, in _receive_response_body
    event = self._receive_event(timeout=timeout)
  File "/home/leseb/cli/test_run_2Fv9yrYE/venv/lib64/python3.10/site-packages/httpcore/_sync/http11.py", line 220, in _receive_event
    with map_exceptions({h11.RemoteProtocolError: RemoteProtocolError}):
  File "/usr/lib64/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/home/leseb/cli/test_run_2Fv9yrYE/venv/lib64/python3.10/site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
    raise to_exc(exc) from exc
httpcore.RemoteProtocolError: peer closed connection without sending complete message body (incomplete chunked read)
```

Now we handle this more elagantly and print before exiting:

```
lab chat
╭──────────────────────────────────────────────────────────────────── system ────────────────────────────────────────────────────────────────────╮
│ Welcome to Chat CLI w/ MERLINITE-7B-Q4_K_M (type /h for help)                                                                                  │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
>>> hello                                                                                                                             [S][default]
Connection to the server was closed
Executing chat failed with: API issue found while executing chat: Connection to the server was closed
```

DO NOT MERGE - DEPENDS ON: https://github.com/instruct-lab/cli/pull/613
