### PR TITLE
Generate examples with simpler heading format

### DIFF
--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -156,7 +156,7 @@ def post_process_gpt3_response(num_prompt_instructions, response, discarded_file
         if not inst.strip():
             continue
 
-        splitted_data = re.split(r"\*\*\s+(Instruction|Input|Output)", inst)
+        splitted_data = re.split(r"\*\*\s+(Instruction|Input|Output):?", inst)
         if len(splitted_data) != 7:
             writeline2file(
                 discarded_file,

--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -129,12 +129,11 @@ def encode_prompt(prompt_instructions, prompt):
         )
         instruction = re.sub(r"\s+", " ", instruction).strip().rstrip(":")
         prompt_input = "<noinput>" if prompt_input.lower() == "" else prompt_input
-        prompt += "###\n"
-        prompt += f"{idx + 1}. Instruction: {instruction}\n"
-        prompt += f"{idx + 1}. Input:\n{prompt_input}\n"
-        prompt += f"{idx + 1}. Output:\n{prompt_output}\n"
-    prompt += "###\n"
-    prompt += f"{idx + 2}. Instruction:"
+        prompt += f"* Task {idx + 1}\n"
+        prompt += f"** Instruction\n{instruction}\n"
+        prompt += f"** Input\n{prompt_input}\n"
+        prompt += f"** Output\n{prompt_output}\n"
+    prompt += f"* Task {idx + 2}\n"
     return prompt
 
 
@@ -148,26 +147,20 @@ def post_process_gpt3_response(num_prompt_instructions, response, discarded_file
     if response is None:
         return [], 0
     raw_instructions = (
-        f"{num_prompt_instructions + 1}. Instruction:" + response.message.content
+        f"* Task {num_prompt_instructions + 1}\n" + response.message.content
     )
-    raw_instructions = re.split("###", raw_instructions)
+    raw_instructions = re.split(r"\* Task \d+", raw_instructions)
     instructions = []
     discarded = 0
-    for idx, inst in enumerate(raw_instructions):
-        # if the decoding stops due to length, the last example is likely truncated so we discard it
-        # if idx == len(raw_instructions) - 1 and response["finish_reason"] == "length":
-        #     continue
-        idx += num_prompt_instructions + 1
-
+    for inst in raw_instructions:
         if not inst.strip():
             continue
 
-        splitted_data = re.split(rf"{idx}\.\s+(Instruction|Input|Output):", inst)
+        splitted_data = re.split(r"\*\*\s+(Instruction|Input|Output)", inst)
         if len(splitted_data) != 7:
             writeline2file(
                 discarded_file,
-                f"Discarded instruction(didn't match expected format, idx={idx}): "
-                + repr(inst),
+                "Discarded instruction(didn't match expected format): " + repr(inst),
             )
             discarded += 1
             continue

--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -274,7 +274,7 @@ def get_instructions_from_model(
         # Requests will be automatically adjusted.
         max_tokens=3072,
         top_p=top_p,
-        stop=["\n5", "5.", "5."],
+        stop=["* Task 5"],
     )
     request_start = time.time()
     results = utils.openai_completion(


### PR DESCRIPTION
Today `ilab generate` creates a large percentage (> 50% in my testing) of discarded examples because the examples do not match our expected format. Typically, the model fails to follow our complicated numbering scheme for instructions, inputs, and outputs. This change simplifies that scheme, taking inspiration from Emacs org-mode without any rigid adherence to it.

Before this change, we expected the model to continue a format like:

```
1. Instruction: Generate a joke involving three horses.
1. Input:
<noinput>
1. Output:
There once were three horses...
```

After this change, we now give the model:

```
* Task 1
** Instruction
Generate a joke involving three horses.
** Input
<noinput>
** Output
There once were three horses...
```

In my local testing, the model is able to replicate our new format with a much higher accuracy than the previous format, resulting in substantially fewer discarded generations due to format.

Other formats I considered but decided against:
- JSON was excluded because the model was not able to reliably handle quotes or special characters when generating JSON, even though overall it did seem to understand the expected format.
- XML was excluded because it resulted in a more verbose prompt, consuming quite a bit more of our available context window. The model did seem to have a good grasp of XML with CDATA elements used to handle special characters.
- Markdown was excluded because knowledge documents are in Markdown format, and I wanted to minimize the chances of the embedded knowledge document interfering with the expected parsing structure.


Resolves #466 

