### PR TITLE
Fix TypeError during `ilab generate`

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 import logging
 import unittest
 
 # Third Party
-# Third party
+import git
 import yaml
 
 # First Party
@@ -43,8 +43,11 @@ class TestUtils(unittest.TestCase):
             f"{exc.exception}",
         )
 
-    @patch("cli.utils.git_clone_checkout", return_value="tests/testdata/temp_repo")
-    def test_get_document(self, git_actions):
+    @patch(
+        "cli.utils.git_clone_checkout",
+        return_value=Mock(spec=git.Repo, working_dir="tests/testdata/temp_repo"),
+    )
+    def test_get_document(self, git_clone_checkout):
         with open(
             "tests/testdata/knowledge_valid.yaml", "r", encoding="utf-8"
         ) as qnafile:
@@ -53,5 +56,5 @@ class TestUtils(unittest.TestCase):
                 skip_checkout=True,
                 logger=logging.getLogger("_test_"),
             )
-            git_actions.assert_called_once()
+            git_clone_checkout.assert_called_once()
             self.assertEqual(len(documents), 2)


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves #885

**Description of your changes:**

Use the `working_dir` of a repo object, not the repo object as base directory for globbing. Fixes:

```
  File "cli/utils.py", line 229, in get_documents
    for file_path in glob.glob(os.path.join(working_dir, pattern)):
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 76, in join
TypeError: expected str, bytes or os.PathLike object, not Repo
```

Replace the mock.patch with a proper spec-ed Mock that walks and talks like a `git.Repo` object. This makes the code easier to understand and does not violate the type annotations.



