### PR TITLE
fix: return an empty response if there is no chat history

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -195,6 +195,12 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
         raise KeyboardInterrupt
 
     def __handle_replay(self, content, display_wrapper=(lambda x: x)):
+        # if the history is empty, then return
+        if (
+            len(self.info["messages"]) == 1
+            and self.info["messages"][0]["role"] == "system"
+        ):
+            raise KeyboardInterrupt
         cs = content.split()
         try:
             i = 1 if len(cs) == 1 else int(cs[1]) * 2 - 1


### PR DESCRIPTION
When chatting and asking for the previous response with either `/p`, `md`or `/d`, if the chat history is empty we return nothing instead of returning an error with "invalid index".

Fixes: https://github.com/instruct-lab/cli/issues/745
Signed-off-by: Sébastien Han <seb@redhat.com>