### PR TITLE
Automate container builds with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,97 @@
+BUILD_ARGS =
+CONTAINER_PREFIX ?= localhost/instructlab
+TOOLBOX ?= instructlab
+
+NULL =
+COMMON_DEPS = \
+	$(CURDIR)/requirements.txt \
+	$(NULL)
+
+CUDA_CONTAINERFILE = $(CURDIR)/containers/cuda/Containerfile
+CUDA_DEPS = \
+	$(CUDA_CONTAINERFILE) \
+	$(COMMON_DEPS) \
+	$(NULL)
+
+ROCM_CONTAINERFILE = containers/rocm/Containerfile
+ROCM_DEPS = \
+	$(ROCM_CONTAINERFILE) \
+	$(COMMON_DEPS) \
+	containers/rocm/remove-gfx.sh \
+	$(NULL)
+
+# so users can do "make rocm-gfx1100 rocm-toolbox"
+.NOTPARALLEL:
+
+.PHONY: all
+all: help
+
+.PHONY: help
+help: ## Print help
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  make %-16s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+.PHONY: cuda
+cuda: $(CUDA_DEPS)  ## Build container for NVidia CUDA
+	podman build $(BUILD_ARGS) \
+		-t $(CONTAINER_PREFIX):$@ \
+		-f $(CUDA_CONTAINERFILE) \
+		.
+
+define podman-build-rocm =
+	@echo "Building ROCm container for GPU arch '$(1)', version '$(2)'"
+	podman build $(BUILD_ARGS) \
+		--build-arg AMDGPU_ARCH=$(1) \
+		--build-arg HSA_OVERRIDE_GFX_VERSION=$(2) \
+		-t $(CONTAINER_PREFIX):rocm-$(1) \
+		-t $(CONTAINER_PREFIX):rocm \
+		-f $(ROCM_CONTAINERFILE) \
+		.
+endef
+
+.PHONY: rocm
+rocm:   ## Build container for AMD ROCm (auto-detect GPU arch)
+	@# amdgpu-arch requires clang-tools-extra and rocm-hip-devel to work
+	@# rocminfo parsing is more messy, but requires less dependencies.
+	@arch=$(shell rocminfo | grep -o -m1 'gfx[1-9][0-9a-f]*'); \
+	    if test -z $$arch; then echo "Unable to detect AMD GPU arch"; exit 2; fi; \
+	    echo "Auto-detected GPU arch '$$arch'"; \
+	    $(MAKE) --silent rocm-$(AMDGPU_ARCH)
+
+# RDNA3 / Radeon RX 7000 series
+.PHONY: rocm-gf1100 rocm-rdna3 rocm-gfx1101 rocm-gfx1102
+rocm-rdna3 rocm-gfx1101 rocm-gfx1102: rocm-gfx1100
+
+rocm-gfx1100: $(ROCM_DEPS)  ## Build container for AMD ROCm RDNA3 (Radeon RX 7000 series)
+	$(call podman-build-rocm,gfx1100,11.0.0)
+
+# RDNA2 / Radeon RX 6000 series
+.PHONY: rocm-gfx1030 rocm-rdna2 rocm-gfx1031
+rocm-rdna2 rocm-gfx1031: rocm-gfx1030
+
+rocm-gfx1030: $(ROCM_DEPS)  ## Build container for AMD ROCm RDNA2 (Radeon RX 6000 series)
+	$(call podman-build-rocm,gfx1030,10.3.0)
+
+# untested older cards
+.PHONY: rocm-gfx90a
+rocm-gfx90a: $(ROCM_DEPS)  ## Build container for AMD ROCm gfx90a (untested)
+	$(call podman-build-rocm,gfx90a,9.0.10)
+
+.PHONY: rocm-gfx908
+rocm-gfx908: $(ROCM_DEPS)  ## Build container for AMD ROCm gfx908 (untested)
+	$(call podman-build-rocm,gfx908,9.0.8)
+
+.PHONY: rocm-gfx906
+rocm-gfx906: $(ROCM_DEPS)  ## Build container for AMD ROCm gfx906 (untested)
+	$(call podman-build-rocm,gfx906,9.0.6)
+
+.PHONY: rocm-gfx900
+rocm-gfx900: $(ROCM_DEPS)  ## Build container for AMD ROCm gfx900 (untested)
+	$(call podman-build-rocm,gfx900,9.0.0)
+
+.PHONY: rocm-toolbox
+toolbox-rocm:  ## Create AMD ROCm toolbox from container
+	toolbox create --image $(CONTAINER_PREFIX):rocm $(TOOLBOX)
+
+.PHONY: toolbox-rm
+toolbox-rm:  ## Stop and remove toolbox container
+	toolbox rm -f $(TOOLBOX)

