### PR TITLE
feat: enhanced `lab check` to make local linting easier

### DIFF
--- a/cli/config.py
+++ b/cli/config.py
@@ -20,6 +20,7 @@ DEFAULT_PROMPT_FILE = "prompt.txt"
 DEFAULT_SEED_FILE = "seed_tasks.json"
 DEFAULT_GENERATED_FILES_OUTPUT_DIR = "generated"
 DEFAULT_GREEDY_MODE = False
+DEFAULT_YAML_RULES = "yaml_rules.yaml"
 
 
 class ConfigException(Exception):

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ trl>=0.7.11,<0.8.0
 # see https://github.com/instruct-lab/cli/issues/579
 # bitsandbytes; sys_platform=='linux' and platform_machine=='x86_64'
 httpx
+yamllint

--- a/tests/taxonomy.py
+++ b/tests/taxonomy.py
@@ -1,6 +1,6 @@
 # Standard
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 import shutil
 
 # Third Party
@@ -23,16 +23,20 @@ class MockTaxonomy:
         """List untracked files in the repository"""
         return self._repo.untracked_files
 
-    def create_untracked(self, rel_path: str) -> None:
+    def create_untracked(self, rel_path: str, contents: Optional[bytes] = None) -> None:
         """Create a new untracked file in the repository.
 
         Args:
-            rel_path (str): Relative path (from repository root) to the file.
+            rel_path (str):   Relative path (from repository root) to the file.
+            contents (bytes): (optional) Byte string to be written to the file.
         """
         assert not Path(rel_path).is_absolute()
         file_path = Path(self.root / rel_path)
         file_path.parent.mkdir(exist_ok=True, parents=True)
-        file_path.write_text("new taxonomy", encoding="utf-8")
+        if not contents:
+            file_path.write_text("new taxonomy", encoding="utf-8")
+        else:
+            file_path.write_bytes(contents)
 
     def add_tracked(self, rel_path: str) -> None:
         """Add a new tracked file to the repository (and commits it).

--- a/tests/test_lab_check.py
+++ b/tests/test_lab_check.py
@@ -1,0 +1,100 @@
+# Standard
+from pathlib import Path
+import unittest
+
+# Third Party
+from click.testing import CliRunner
+import pytest
+
+# First Party
+from cli import lab
+
+TAXONOMY_BASE = "main"
+TEST_VALID_YAML = b"""created_by: nathan-weinberg
+seed_examples:
+- answer: "Yes I can!"
+  context: "This unit test is valid!"
+  question: "Could you write a unit test?"
+task_description: ''
+"""
+TEST_INVALID_YAML = b"""created_by: nathan-weinberg
+seed_examples:
+- answer: "Yes I can!"
+  context: "This unit test has a line with 124 characters! It is too long for the default rules but not too long for the customer rules!"
+  question: "Could you write a unit test?"
+task_description: ''
+"""
+TEST_CUSTOM_YAML_RULES = b"""extends: relaxed
+
+rules:
+  line-length:
+    max: 180
+"""
+
+
+class TestLabCheck(unittest.TestCase):
+    """Test collection for `lab check` command."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @pytest.fixture(autouse=True)
+    def _init_taxonomy(self, taxonomy_dir):
+        self.taxonomy = taxonomy_dir
+
+    def test_check_valid_yaml(self):
+        valid_yaml_file = "compositional_skills/qna_valid.yaml"
+        self.taxonomy.create_untracked(valid_yaml_file, TEST_VALID_YAML)
+        runner = CliRunner()
+        result = runner.invoke(
+            lab.check,
+            [
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        self.assertIn(f"Taxonomy in {self.taxonomy.root} is valid :)", result.output)
+        self.assertEqual(result.exit_code, 0)
+
+    def test_check_invalid_yaml(self):
+        invalid_yaml_file = "compositional_skills/qna_invalid.yaml"
+        self.taxonomy.create_untracked(invalid_yaml_file, TEST_INVALID_YAML)
+        runner = CliRunner()
+        result = runner.invoke(
+            lab.check,
+            [
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        self.assertIn(
+            "1 taxonomy files with errors!",
+            result.output,
+        )
+        self.assertEqual(result.exit_code, 1)
+
+    def test_check_custom_yaml(self):
+        custom_rules_file = Path("custom_rules.yaml")
+        custom_rules_file.write_bytes(TEST_CUSTOM_YAML_RULES)
+        invalid_yaml_file = "compositional_skills/qna_invalid.yaml"
+        self.taxonomy.create_untracked(invalid_yaml_file, TEST_INVALID_YAML)
+        runner = CliRunner()
+        result = runner.invoke(
+            lab.check,
+            [
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+                "--yaml-rules",
+                custom_rules_file,
+            ],
+        )
+        # custom yaml rules mean "invalid" yaml file should pass
+        self.assertIn(f"Taxonomy in {self.taxonomy.root} is valid :)", result.output)
+        self.assertEqual(result.exit_code, 0)
+        Path.unlink(custom_rules_file)


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #515

**Description of your changes:**
*edited from original: for context originally created `lab lint` command that linted CLI Python code via tox*
- Adds yaml linting to `lab check'
- Adds tests for `lab check'
- `create-untracked()` func can now write byte strings
 
Also fixes incorrect version pin for Labeler action
