### PR TITLE
fix: use the host from the config when running temp server

### DIFF
--- a/cli/server.py
+++ b/cli/server.py
@@ -28,7 +28,8 @@ def ensure_server(logger, serve_config):
         return (None, None)
     except ClientException:
         port = random.randint(1024, 65535)
-        host_port = f"localhost:{port}"
+        host = serve_config.host_port.rsplit(":", 1)[0]
+        host_port = f"{host}:{port}"
         temp_api_base = get_api_base(host_port)
         logger.debug(
             f"Connection to {api_base} failed. Starting a temporary server at {temp_api_base}..."
@@ -44,6 +45,7 @@ def ensure_server(logger, serve_config):
                 "gpu_layers": serve_config.gpu_layers,
                 "max_ctx_size": serve_config.max_ctx_size,
                 "port": port,
+                "host": host,
             },
             daemon=True,
         )


### PR DESCRIPTION
If we fallback to starting a temporary server, we should use the host specified in the config.yaml file and not hardcode `localhost`.

Signed-off-by: Sébastien Han <seb@redhat.com>