### PR TITLE
(dep) fix transformer dep issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ wandb>=0.16.4,<0.17.0
 GitPython>=3.1.42,<4.0.0
 gguf>=0.6.0,<0.7.0
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-transformers>=4.38.2,<5.0.0
+transformers>=4.30.0,<=4.38.2
 numpy>=1.26.4,<2.0.0
 torch>=2.2.1,<3.0.0
 peft>=0.9.0,<0.10.0


### PR DESCRIPTION
[This error](https://github.com/instruct-lab/cli/pull/631/files#r1534956997)* is happening because of [this](https://github.com/huggingface/trl/issues/6). Applying the suggestion of [using transformersv4.38.2](https://github.com/huggingface/trl/issues/6#issuecomment-1986874351)

*Error: 

> trl>=0.7.11,<0.8.0
```
This version is causing an issue on my mac:

When it hits this line in linux_train:

from trl import DataCollatorForCompletionOnlyLM, SFTTrainer

It breaks with:

Traceback (most recent call last):
File "/Users/dmcphers/Code/cli/cli/train/linux_train.py", line 18, in
from trl import DataCollatorForCompletionOnlyLM, SFTTrainer
File "/Users/dmcphers/Code/cli/.tox/unit/lib/python3.12/site-packages/trl/init.py", line 5, in
from .core import set_seed
File "/Users/dmcphers/Code/cli/.tox/unit/lib/python3.12/site-packages/trl/core.py", line 25, in
from transformers import top_k_top_p_filtering
ImportError: cannot import name 'top_k_top_p_filtering' from 'transformers' (/Users/dmcphers/Code/cli/.tox/unit/lib/python3.12/site-packages/transformers/init.py)

It doesn't give the error with version 0.8.1


```
**Which issue is resolved by this Pull Request:** 
Resolves #

**Description of your changes:**
