### PR TITLE
fix: openai and http log level

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -264,6 +264,19 @@ test_temp_server_sigint(){
     '
 }
 
+test_no_chat_logs(){
+    expect -c '
+        set timeout 30
+        spawn ilab chat
+        expect "Starting a temporary server at"
+        send "hello!\r"
+        sleep 1
+        expect {
+            "_base_client.py" { exit 1 }
+        }
+    '
+}
+
 ########
 # MAIN #
 ########
@@ -280,5 +293,7 @@ cleanup
 test_temp_server
 cleanup
 test_temp_server_sigint
+cleanup
+test_no_chat_logs
 
 exit 0

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -24,6 +24,10 @@ import yaml
 # NOTE: Subcommands are using local imports to speed up startup time.
 from . import config, utils
 
+# Set logging level of OpenAI client and httpx library to ERROR to suppress INFO messages
+logging.getLogger("openai").setLevel(logging.ERROR)
+logging.getLogger("httpx").setLevel(logging.ERROR)
+
 if typing.TYPE_CHECKING:
     # Third Party
     import torch


### PR DESCRIPTION
Lately, more INFO messages have appeared in the chat, so let's set the log level to ERROR only on the openai and http clients.

Without this change:

```
$ ilab chat
INFO 2024-04-16 11:49:33,283 _base_client.py:1040 Retrying request to /models in 0.911925 seconds
INFO 2024-04-16 11:49:34,197 _base_client.py:1040 Retrying request to /models in 1.571945 seconds
```

A more granular control over the log levels for various libraries will be implemented in a follow-up PR. That enhancement is tracked in https://github.com/instructlab/instructlab/issues/905.

Resolves: https://github.com/instructlab/instructlab/issues/909
Signed-off-by: Sébastien Han [seb@redhat.com](mailto:seb@redhat.com)