### PR TITLE
fix: reduce client timeout while attempting to connect to server

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -19,7 +19,7 @@ import httpx
 import openai
 
 # Local
-from ..config import DEFAULT_API_KEY
+from ..config import DEFAULT_API_KEY, DEFAULT_CONNECTION_TIMEOUT
 
 HELP_MD = """
 Help / TL;DR
@@ -433,7 +433,9 @@ def chat_cli(
     logger, api_base, config, question, model, context, session, qq, greedy_mode
 ):
     """Starts a CLI-based chat with the server"""
-    client = OpenAI(base_url=api_base, api_key=DEFAULT_API_KEY)
+    client = OpenAI(
+        base_url=api_base, api_key=DEFAULT_API_KEY, timeout=DEFAULT_CONNECTION_TIMEOUT
+    )
 
     # Load context/session
     loaded = {}

--- a/cli/client.py
+++ b/cli/client.py
@@ -2,7 +2,7 @@
 from openai import OpenAI, OpenAIError
 
 # Local
-from .config import DEFAULT_API_KEY
+from .config import DEFAULT_API_KEY, DEFAULT_CONNECTION_TIMEOUT
 
 
 class ClientException(Exception):
@@ -12,7 +12,9 @@ class ClientException(Exception):
 def list_models(api_base, api_key=DEFAULT_API_KEY):
     """List models from OpenAI-compatible server"""
     try:
-        client = OpenAI(base_url=api_base, api_key=api_key)
+        client = OpenAI(
+            base_url=api_base, api_key=api_key, timeout=DEFAULT_CONNECTION_TIMEOUT
+        )
         return client.models.list()
     except OpenAIError as exc:
         raise ClientException(f"Connection Error {exc}") from exc

--- a/cli/config.py
+++ b/cli/config.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 # Third Party
 from pydantic import BaseModel, ConfigDict, PositiveInt, StrictStr, ValidationError
+import httpx
 import yaml
 
 DEFAULT_API_KEY = "no_api_key"
@@ -18,6 +19,7 @@ DEFAULT_NUM_CPUS = 10
 DEFAULT_NUM_INSTRUCTIONS = 100
 DEFAULT_PROMPT_FILE = "prompt.txt"
 DEFAULT_GENERATED_FILES_OUTPUT_DIR = "generated"
+DEFAULT_CONNECTION_TIMEOUT = httpx.Timeout(timeout=30.0)
 
 
 class ConfigException(Exception):

--- a/cli/generator/utils.py
+++ b/cli/generator/utils.py
@@ -110,6 +110,7 @@ def openai_completion(
             # connects to our local server
             api_key = "no_api_key"
 
+        # do not pass a lower timeout to this client since generating a dataset takes some time
         client = OpenAI(base_url=api_base, api_key=api_key)
 
         messages = [


### PR DESCRIPTION
When running `lab chat`, if the 8000 port is taken by another application, the client's timeout to connect to the server is set to 10min with a second retry. So the client could wait up to 20min before we fallback to starting a temporary server. This change sets a timeout to 30s and the retry of 2 remains unchanged.

Signed-off-by: Sébastien Han <seb@redhat.com>