### PR TITLE
Test for missing mlx on Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,9 +61,10 @@ jobs:
         id: cache
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
+          # v2: previous restore key did not depend on requirements.txt and contained 'mlx'
+          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-v2-${{ hashFiles('requirements-dev.txt') }}
           restore-keys:
-            ${{ env.pythonLocation }}-
+            ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-v2-
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -4,9 +4,11 @@ import unittest
 
 # Third Party
 import click
+import pytest
 
 # First Party
 from cli import lab
+from cli.utils import is_macos_with_m_chip
 
 
 class TestConfig(unittest.TestCase):
@@ -23,3 +25,13 @@ class TestConfig(unittest.TestCase):
         self.assertFalse(
             invalid_flags, "<- these commands are using non-hyphenated params"
         )
+
+
+def test_import_mlx():
+    # smoke test to verify that mlx is always available on Apple Silicon
+    # but never on Linux and Intel macOS.
+    if is_macos_with_m_chip():
+        assert __import__("mlx")
+    else:
+        with pytest.raises(ModuleNotFoundError):
+            __import__("mlx")

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist = fmt, lint, unit, functional
 
 [testenv]
-# use CPU build of Torch in testenvs. CUDA bindings are huge.
+# Use PyTorch CPU build instead of CUDA build in test envs. CUDA dependencies
+# are huge. This reduces venv from 5.7 GB to 1.5 GB.
 setenv =
     PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
See #673

**Description of your changes:**
Add a test case to check that `mlx` is only installed on ARM64 macOS.

Change GHA cache restore key to take `requirements.txt` into account. Otherwise it restores caches from a previous `requirements.txt` and stores them under the new cache key. That's how we ended up with `mlx` on Linux, although we dropped the dependency a while ago.

Tests are now using CPU builds of Torch instead of the default CUDA builds. This reduces the size of tox's virtual environment from 5.7 GB to 1.5 GB.