### PR TITLE
cli: Fix regression in call to list_models()

### DIFF
--- a/cli/server.py
+++ b/cli/server.py
@@ -36,11 +36,11 @@ def ensure_server(
         api_base = serve_config.api_base()
         logger.debug(f"Trying to connect to {api_base}...")
         list_models(
-            api_base,
-            tls_insecure,
-            tls_client_cert,
-            tls_client_key,
-            tls_client_passwd,
+            api_base=api_base,
+            tls_insecure=tls_insecure,
+            tls_client_cert=tls_client_cert,
+            tls_client_key=tls_client_key,
+            tls_client_passwd=tls_client_passwd,
         )
         return (None, None)
     except ClientException:


### PR DESCRIPTION
When the new TLS arguments were added, the call to list_models
accidentally skipped over the `api_key` argument, so all of the
arguments were used incorrectly other than `api_base`.

This patch changes the `list_modules()` call to use all keyword
arguments to avoid this sort of accidental thing from happening.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
