### PR TITLE
Get system prompt from a single source

### DIFF
--- a/cli/chat/chat.py
+++ b/cli/chat/chat.py
@@ -20,6 +20,7 @@ import openai
 
 # Local
 from ..config import DEFAULT_API_KEY, DEFAULT_CONNECTION_TIMEOUT
+from ..utils import get_sysprompt
 
 HELP_MD = """
 Help / TL;DR
@@ -42,7 +43,7 @@ Press Alt (or Meta) and Enter or Esc Enter to end multiline input.
 """
 
 CONTEXTS = {
-    "default": "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior.",
+    "default": get_sysprompt(),
     "cli_helper": "You are an expert for command line interface and know all common commands. Answer the command to execute as it without any explanation.",
 }
 

--- a/cli/common.py
+++ b/cli/common.py
@@ -1,0 +1,1 @@
+SYS_PROMPT = "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior."

--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -381,7 +381,7 @@ def generate_data(
         try:
             test_data.append(
                 {
-                    "system": utils.SYSTEM_PROMPT,
+                    "system": utils.get_sysprompt(),
                     "user": unescape(user),
                     "assistant": unescape(seed_example["output"]),
                 }
@@ -511,7 +511,7 @@ def generate_data(
                 user += "\n" + synth_example["input"]
             train_data.append(
                 {
-                    "system": utils.SYSTEM_PROMPT,
+                    "system": utils.get_sysprompt(),
                     "user": unescape(user),
                     "assistant": unescape(synth_example["output"]),
                 }

--- a/cli/generator/utils.py
+++ b/cli/generator/utils.py
@@ -14,10 +14,9 @@ from openai import OpenAI, OpenAIError
 
 # Local
 from ..config import DEFAULT_API_KEY
+from ..utils import get_sysprompt
 
 StrOrOpenAIObject = Union[str, object]
-
-SYSTEM_PROMPT = "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior."
 
 
 class GenerateException(Exception):
@@ -114,7 +113,7 @@ def openai_completion(
         client = OpenAI(base_url=api_base, api_key=api_key)
 
         messages = [
-            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "system", "content": get_sysprompt()},
             {"role": "user", "content": prompt_batch[batch_id]},
         ]
 

--- a/cli/lab.py
+++ b/cli/lab.py
@@ -994,8 +994,7 @@ def test(data_dir, model_dir, adapter_file):
     with open(test_data_dir, "r", encoding="utf-8") as f:
         test_data = [json.loads(line) for line in f]
 
-    SYS_PROMPT = "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior."
-    print("system prompt:", SYS_PROMPT)
+    print("system prompt:", utils.get_sysprompt())
     for idx, example in enumerate(test_data):
         system = example["system"]
         user = example["user"]

--- a/cli/train/lora_mlx/make_data.py
+++ b/cli/train/lora_mlx/make_data.py
@@ -1,7 +1,8 @@
 # Standard
 import json
 
-SYS_PROMPT = "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior."
+# Local
+from . import utils
 
 
 def format_text(obj):
@@ -29,7 +30,7 @@ def make_data(data_dir: str, is_shiv: bool = False):
             data_new = []
             for obj in data:
                 obj_new = {
-                    "system": SYS_PROMPT,
+                    "system": utils.get_sysprompt(),
                     "user": obj["user"],
                     "assistant": obj["assistant"],
                 }
@@ -61,7 +62,7 @@ def make_data(data_dir: str, is_shiv: bool = False):
         data_new = []
         for obj in data:
             obj_new = {
-                "system": SYS_PROMPT,
+                "system": utils.get_sysprompt(),
                 "user": obj["inputs"],
                 "assistant": obj["targets"],
             }

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -18,6 +18,9 @@ import git
 import gitdb
 import yaml
 
+# Local
+from . import common
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(levelname)s %(asctime)s %(filename)s:%(lineno)d %(message)s",
@@ -248,3 +251,15 @@ def chunk_document(documents: List, server_ctx_size, chunk_word_count) -> List[s
         content.extend([item.page_content for item in temp])
 
     return content
+
+
+# pylint: disable=unused-argument
+def get_sysprompt(model=None):
+    """
+    Gets a system prompt specific to a model
+    Args:
+        model (str): currently not implemented
+    Returns:
+        str: The system prompt for the model being used
+    """
+    return common.SYS_PROMPT

--- a/mac_inference/model_load_run.py
+++ b/mac_inference/model_load_run.py
@@ -4,6 +4,9 @@ import os
 # Third Party
 from llama_cpp import Llama
 
+# Local
+from . import utils
+
 # Get model_path from env
 MODEL_FILE = os.getenv("MODEL_FILE")
 
@@ -14,9 +17,14 @@ MODEL_FILE = os.getenv("MODEL_FILE")
 model = Llama(model_path=MODEL_FILE, n_gpu_layers=-1)
 
 # System prompt
-sys_prompt = "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior."
 usr_prompt = "what is ibm?"
-prompt = "<|system|>\n" + sys_prompt + "\n<|user|>\n" + usr_prompt + "\n<|assistant|>\n"
+prompt = (
+    "<|system|>\n"
+    + utils.get_sysprompt()
+    + "\n<|user|>\n"
+    + usr_prompt
+    + "\n<|assistant|>\n"
+)
 
 # Inference the model
 result = model(prompt, max_tokens=200, echo=True, stop="<|endoftext|>")


### PR DESCRIPTION
Introduce get_sysprompt as a single source for a
system prompt. In future, if supported models
have a different sys prompt, support can be added here.

Fixes #347

