### PR TITLE
fix: regression in train command when single source system prompt added

### DIFF
--- a/cli/train/lora_mlx/make_data.py
+++ b/cli/train/lora_mlx/make_data.py
@@ -2,7 +2,7 @@
 import json
 
 # Local
-from . import utils
+from ...utils import get_sysprompt
 
 
 def format_text(obj):
@@ -30,7 +30,7 @@ def make_data(data_dir: str, is_shiv: bool = False):
             data_new = []
             for obj in data:
                 obj_new = {
-                    "system": utils.get_sysprompt(),
+                    "system": get_sysprompt(),
                     "user": obj["user"],
                     "assistant": obj["assistant"],
                 }
@@ -62,7 +62,7 @@ def make_data(data_dir: str, is_shiv: bool = False):
         data_new = []
         for obj in data:
             obj_new = {
-                "system": utils.get_sysprompt(),
+                "system": get_sysprompt(),
                 "user": obj["inputs"],
                 "assistant": obj["targets"],
             }


### PR DESCRIPTION
When the system prompt from a single source was added in #824, the utils accessed in the train module was its local utils and not the cli utils. Therefore, it could not find the `get_sysprompt()` function and `ilab train` command on Mac fails.

Error as follows:

```command
$ ilab train

[...]

File "/Users/mhickey/.pyenv/versions/3.11.7/envs/cli-main/lib/python3.11/site-packages/cli/train/lora_mlx/make_data.py", line 33, in make_data
    "system": utils.get_sysprompt(),
              ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'cli.train.lora_mlx.utils' has no attribute 'get_sysprompt'
```

This PR fixes the regression.