### PR TITLE
(fix) ilab diff for knowledge doc bug

### DIFF
--- a/cli/utils.py
+++ b/cli/utils.py
@@ -206,22 +206,23 @@ def get_documents(
     file_patterns = source.get("patterns")
     with tempfile.TemporaryDirectory() as temp_dir:
         try:
-            skip_checkout = False
+            sc = False
             if skip_checkout:
-                skip_checkout = True
+                sc = True
             repo = git_clone_checkout(
                 repo_url=repo_url,
                 commit_hash=commit_hash,
                 temp_dir=temp_dir,
-                skip_checkout=skip_checkout,
+                skip_checkout=sc,
             )
             file_contents = []
 
             # hack for unit tests. Unit tests use temp dirs in tests/testdata
-            # that needs to be processed instead of the temp_dir created
-            working_dir = temp_dir
+            # that needs to be processed instead of the cloned project inside
+            # temp_dir
+            working_dir = repo
             if not skip_checkout:
-                working_dir = repo
+                working_dir = repo.working_dir
 
             logger.debug("Processing files...")
             for pattern in file_patterns:


### PR DESCRIPTION
Closes #885

Fix: `working_dir` arg being passed to `os.path.join()` for `glob.glob` was of type `Repo`. Fix is to pass in `Repo.working_dir`, which is of type `str` instead.

Also fixes an issue with `skip_checkout` variable, which was always `False`. Fix is to use a temp variable `sc` and set `sc` to `True/False` based on `skip_checkout`

# Changes

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
