### PR TITLE
Adds maintainers.md file and links to community repo maintainers file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,1 @@
+For a complete list of InstructLab project maintainers, see [Maintainers](https://github.com/instruct-lab/community/blob/main/MAINTAINERS.md).


### PR DESCRIPTION
This PR adds a Maintainers.md file and links to the community repo's Maintainers.md file. 

Addresses https://github.com/orgs/instruct-lab/projects/1/views/1?pane=issue&itemId=59049356 