### PR TITLE
fix: ignore SIGINT when running the temp server

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -245,6 +245,24 @@ test_temp_server(){
     '
 }
 
+test_temp_server_sigint(){
+    expect -c '
+        set timeout 30
+        spawn ilab chat
+        expect "Starting a temporary server at"
+        send "hello!\r"
+        sleep 5
+        send "\003"
+        expect "Disconnected from client (via refresh/close)"
+        send "\003"
+        send "hello again\r"
+        sleep 1
+        expect {
+            "Connection error, try again" { exit 1 }
+        }
+    '
+}
+
 ########
 # MAIN #
 ########
@@ -259,5 +277,7 @@ test_generate
 test_server_shutdown_while_chatting
 cleanup
 test_temp_server
+cleanup
+test_temp_server_sigint
 
 exit 0


### PR DESCRIPTION
When we simply run `ilab chat`, a temporary server will run in the background and we can enjoy a great chat. However, if the chat response is interrupted with ctrl+C, the signal will be caught by uvicorn and then the server will be killed making further chat impossible and printing a large backtrace.

Another option was to run the temp server in a dedicated thread but this requires a bit more changes as well as the difficulty of handling the thread termination. This would have been handled by uvicorn natively since it is not setting up any signal handler but would still require us to handle it manually in our code.

Fixes: https://github.com/instruct-lab/cli/issues/883