--- a/containers/rocm/Containerfile
+++ b/containers/rocm/Containerfile
@@ -92,6 +92,7 @@ FROM runtime as final
 COPY --from=pip-install /opt/rocm-venv/lib/python3.12/site-packages /opt/rocm-venv/lib/python3.12/site-packages
 COPY --from=pip-install /opt/rocm-venv/bin /opt/rocm-venv/bin
 LABEL com.github.containers.toolbox="true" \
+      com.github.instruct-lab.cli.gpu="rocm-${AMDGPU_ARCH}" \
       name="instructlab-rocm-base-gfx${GFX_VERSION}" \
       usage="This image is meant to be used with the toolbox(1) command" \
       summary="PyTorch, llama.cpp, and instruct-lab dependencies for AMD ROCm GPU ${AMDGPU_ARCH}" \

--- a/containers/rocm/README.md
+++ b/containers/rocm/README.md
@@ -11,9 +11,9 @@ The container has all Python dependencies installed in a virtual env. The virtua
 1. git clone the `cli` and `taxonomy` project into a common folder in your
    home directory (e.g. `~/path/to/instruct-lab`)
 2. add your account to `render` and `video` group: `sudo usermod -a -G render,video $LOGNAME`
-3. install build dependency for this container: `sudo dnf install toolbox podman make`
-4. build the container for RDNA3: `podman build -t localhost/instructlab:rocm-gf1100 -f container/rocm/Containerfile .`
-5. create a toolbox `toolbox create --image localhost/instructlab:rocm-gf1100 instructlab`
+3. install build dependency for this container: `sudo dnf install toolbox podman make rocminfo`
+4. build the container: `make rocm`
+5. create a toolbox `make rocm-toolbox`
 6. enter toolbox `toolbox enter instructlab`. The container has your
    home directory mounted.
 7. install lab cli with `pip install -e ~/path/to/instruct-lab/cli/`
@@ -66,15 +66,6 @@ Build the container with additional build arguments:
 podman build \
     --build-arg AMDGPU_ARCH="gfx1030" \
     --build-arg HSA_OVERRIDE_GFX_VERSION="10.3.0" \
-    -f container/rocm/Containerfile \
-    -t localhost/instructlab:rocm-gf1030
-```
-
-or use pre-defined build arguments from a config file:
-
-```shell
-podman build \
-    --build-args-file container/rocm/gfx1030.conf
     -f container/rocm/Containerfile \
     -t localhost/instructlab:rocm-gf1030
 ```

--- a/containers/rocm/gfx1030.conf
+++ b/containers/rocm/gfx1030.conf
@@ -1,3 +1,0 @@
-# build arguments for AMD Radeon RX 6000 series
-AMDGPU_ARCH=gfx1030
-HSA_OVERRIDE_GFX_VERSION=10.3.0


### PR DESCRIPTION
**Description of your changes:**
The `Makefile` automates building of container and toolbox for CUDA and ROCm.

```
$ make
  make help              Print help
  make cuda              Build container for NVidia CUDA
  make rocm              Build container for AMD ROCm (auto-detect GPU arch)
  make rocm-gfx1100      Build container for AMD ROCm RDNA3 (Radeon RX 7000 series)
  make rocm-gfx1030      Build container for AMD ROCm RDNA2 (Radeon RX 6000 series)
  make rocm-gfx90a       Build container for AMD ROCm gfx90a (untested)
  make rocm-gfx908       Build container for AMD ROCm gfx908 (untested)
  make rocm-gfx906       Build container for AMD ROCm gfx906 (untested)
  make rocm-gfx900       Build container for AMD ROCm gfx900 (untested)
  make rocm-toolbox      Create AMD ROCm toolbox from container
  make toolbox-rm        Stop and remove toolbox container
```

See: #623