### PR TITLE
Fix ROCm container build

### DIFF
--- a/containers/rocm/Containerfile
+++ b/containers/rocm/Containerfile
@@ -52,7 +52,7 @@ FROM pytorch AS llama
 RUN --mount=type=cache,target=/root/.cache/pip,z \
     pip cache remove llama_cpp_python && \
     umask 0000 && \
-    CMAKE_ARGS="-DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DAMDGPU_TARGETS=${AMDGPU_ARCH}" \
+    CMAKE_ARGS="-DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER=/usr/bin/clang-17 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-17 -DAMDGPU_TARGETS=${AMDGPU_ARCH}" \
     FORCE_CMAKE=1 \
     ${VIRTUAL_ENV}/bin/pip install -c ${VIRTUAL_ENV}/constraints.txt llama-cpp-python && \
     $(chcon -R -l s0 /root/.cache/pip 2>/dev/null || true)


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/instruct-lab/cli/issues/855

**Description of your changes:**
In Fedora 40, ROCm device libs use clang-17. The default clang compiler was updated to clang-18. Build llama-cpp-python with clang-17 and clang++-17.