### PR TITLE
Exit on git error

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -216,8 +216,7 @@ def get_documents(input_pattern: Dict[str, Union[str, List[str]]]) -> List[str]:
 
     except (OSError, git.exc.GitCommandError, FileNotFoundError) as e:
         logger.error("Error: {}".format(str(e)))
-        return [f"Error: {str(e)}"]
-
+        sys.exit()
     finally:
         # Cleanup: Remove the temporary directory if it exists
         if os.path.exists(temp_dir):


### PR DESCRIPTION
get_documents should not return the error message as we end up generating synthetic q&a for a git error message instead of the intended document.

Fixes #807
