### PR TITLE
Show default values in help for all Click options that set them (where applicable)

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -483,13 +483,13 @@ def chat(ctx, question, model, context, session, quick_question, greedy_mode):
 @cli.command()
 @click.option(
     "--repository",
-    default="ibm/merlinite-7b-GGUF", # TODO: add to config.yaml
+    default="ibm/merlinite-7b-GGUF",  # TODO: add to config.yaml
     show_default=True,
     help="Hugging Face repository of the model to download.",
 )
 @click.option(
     "--release",
-    default="main", # TODO: add to config.yaml
+    default="main",  # TODO: add to config.yaml
     show_default=True,
     help="The git revision of the model to download - e.g. a branch, tag, or commit hash.",
 )
@@ -529,7 +529,7 @@ def download(ctx, repository, release, filename, model_dir):
 @click.option(
     "--input-dir",
     type=click.Path(),
-    show_default=True, # TODO: set to None and change help message
+    show_default=True,  # TODO: set to None and change help message
     help="Path to generated files to use as input",
 )
 @click.option(
@@ -769,7 +769,8 @@ def train(
     default="ibm-merlinite-7b-mlx-q",
     show_default=True,
 )
-@click.option("--adapter-file",
+@click.option(
+    "--adapter-file",
     help="LoRA adapter to use for test.",
     default=None,
     show_default=True,


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #https://github.com/instruct-lab/cli/issues/627

**Description of your changes:**

Add the `show_default=True` setting to all applicable `click.option()` decorators.

**Note**: we intentionally still do NOT show the API service's API key and commented as such to future contributors.
