### PR TITLE
allow for setting verbosity level in 'lab download'

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -12,6 +12,7 @@ import sys
 from click_didyoumean import DYMGroup
 from git import GitError, Repo
 from huggingface_hub import hf_hub_download
+from huggingface_hub import logging as hf_logging
 import click
 
 # Local
@@ -507,6 +508,9 @@ def download(ctx, repository, release, filename, model_dir):
     """Download the model(s) to train"""
     click.echo(f"Downloading model from {repository}@{release} to {model_dir}...")
     try:
+        if ctx.obj is not None:
+            hf_logging.set_verbosity(ctx.obj.config.general.log_level.upper())
+
         hf_hub_download(
             repo_id=repository,
             revision=release,


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #https://github.com/instruct-lab/cli/issues/492

**Description of your changes:**
Allow the user to configure the verbosity level
for the 'lab download' command.  It can accept
the following levels:

- debug
- info
- warning
- error

and defaults to warning.