### PR TITLE
ci: fix labeler permissions and identation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,15 +2,15 @@
 
 documentation:
   - changed-files:
-    - any-glob-to-any-file:
-      - CODE_OF_CONDUCT.md
-      - README.md
-      - TROUBLESHOOTING.md
-      - CONTRIBUTING/**/*
-      - docs/**/*
+      - any-glob-to-any-file:
+          - CODE_OF_CONDUCT.md
+          - README.md
+          - TROUBLESHOOTING.md
+          - CONTRIBUTING/**/*
+          - docs/**/*
 
 testing:
   - changed-files:
-    - any-glob-to-any-file:
-      - tests/**/*
-      - scripts/functional-tests.sh
+      - any-glob-to-any-file:
+          - tests/**/*
+          - scripts/functional-tests.sh

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
-name: labeler
+name: "Pull Request Labeler"
 
 on:
 - pull_request_target
 
 jobs:
-  label:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v5


### PR DESCRIPTION
**Description of your changes:**
The labeler in this repo is currently broken - this PR changes the config to match what we have in https://github.com/instructlab/taxonomy which is currently working