### PR TITLE
pre-commit: implement pyspelling for pre commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,9 @@ repos:
       hooks:
           - id: isort
             exclude: imports
+    - repo: https://github.com/schuellerf/pre-commit-pyspelling
+      rev: 0.1.0
+      hooks:
+          - id: pyspelling
+            args: ["--config", ".spellcheck.yml"]
+


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Avoid round trip by seeing spellchecker only in github actions

**Description of your changes:**
Implemented pyspelling plugin and integration
