### PR TITLE
Replace Black with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,14 @@
 repos:
-    - repo: https://github.com/psf/black
-      rev: 22.3.0
-      hooks:
-          - id: black
-            exclude: imports
     - repo: https://github.com/PyCQA/isort
       rev: 5.11.5
       hooks:
           - id: isort
             exclude: imports
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      # Ruff version.
+      rev: v0.3.4
+      hooks:
+        # Run the linter (most fixers are disabled for now).
+        - id: ruff
+        # Run the formatter.
+        - id: ruff-format

--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -121,7 +121,12 @@ def encode_prompt(prompt_instructions, prompt):
 
     # pylint: disable=unused-variable
     for idx, task_dict in enumerate(prompt_instructions):
-        (instruction, prompt_input, prompt_output, taxonomy_path,) = (
+        (
+            instruction,
+            prompt_input,
+            prompt_output,
+            taxonomy_path,
+        ) = (
             task_dict["instruction"],
             task_dict["input"],
             task_dict["output"],

--- a/cli/llamacpp/llamacpp_convert_to_gguf.py
+++ b/cli/llamacpp/llamacpp_convert_to_gguf.py
@@ -578,10 +578,14 @@ class HfVocab:
             token_text = reverse_vocab[token_id].encode("utf-8")
 
             # Yield token text, score, and type
-            yield token_text, self.get_token_score(token_id), self.get_token_type(
-                token_id,
+            yield (
                 token_text,
-                self.special_ids,  # Reuse already stored special IDs
+                self.get_token_score(token_id),
+                self.get_token_type(
+                    token_id,
+                    token_text,
+                    self.special_ids,  # Reuse already stored special IDs
+                ),
             )
 
     def get_token_type(
@@ -649,26 +653,21 @@ class Tensor(metaclass=ABCMeta):
     data_type: DataType
 
     @abstractmethod
-    def astype(self, data_type: DataType) -> Tensor:
-        ...
+    def astype(self, data_type: DataType) -> Tensor: ...
 
     @abstractmethod
-    def permute(self, n_head: int, n_head_kv: int) -> Tensor:
-        ...
+    def permute(self, n_head: int, n_head_kv: int) -> Tensor: ...
 
     @abstractmethod
     def permute_part(
         self, n_part: int, n_head: int, n_head_kv: int
-    ) -> UnquantizedTensor:
-        ...
+    ) -> UnquantizedTensor: ...
 
     @abstractmethod
-    def part(self, n_part: int) -> UnquantizedTensor:
-        ...
+    def part(self, n_part: int) -> UnquantizedTensor: ...
 
     @abstractmethod
-    def to_ggml(self) -> GGMLCompatibleTensor:
-        ...
+    def to_ggml(self) -> GGMLCompatibleTensor: ...
 
 
 def bf16_to_fp32(bf16_arr: np.ndarray[Any, np.dtype[np.uint16]]) -> NDArray:

--- a/cli/train/lora_mlx/make_data.py
+++ b/cli/train/lora_mlx/make_data.py
@@ -20,7 +20,6 @@ def make_data(data_dir: str, is_shiv: bool = False):
         # This branch uses data from `lab generate`
         # train_gen.jsonl and test_gen.jsonl are the two files produced by `lab generate`
         for fn in [f"{data_dir}/train_gen.jsonl", f"{data_dir}/test_gen.jsonl"]:
-
             # Load the JSON Lines file
             with open(fn, "r") as f:
                 data = [json.loads(line) for line in f]

--- a/cli/train/lora_mlx/prepare_model.py
+++ b/cli/train/lora_mlx/prepare_model.py
@@ -8,8 +8,9 @@ import torch
 
 
 def convert_bin_to_safetensors(input_dir, output_dir):
-    input_dir, output_dir = os.path.expanduser(input_dir), os.path.expanduser(
-        output_dir
+    input_dir, output_dir = (
+        os.path.expanduser(input_dir),
+        os.path.expanduser(output_dir),
     )
 
     model_path = os.path.expanduser(input_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,40 @@ include = ["cli", "cli.chat", "cli.generator", "cli.train", "cli.train.lora_mlx"
 
 [tool.setuptools.package-data]
 "*" = ["quantize"]
+
+[tool.ruff]
+target-version = "py39"
+# same as black's default line length
+line-length = 88
+
+[tool.ruff.lint]
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Fixers will be enabled gradually.
+select = [
+    # "B",  # flake8-bugbear
+    # "E",  # pycodestyle
+    # "F",  # Pyflakes
+    "Q",  # flake8-quotes
+    # Ruff does not support isort's import_headings feature, yet.
+    # "I",  # isort
+    # "UP",  # pyupgrade
+    # "SIM",  # flake8-simplify
+]
+ignore = [
+    # some embedded strings are longer than 88 characters
+    "E501",  # line too long
+]
+
+[tool.ruff.lint.isort]
+# same as .isort.cfg
+from-first = true
+# not supported yet
+# import-heading-future=Future
+# import-heading-stdlib=Standard
+# import-heading-thirdparty=Third Party
+# import-heading-firstparty=First Party
+# import-heading-localfolder=Local
+known-local-folder = ["tuning"]

--- a/tox.ini
+++ b/tox.ini
@@ -36,3 +36,16 @@ allowlist_externals = ./scripts/fmt.sh
 description = run functional tests
 commands = ./scripts/functional-tests.sh
 allowlist_externals = ./scripts/functional-tests.sh
+
+[testenv:ruff]
+description = Reformat and fix code with Ruff (and isort)
+skip_install = True
+# keep in sync with .pre-commit-config.yaml
+deps =
+    ruff==0.3.4
+    isort==5.11.5
+commands =
+    ruff format .
+    ruff check --fix .
+    # Ruff does not support import headings, yet
+    isort .


### PR DESCRIPTION
**Description of your changes:**

Ruff is an extremely fast Python linter and code formatter, written in Rust. It is a fantastic tool that combines the features of flake8 linter, isort, Black code formatter, and (to some degree) pylint in one tool. It comes with over 800 linting rules. Ruff is not only blazing fast, it can also fix most code violation. The code fixer is a fantastic quality of life feature for developers.

Gradually introduce Ruff for linting and code formatting. Replaces Black as code formatting tool. Ruff is configured to create the same results as Black's default configuration.

Linters will be enabled in future commits.

Co-authored-by: @thrix 

**Which issue is resolved by this Pull Request:** 
See #739


