### PR TITLE
Restrict server to one client

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ The full process is described graphically in the [workflow diagram](./docs/workf
    Press CTRL+C to shut down the server.
    ```
 
+   > **NOTE:** If multiple `ilab` clients try to connect to the same ilab server at the same time, the 1st will connect to the server while the others will start their own temporary server. This will require additional resources on the host machine.
+
 ### 📣 Chat with the model (Optional)
 
 Because you're serving the model in one terminal window, you will have to create a new window and re-activate your Python virtual environment to run `ilab chat` command:

--- a/cli/server.py
+++ b/cli/server.py
@@ -156,7 +156,14 @@ def server(
     logger.info(
         f"After application startup complete see http://{host}:{port}/docs for API."
     )
-    uvicorn.run(app, host=host, port=port, log_level=logging.ERROR)
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_level=logging.ERROR,
+        limit_concurrency=2,  # Make sure we only serve a single client at a time
+        timeout_keep_alive=0,  # prevent clients holding connections open (we only have 1)
+    )
 
 
 def can_bind_to_port(host, port):


### PR DESCRIPTION
The server frequently crashes when dealing with 2 clients simultaniously, limit it to a single worker, If a user tries to connect ilab to the server the second command will start its own local server (as it gets a http 503).

We also need to disable keep-alive to prevent consecutive calls in the same client holding the only worker open and DOS'ing itself.

There is still one error case, if the chat client is started but not activly chatting when generate is started. chat will fail when the model is called. Not ideal but not as bad as an hour long "ilab generate" failing.

Fixes #346
