### PR TITLE
Set initial_branch for consistency between git versions

### DIFF
--- a/tests/taxonomy.py
+++ b/tests/taxonomy.py
@@ -12,7 +12,7 @@ class MockTaxonomy:
 
     def __init__(self, path: Path) -> None:
         self.root = path
-        self._repo = git.Repo.init(path)
+        self._repo = git.Repo.init(path, initial_branch="main")
         with open(path / self.INIT_COMMIT_FILE, "wb"):
             pass
         self._repo.index.add([self.INIT_COMMIT_FILE])

--- a/tests/test_lab_list.py
+++ b/tests/test_lab_list.py
@@ -8,7 +8,7 @@ import pytest
 # First Party
 from cli import lab
 
-TAXONOMY_BASE = "master"
+TAXONOMY_BASE = "main"
 
 
 class TestLabList(unittest.TestCase):
@@ -74,12 +74,12 @@ class TestLabList(unittest.TestCase):
                 ],
             )
             self.assertListEqual(self.taxonomy.untracked_files, [untracked_file])
-            # Invalid extension is silently filtered out.
+            # Invalid extension is silently filtered out
             self.assertNotIn(untracked_file, result.output)
             self.assertEqual(result.exit_code, 0)
 
     def test_list_invalid_base(self):
-        taxonomy_base = "main"
+        taxonomy_base = "invalid"
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #694

**Description of your changes:**

Sets an initial branch to avoid any issues with changes in git client default and changes the invalid test to a name more obvious what it's testing for.