### PR TITLE
Add option for knowledge yaml with self-contained document

### DIFF
--- a/src/instructlab/schema/v1/knowledge.json
+++ b/src/instructlab/schema/v1/knowledge.json
@@ -56,13 +56,30 @@
         "document": {
             "description": "The knowledge documents.",
             "type": "object",
-            "required": [
-                "repo",
-                "commit",
-                "patterns"
+            "oneOf": [
+                {
+                    "required": [
+                        "content"
+                    ]
+                },
+                {
+                    "required": [
+                        "repo",
+                        "commit",
+                        "patterns"
+                    ]
+                }
             ],
             "unevaluatedProperties": false,
             "properties": {
+                "content": {
+                    "description": "Document content.",
+                    "type": "string",
+                    "minLength": 1,
+                    "examples": [
+                        "This is a text content."
+                    ]
+                },
                 "repo": {
                     "description": "The URL to a Git repository holding the knowledge documents.",
                     "type": "string",

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -196,11 +196,16 @@ def get_documents(
     Retrieve the content of files from a Git repository.
 
     Args:
-        source (dict): Source info containing repository URL, commit hash, and list of file patterns.
+        source (dict): Source info containing document content or 
+        repository URL, commit hash, and list of file patterns.
 
     Returns:
          List[str]: List of document contents.
     """ ""
+    content = source.get('content')
+    if content and isinstance(content, str):
+        return [content]
+    
     repo_url = source.get("repo")
     commit_hash = source.get("commit")
     file_patterns = source.get("patterns")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,3 +59,19 @@ class TestUtils(unittest.TestCase):
             )
             git_clone_checkout.assert_called_once()
             self.assertEqual(len(documents), 2)
+        
+    @patch(
+        "instructlab.utils.git_clone_checkout",
+        return_value=Mock(spec=git.Repo, working_dir="tests/testdata/temp_repo"),
+    )
+    def test_get_document_with_doc(self, git_clone_checkout):
+        with open(
+            "tests/testdata/knowledge_with_doc_valid.yaml", "r", encoding="utf-8"
+        ) as qnafile:
+            documents = utils.get_documents(
+                source=yaml.safe_load(qnafile).get("document"),
+                skip_checkout=True,
+                logger=logging.getLogger("_test_"),
+            )
+            git_clone_checkout.assert_not_called()
+            self.assertEqual(len(documents), 1)

--- a/tests/testdata/knowledge_with_doc_valid.yaml
+++ b/tests/testdata/knowledge_with_doc_valid.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+created_by: test-bot
+domain: test-domain
+seed_examples:
+  - question: What is this knowledge about?
+    answer: It's a document about testing
+  - answer: "answer2"
+    question: "question2"
+  - answer: "answer3"
+    question: "question3"
+  - answer: "answer4"
+    question: "question4"
+  - answer: "answer5"
+    question: "question5"
+task_description: For knowledge tests
+document:
+  content: |
+    This knowledge document is about testing self-contained knowledge text.


### PR DESCRIPTION
# Changes

Enables knowledge yaml files with self-contained document. This will restore compatibility with `instructlab-ui` generated files.