### PR TITLE
De-duplicate prompt templates

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -349,11 +349,6 @@ def serve(ctx, model_path, gpu_layers, num_threads, max_ctx_size):
     help="Suppress output of synthesized instructions.",
 )
 @click.option(
-    "--has-document",
-    is_flag=True,
-    help="Whether or not the examples contain the document field.",
-)
-@click.option(
     "--endpoint-url",
     type=click.STRING,
     help="Custom URL endpoint for OpenAI-compatible API. Defaults to the `lab serve` endpoint.",
@@ -376,7 +371,6 @@ def generate(
     seed_file,
     rouge_threshold,
     quiet,
-    has_document,
     endpoint_url,
     api_key,
 ):
@@ -409,7 +403,6 @@ def generate(
             seed_tasks_path=seed_file,
             rouge_threshold=rouge_threshold,
             console_output=not quiet,
-            has_document=has_document,
         )
     except GenerateException as exc:
         click.secho(


### PR DESCRIPTION
De-duplicate prompt templates
    
Use a single jinja template for the prompts with and
without a document. Also remove the conditionals
checking for te presence of a document.
    
Fixes #629

Also includes a typo fix from 
https://github.com/instruct-lab/cli/pull/569