### PR TITLE
Adds more stop-tokens to chat formatter

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -611,6 +611,7 @@ def download(ctx, repository, release, filename, model_dir):
             filename=filename,
             local_dir=model_dir,
         )
+        click.echo("==> Model ready!")
     except Exception as exc:
         click.secho(
             f"Downloading model failed with the following Hugging Face Hub error: {exc}",


### PR DESCRIPTION
Resolves #452

May fix #159, #137 

Adds more stop-tokens to `ChatFormatter` object:
`[<|endoftext|>, <|system|>, <|user|>, <|assistant|>]`
