### PR TITLE
diff: Rework --quiet logic and handle file without needing --quiet

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -234,34 +234,36 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
         logger = logging.getLogger(__name__)
     else:
         logger = ctx.obj.logger
-    if quiet:
-        try:
-            read_taxonomy(logger, taxonomy_path, taxonomy_base, yaml_rules)
-        except (SystemExit, yaml.YAMLError) as exc:
-            raise SystemExit(1) from exc
-        return
-    try:
-        updated_taxonomy_files = get_taxonomy_diff(taxonomy_path, taxonomy_base)
-    except (SystemExit, GitError) as exc:
-        click.secho(
-            f"Reading taxonomy failed with the following error: {exc}",
-            fg="red",
-        )
-        return
-    for f in updated_taxonomy_files:
-        click.echo(f)
+
+    if not quiet:
+        is_file = os.path.isfile(taxonomy_path)
+        if is_file:  # taxonomy_path is file
+            click.echo(taxonomy_path)
+        else:  # taxonomy_path is dir
+            try:
+                updated_taxonomy_files = get_taxonomy_diff(taxonomy_path, taxonomy_base)
+            except (SystemExit, GitError) as exc:
+                click.secho(
+                    f"Reading taxonomy failed with the following error: {exc}",
+                    fg="red",
+                )
+                raise SystemExit(1) from exc
+            for f in updated_taxonomy_files:
+                click.echo(f)
     try:
         read_taxonomy(logger, taxonomy_path, taxonomy_base, yaml_rules)
     except (SystemExit, yaml.YAMLError) as exc:
-        click.secho(
-            f"Reading taxonomy failed with the following error: {exc}",
-            fg="red",
-        )
+        if not quiet:
+            click.secho(
+                f"Reading taxonomy failed with the following error: {exc}",
+                fg="red",
+            )
         raise SystemExit(1) from exc
-    click.secho(
-        f"Taxonomy in /{taxonomy_path}/ is valid :)",
-        fg="green",
-    )
+    if not quiet:
+        click.secho(
+            f"Taxonomy in /{taxonomy_path}/ is valid :)",
+            fg="green",
+        )
 
 
 # ilab list => ilab diff

--- a/tests/test_lab_diff.py
+++ b/tests/test_lab_diff.py
@@ -140,13 +140,13 @@ class TestLabDiff(unittest.TestCase):
                     self.taxonomy.root,
                 ],
             )
-            self.assertIsNone(result.exception)
+            self.assertIsNotNone(result.exception)
             self.assertIn(
                 f'Couldn\'t find the taxonomy git ref "{taxonomy_base}" '
                 "from the current HEAD",
                 result.output,
             )
-            self.assertEqual(result.exit_code, 0)
+            self.assertNotEqual(result.exit_code, 0)
 
     def test_diff_invalid_path(self):
         taxonomy_path = "/path/to/taxonomy"
@@ -161,9 +161,9 @@ class TestLabDiff(unittest.TestCase):
                     taxonomy_path,
                 ],
             )
-            self.assertIsNone(result.exception)
+            self.assertIsNotNone(result.exception)
             self.assertIn(f"{taxonomy_path}", result.output)
-            self.assertEqual(result.exit_code, 0)
+            self.assertNotEqual(result.exit_code, 0)
 
     def test_diff_valid_yaml(self):
         valid_yaml_file = "compositional_skills/qna_valid.yaml"


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves #796

**Description of your changes:**

The logic is organized so there is not separate work paths for quiet and non-quiet. The non-quiet code now properly identifies and handles single files.

An exception in the quiet code when reading the repo now results in a
failing exit code.

