### PR TITLE
Added encoding hack to avoid data generation error due to latin-1 encoding

### DIFF
--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -487,8 +487,8 @@ def generate_data(
                     instruction_data_entry['input'] = instruction_data_entry['input'].encode('latin-1', 'ignore').decode('latin-1')
                 if 'output' in instruction_data_entry:
                     instruction_data_entry['output'] = instruction_data_entry['output'].encode('latin-1', 'ignore').decode('latin-1')
-            except:
-                print('Tried to fix entry encoding. May lead to `"latin-1" codec can\'t encode character "\u0107"`.')
+            except Exception as e:
+                print(f'Tried to fix entry encoding. May lead to `"latin-1" codec can\'t encode character "\u0107"`. \nException: {str(e)}')
 
             # computing similarity with the pre-tokenized instructions
             new_instruction_tokens = scorer._tokenizer.tokenize(

--- a/cli/generator/generate_data.py
+++ b/cli/generator/generate_data.py
@@ -478,6 +478,18 @@ def generate_data(
         keep = 0
         assess_start = time.time()
         for instruction_data_entry in instruction_data:
+
+            # fix encoding... is this the right place? LB
+            try:
+                instruction_data_entry["instruction"] = instruction_data_entry["instruction"].encode('latin-1', 'ignore').decode('latin-1')
+
+                if 'input' in instruction_data_entry:
+                    instruction_data_entry['input'] = instruction_data_entry['input'].encode('latin-1', 'ignore').decode('latin-1')
+                if 'output' in instruction_data_entry:
+                    instruction_data_entry['output'] = instruction_data_entry['output'].encode('latin-1', 'ignore').decode('latin-1')
+            except:
+                print('Tried to fix entry encoding. May lead to `"latin-1" codec can\'t encode character "\u0107"`.')
+
             # computing similarity with the pre-tokenized instructions
             new_instruction_tokens = scorer._tokenizer.tokenize(
                 instruction_data_entry["instruction"]


### PR DESCRIPTION
# Changes

Change made to `cli/generator/generate_data.py`

**Which issue is resolved by this Pull Request:**

Resolves # No Issue Raised...

`UnicodeEncodeError` happens during data generation when there are special characters in the seed data or corpus (document) data such as `é` or `ã`.

Actual error message:
```
UnicodeEncodeError: 'latin-1' codec can't encode character u'\u0107' in position 0: ordinal not in range(256)
```

**Description of your changes:**

Added the following lines of code:

```python
             # fix encoding... is this the right place? LB
             try:
                 instruction_data_entry["instruction"] =                                  instruction_data_entry["instruction"].encode('latin-1', 'ignore').decode('latin-1')     
 
                 if 'input' in instruction_data_entry:
                     instruction_data_entry['input'] = instruction_data_entry['input'].   encode('latin-1', 'ignore').decode('latin-1')
                 if 'output' in instruction_data_entry:
                     instruction_data_entry['output'] = instruction_data_entry['output']. encode('latin-1', 'ignore').decode('latin-1')
             except:
                 print('Tried to fix entry encoding. May lead to `"latin-1" codec can\'t  encode character "\u0107"`.')
```

Basically, simple encoding/decoding to ignore scenarios with the above special characters on `instruction`, `input`, and `output` data.


