### PR TITLE
Ensure the CUDA container image works on most CPUs

### DIFF
--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -14,7 +14,7 @@ RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cu
     && export PATH="/usr/local/cuda/bin:$PATH" \
     && export XLA_TARGET=cuda120 \
     && export XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
-RUN --mount=type=ssh,id=default CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-cache-dir llama-cpp-python 
+RUN --mount=type=ssh,id=default CMAKE_ARGS="-DLLAMA_CUBLAS=on -DLLAMA_AVX2=off -DLLAMA_FMA=off -DLLAMA_F16C=off" python3.11 -m pip install --force-reinstall --no-cache-dir llama-cpp-python
 RUN --mount=type=ssh,id=default python3.11 -m pip install git+ssh://git@github.com/instructlab/instructlab.git@stable
 CMD ["/bin/bash"]
 


### PR DESCRIPTION
This disables AVX2, FMA, and F16C in the CMAKE_ARGS when rebuilding llama_cpp_python to ensure that the container build from this Containerfile will work on any CPU architecture as long as it has the basic `avx` instruction set.

Fixes #822

This is a reopened version of #823  which accidentally got closed.