### PR TITLE
feat: add '--version' flag to CLI

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -67,6 +67,7 @@ def configure(ctx, param, filename):
     is_eager=True,
     help="Path to a configuration file.",
 )
+@click.version_option(package_name="cli")
 @click.pass_context
 # pylint: disable=redefined-outer-name
 def cli(ctx, config):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ Issues = "https://github.com/instruct-lab/cli/issues"
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
+version = {attr = "cli.__version__"}
 
 [project.scripts]
 # defines lab executable


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:** 
Resolves #268 

**Description of your changes:**
Adds `--version` flag using the built-in `click` method: https://click.palletsprojects.com/en/8.1.x/api/#click.version_option

Example output:
```bash
(venv) [nathan@nathan-redhat instruct-lab]$ lab --version
lab, version 0.0.1
```