### PR TITLE
fix: openai and http log level

### DIFF
--- a/cli/lab.py
+++ b/cli/lab.py
@@ -22,6 +22,10 @@ import yaml
 # NOTE: Subcommands are using local imports to speed up startup time.
 from . import config, utils
 
+# Set logging level of OpenAI client and httpx library to ERROR to suppress INFO messages
+logging.getLogger("openai").setLevel(logging.ERROR)
+logging.getLogger("httpx").setLevel(logging.ERROR)
+
 if typing.TYPE_CHECKING:
     # Third Party
     import torch

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -245,6 +245,19 @@ test_temp_server(){
     '
 }
 
+test_no_chat_logs(){
+    expect -c '
+        set timeout 30
+        spawn ilab chat
+        expect "Starting a temporary server at"
+        send "hello!\r"
+        sleep 1
+        expect {
+            "_base_client.py" { exit 1 }
+        }
+    '
+}
+
 ########
 # MAIN #
 ########
@@ -259,5 +272,7 @@ test_generate
 test_server_shutdown_while_chatting
 cleanup
 test_temp_server
+cleanup
+test_no_chat_logs
 
 exit 0


### PR DESCRIPTION
Lately, more INFO messages have appeared in the chat, so let's set the log level to ERROR only on the openai and http clients.

Without this change:

```
$ ilab chat
INFO 2024-04-16 11:49:33,283 _base_client.py:1040 Retrying request to /models in 0.911925 seconds
INFO 2024-04-16 11:49:34,197 _base_client.py:1040 Retrying request to /models in 1.571945 seconds
```

A more granular control over the log levels for various libraries will
be implemented in a follow-up PR. That enhancement is tracked in
https://github.com/instructlab/instructlab/issues/905.

Fixes: https://github.com/instructlab/instructlab/issues/909
Signed-off-by: Sébastien Han <seb@redhat.com>
