### PR TITLE
Add note that the tool can also be used on Intel MACs for chatting …

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ The full process is described graphically in the [workflow diagram](./docs/workf
 ## 📋 Requirements
 
 - **🍎 Apple M1/M2/M3 Mac or 🐧 Linux system** (tested on Fedora). We anticipate support for more operating systems in the future.
+  **NOTE:** This CLI tool can also be used on x86 (Intel/ AMD) based Macs for interacting with a pre-trained LLM. However, it would not be efficient to also train a model on these systems if they lack a GPU or equivalent AI acceleration hardware. 
 - C++ compiler
 - Python 3.9+
 - Approximately 60GB disk space (entire process)
+- Note: This cli tool can also be used on x86 (Intel/ AMD) based Macs for interacting (i.e. chatting)  with a pre-trained LLM. However it would not usually be efficient to also train a model on these systems if they lack a GPU or equivalent AI acceleration hardware. 
 
 On Fedora Linux this means installing:
 ```shell


### PR DESCRIPTION
… only with an existing pre-trained LLM. Since I (and others) have used the tool for this on Intel MACs, we know it works on those machines as well.

**Description of your changes:**
Added a text note that the tool can also be used on Intel/ x86 based MACs for chatting/ interacting with a pre-trained LLM but these machines wouldnt be efficient for also training models with new datasets unless they had support for GPUs or equivalent AI acceleration hardware
