### PR TITLE
tests: fix input data file contents

### DIFF
--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -30,8 +30,8 @@ ENCODING = "UTF-8"
 def setup_input_dir():
     os.mkdir(INPUT_DIR)
     for f_path in ["/train_1.jsonl", "/test_1.jsonl"]:
-        with open(INPUT_DIR + f_path, "w", encoding=ENCODING) as f:
-            f.write("{}")
+        with open(INPUT_DIR + f_path, "w", encoding=ENCODING):
+            pass
 
 
 def setup_linux_dir():


### PR DESCRIPTION
Test code was writing {} in the file but this results in an empty dict() produced by json.load, which would later fail with KeyError('user') in make_data.

The reason why this doesn't show up in the test runs is because make_data is mocked out. This test bug was noticed while working on another fix for the test suite where mocks were not effective [1].

While the test suite was not failing (because of mocks), it's still better to inject data that conforms to loader expectations.

[1] https://github.com/instructlab/instructlab/pull/890

# Changes

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
