### PR TITLE
switch lab coat emoji to dog emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# InstructLab 🥼 (`ilab`)
+# InstructLab 🐶 (`ilab`)
 
 ![Tests](https://github.com/instruct-lab/cli/actions/workflows/test.yml/badge.svg)
 
@@ -25,8 +25,8 @@
 
 ## Welcome to the InstructLab CLI
 
-InstructLab 🥼 uses a novel synthetic data-based alignment tuning method for
-Large Language Models (LLMs.) The "**lab**" in Instruct**Lab** 🥼 stands for
+InstructLab 🐶 uses a novel synthetic data-based alignment tuning method for
+Large Language Models (LLMs.) The "**lab**" in Instruct**Lab** 🐶 stands for
 [**L**arge-Scale **A**lignment for Chat**B**ots](https://arxiv.org/abs/2403.01081) [1].
 
 [1] Shivchander Sudalairaj*, Abhishek Bhandwaldar*, Aldo Pareja*, Kai Xu, David D. Cox, Akash Srivastava*. "LAB: Large-Scale Alignment for ChatBots", arXiv preprint arXiv: 2403.01081, 2024. (* denotes equal contributions)


### PR DESCRIPTION
For launch, given that we have the dog in the instructlab org picture, the labcoat emojis should also be dogs.