### PR TITLE
Reduce number of discarded generated data samples

### DIFF
--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -145,7 +145,7 @@ def post_process_gpt3_response(num_prompt_instructions, response, discarded_file
         if not inst.strip():
             continue
 
-        splitted_data = re.split(r"\*\*\s+(Instruction|Input|Output)", inst)
+        splitted_data = re.split(r"\*\*\s+(Instruction|Input|Output):?", inst)
         if len(splitted_data) != 7:
             writeline2file(
                 discarded_file,

--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -252,7 +252,7 @@ def get_instructions_from_model(
         # Requests will be automatically adjusted.
         max_tokens=3072,
         top_p=top_p,
-        stop=["\n5", "5.", "5."],
+        stop=["* Task 5"],
     )
     request_start = time.time()
     results = utils.openai_completion(


### PR DESCRIPTION
Today `ilab generate` creates a large percentage (> 50% in my testing) of discarded examples because the examples do not match our expected format. Typically, the model fails to follow our complicated numbering scheme for instructions, inputs, and outputs. This change simplifies that scheme, taking inspiration from Emacs org-mode without any rigid adherence to it.

Before this change, we expected the model to continue a format like:

```
1. Instruction: Generate a joke involving three horses.
1. Input:
<noinput>
1. Output:
There once were three horses...
```

After this change, we now give the model:

```
* Task 1
** Instruction
Generate a joke involving three horses.
** Input
<noinput>
** Output
There once were three horses...
```

In my local testing, the model is able to replicate our new format with a much higher accuracy than the previous format, resulting in substantially fewer discarded generations due to format.

Other formats I considered but decided against:
- JSON was excluded because the model was not able to reliably handle quotes or special characters when generating JSON, even though overall it did seem to understand the expected format.
- XML was excluded because it resulted in a more verbose prompt, consuming quite a bit more of our available context window. The model did seem to have a good grasp of XML with CDATA elements used to handle special characters.
- Markdown was excluded because knowledge documents are in Markdown format, and I wanted to minimize the chances of the embedded knowledge document interfering with the expected parsing structure.


Resolves #466 

This is a reopened version of #857 which accidentally got closed.

