### PR TITLE
fix: properly propagate errors when temp server fails to start

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -413,10 +413,14 @@ def generate(
     if endpoint_url:
         api_base = endpoint_url
     else:
-        server_process, api_base = ensure_server(
-            ctx.obj.logger,
-            ctx.obj.config.serve,
-        )
+        try:
+            server_process, api_base = ensure_server(
+                ctx.obj.logger,
+                ctx.obj.config.serve,
+            )
+        except Exception as exc:
+            click.secho(f"Failed to start server: {exc}", fg="red")
+            raise click.exceptions.Exit(1)
         if not api_base:
             api_base = ctx.obj.config.serve.api_base()
     try:
@@ -493,10 +497,14 @@ def chat(ctx, question, model, context, session, quick_question, greedy_mode):
     from .chat.chat import ChatException, chat_cli
     from .server import ensure_server
 
-    server_process, api_base = ensure_server(
-        ctx.obj.logger,
-        ctx.obj.config.serve,
-    )
+    try:
+        server_process, api_base = ensure_server(
+            ctx.obj.logger,
+            ctx.obj.config.serve,
+        )
+    except Exception as exc:
+        click.secho(f"Failed to start server: {exc}", fg="red")
+        raise click.exceptions.Exit(1)
     if not api_base:
         api_base = ctx.obj.config.serve.api_base()
     try:


### PR DESCRIPTION
As reported in https://github.com/instruct-lab/cli/issues/683, the temp server will fail to start if the 'lab chat' is called and the server is not running. In this scenario, the temporary server is launched but multiple exceptions could occur and they need to be reported cleanly. One of them is the model being absent.

Fixes: https://github.com/instruct-lab/cli/issues/683

Signed-off-by: Sébastien Han <seb@redhat.com>
