### PR TITLE
Advice against running "generate" and "chat" in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,11 @@ lab generate --endpoint-url http://localhost:8000/v1
 
 There are three options to train the model on your synthetic data-enhanced dataset.
 
-> **Note:** **Every** `lab` command needs to be run from within your Python virtual environment.
+> [!NOTE]
+> **Every** `lab` command needs to be run from within your Python virtual environment.
+
+> [!IMPORTANT]
+> Do not use `lab train` and `lab chat` in parallel for the same model, it could cause the model to crash.
 
 #### Train the model locally on Linux
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The next step is to generate a synthetic dataset based on your newly added knowl
 
 > **NOTE:** ⏳ This can take from 15 minutes to 1+ hours to complete, depending on your computing resources.
 
-> **IMPORTANT:** Do not use `lab generate` and `lab chat` in parallel, it could cause the model to crash ([#346](https://github.com/instruct-lab/cli/issues/346)).
+> **IMPORTANT:** Do not use `lab generate` and `lab chat` in parallel for the same model, it could cause the model to crash.
 
 ```
 (venv) $ lab generate

--- a/README.md
+++ b/README.md
@@ -224,7 +224,11 @@ INFO 2024-03-15 11:33:23,973 generate_data.py:566 * compositional_skills/writing
 lab generate
 ```
 
-The next step is to generate a synthetic dataset based on your newly added knowledge or skill set in the [taxonomy](https://github.com/instruct-lab/taxonomy.git) repository:
+The next step is to generate a synthetic dataset based on your newly added knowledge or skill set in the [taxonomy](https://github.com/instruct-lab/taxonomy.git) repository.
+
+> **NOTE:** ⏳ This can take from 15 minutes to 1+ hours to complete, depending on your computing resources.
+
+> **IMPORTANT:** Do not use `lab generate` and `lab chat` in parallel, it could cause the model to crash ([#346](https://github.com/instruct-lab/cli/issues/346)).
 
 ```
 (venv) $ lab generate
@@ -241,8 +245,6 @@ The synthetic data set will be three files in the newly created `generated` dire
  'generated_ggml-malachite-7b-0226-Q4_K_M_2024-02-29T19 09 48.json'   'train_ggml-malachite-7b-0226-Q4_K_M_2024-02-29T19 09 48.jsonl'
  'test_ggml-malachite-7b-0226-Q4_K_M_2024-02-29T19 09 48.jsonl'
 ```
-
-> **NOTE:** ⏳ This can take from 15 minutes to 1+ hours to complete, depending on your computing resources.
 
 It is also possible to run the generate step against a different model via an
 OpenAI-compatible API. For example, the one spawned by `lab serve` or any remote or locally hosted LLM (e.g. via [ollama](ollama.ai/), [LM Studio](https://lmstudio.ai), etc.)

--- a/README.md
+++ b/README.md
@@ -226,9 +226,11 @@ lab generate
 
 The next step is to generate a synthetic dataset based on your newly added knowledge or skill set in the [taxonomy](https://github.com/instruct-lab/taxonomy.git) repository.
 
-> **NOTE:** ⏳ This can take from 15 minutes to 1+ hours to complete, depending on your computing resources.
+> [!NOTE]
+> ⏳ This can take from 15 minutes to 1+ hours to complete, depending on your computing resources.
 
-> **IMPORTANT:** Do not use `lab generate` and `lab chat` in parallel for the same model, it could cause the model to crash.
+> [!IMPORTANT]
+> Do not use `lab generate` and `lab chat` in parallel for the same model, it could cause the model to crash.
 
 ```
 (venv) $ lab generate


### PR DESCRIPTION
Make users aware of possible segfaults (#346).

Place the notice at the beginning of the respective section. Also move the existing notice on how long "lab generate" takes next to it.

(This PR replaces PR #508 which I dropped due to missing sign-off and merge conflicts)