### PR TITLE
ci: Update labeler.yml with v5 schema

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,10 +1,14 @@
 documentation:
-- CODE_OF_CONDUCT.md
-- README.md
-- TROUBLESHOOTING.md
-- CONTRIBUTING/**/*
-- docs/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - CODE_OF_CONDUCT.md
+      - README.md
+      - TROUBLESHOOTING.md
+      - CONTRIBUTING/**/*
+      - docs/**/*
 
 testing:
-- tests/**/*
-- scripts/functional-tests.sh
+  - changed-files:
+    - any-glob-to-any-file:
+      - tests/**/*
+      - scripts/functional-tests.sh


### PR DESCRIPTION
**Description of your changes:**
Followup of https://github.com/instruct-lab/cli/pull/591

The initial labeler PR implemented v5 of the action but used the v4 matching schema, this PR fixes that