### PR TITLE
Fix bug in make_data() train-test split

### DIFF
--- a/cli/train/lora-mlx/make_data.py
+++ b/cli/train/lora-mlx/make_data.py
@@ -42,7 +42,7 @@ def make_data(data_dir, is_shiv):
 
             # Save the modified objects back to the JSON Lines file
             if "train_gen" in fn:
-                n = len(data_new) // 10 * 8
+                n = len(data_new) * 8 // 10
                 with open(f"{data_dir}/train.jsonl", "w") as f:
                     for obj in data_new[:n]:
                         f.write(json.dumps(obj) + "\n")


### PR DESCRIPTION
Swapped order of division and multiplication to calculate 80% training data.

Previously, the line `n = len(data_new) // 10 * 8` would evaluate to 0 whenever you provide `lab generate` with `--num-instructions` < 10, so `train.jsonl` ends up empty. Now, as long as we have 2 instructions, at least 1 should be populated in each `train.jsonl` and `valid.jsonl`.