### PR TITLE
chat: Add --endpoint-url and --api-key options

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -436,11 +436,20 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
 
 
 def chat_cli(
-    logger, api_base, config, question, model, context, session, qq, greedy_mode
+    logger,
+    api_base,
+    api_key,
+    config,
+    question,
+    model,
+    context,
+    session,
+    qq,
+    greedy_mode,
 ):
     """Starts a CLI-based chat with the server"""
     client = OpenAI(
-        base_url=api_base, api_key=DEFAULT_API_KEY, timeout=DEFAULT_CONNECTION_TIMEOUT
+        base_url=api_base, api_key=api_key, timeout=DEFAULT_CONNECTION_TIMEOUT
     )
 
     # Load context/session


### PR DESCRIPTION
This change ands `--endpoint-url` and `--api-key` options to `ilab
chat`, similar to the same options available to `ilab generate`.

The reason I need this is for doing model testing from
`instruct-lab-bot`. The models we want to get test responses from is
hosted elsewhere.

* `@instruct-lab-bot generate` -- `ilab generate` already has the
  endpoint URL option, so that one is fine.

* `@instruct-lab-bot precheck` -- This is where we check model
  behavior for the proposed questions in a qna.yaml to see what the
  behavior looks like prior to the proposed addition. `ilab test`
  is close to what we need, but only works locally and does not work
  on Linux. The easy fallback for now is to just use `ilab chat` using
  questions from qna.yaml. To do that I need to be able to specify the
  endpoint URL to use.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
