### PR TITLE
Add cov-report term to see coverage when tests run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ allowlist_externals = pytest
 [testenv:unitcov]
 deps = -r requirements-dev.txt
 description = run unit tests with coverage
-commands = pytest --cov=cli --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html {posargs:tests -m "not (examples or slow)"} -W error::UserWarning
+commands = pytest --cov=cli --cov-report term --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html {posargs:tests -m "not (examples or slow)"} -W error::UserWarning
 allowlist_externals = pytest
 
 [testenv:lint]


### PR DESCRIPTION
* In addition to the HTML report which is already generated
* The term listing will be seen in CI job output

Part of: #475 

