### PR TITLE
Bump "lab generate" timeout up to 10m

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -199,7 +199,7 @@ EOF
     sed -i -e 's/num_instructions:.*/num_instructions: 1/g' config.yaml
 
     # This should be finished in a minut or so but time it out incase it goes wrong
-    timeout 5m lab generate --taxonomy-path simple_math.yaml
+    timeout 10m lab generate --taxonomy-path simple_math.yaml
 
     # Test if generated was created and contains files
     ls -l generated/*


### PR DESCRIPTION
We seem to be hitting the 5m timeout to much.

Fixes #722
