### PR TITLE
    fix: run the temp server with an available port

### DIFF
--- a/cli/server.py
+++ b/cli/server.py
@@ -2,6 +2,7 @@
 import logging
 import multiprocessing
 import random
+import socket
 
 # Third Party
 from llama_cpp import llama_chat_format
@@ -20,15 +21,39 @@ class ServerException(Exception):
 
 
 def ensure_server(logger, serve_config):
-    """Checks if server is running, if not starts one as a subprocess. Returns the server process and the URL where it's available."""
+    """Checks if server is running, if not starts one as a subprocess. Returns the server process
+    and the URL where it's available."""
     try:
         api_base = serve_config.api_base()
         logger.debug(f"Trying to connect to {api_base}...")
         list_models(api_base)
         return (None, None)
     except ClientException:
+        tried_ports = set()
         port = random.randint(1024, 65535)
         host = serve_config.host_port.rsplit(":", 1)[0]
+        logger.debug(f"Trying port {port}...")
+
+        # extract address provided in the config
+        while not can_bind_to_port(host, port):
+            logger.debug(f"Port {port} is not available.")
+            # add the port to the map so that we can avoid using the same one
+            tried_ports.add(port)
+            port = random.randint(1024, 65535)
+            while True:
+                # if all the ports have been tried, exit
+                if len(tried_ports) == 65535 - 1024:
+                    # pylint: disable=raise-missing-from
+                    raise SystemExit(
+                        "No available ports to start the temporary server."
+                    )
+                if port in tried_ports:
+                    logger.debug(f"Port {port} has already been tried.")
+                    port = random.randint(1024, 65535)
+                else:
+                    break
+        logger.debug(f"Port {port} is available.")
+
         host_port = f"{host}:{port}"
         temp_api_base = get_api_base(host_port)
         logger.debug(
@@ -93,3 +118,12 @@ def server(
         f"After application startup complete see http://{host}:{port}/docs for API."
     )
     uvicorn.run(app, host=host, port=port, log_level=logging.ERROR)
+
+
+def can_bind_to_port(host, port):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind((host, port))
+            return True
+        except socket.error:
+            return False


### PR DESCRIPTION
If the server is not reachable and we fallback to running a temporary
server we need to pick a port that is available. Prior to this, we were
simply trying our luck by randomly picking a port within the (1024,65535) range.
In case we get unlucky and the port we picked already runs
a service, this would leave the chat with a binding error and a prompt
making it very confusing for the end user (since the server actually
never started).
Now, prior to running the temp server, we make sure the port is
available (at least at the time of the socket test) and use it to run
the server. If not, we try again and keep a list of tried ports, also we
fail in the unlikely event where no ports are available at all and we
tried all possible ones.
    
Signed-off-by: Sébastien Han <seb@redhat.com>

ON TOP OF https://github.com/instruct-lab/cli/pull/743