### PR TITLE
fix: ignore SIGINT when running the temp server

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -246,6 +246,24 @@ test_temp_server(){
     '
 }
 
+test_temp_server_sigint(){
+    expect -c '
+        set timeout 30
+        spawn ilab chat
+        expect "Starting a temporary server at"
+        send "hello!\r"
+        sleep 5
+        send "\003"
+        expect "Disconnected from client (via refresh/close)"
+        send "\003"
+        send "hello again\r"
+        sleep 1
+        expect {
+            "Connection error, try again" { exit 1 }
+        }
+    '
+}
+
 ########
 # MAIN #
 ########
@@ -260,5 +278,7 @@ test_generate
 test_server_shutdown_while_chatting
 cleanup
 test_temp_server
+cleanup
+test_temp_server_sigint
 
 exit 0

--- a/src/instructlab/server.py
+++ b/src/instructlab/server.py
@@ -6,12 +6,14 @@ from time import sleep
 import logging
 import multiprocessing
 import random
+import signal
 import socket
 
 # Third Party
 from llama_cpp import llama_chat_format
 from llama_cpp.server.app import create_app
 from llama_cpp.server.settings import Settings
+from uvicorn import Config
 import llama_cpp.server.app as llama_app
 import uvicorn
 
@@ -22,6 +24,20 @@ from .config import get_api_base
 
 class ServerException(Exception):
     """An exception raised when serving the API."""
+
+
+class Server(uvicorn.Server):
+    """Override uvicorn.Server to handle SIGINT."""
+
+    def handle_exit(self, sig, frame):
+        # type: (int, Optional[FrameType]) -> None
+        if (
+            # if this is the main process (`ilab serve`) we keep uvicorn's default behavior
+            not is_temp_server_running()
+            # if this is the child process (the temp server) we want to ignore the SIGINT signal
+            or sig != signal.SIGINT
+        ):
+            super().handle_exit(sig=sig, frame=frame)
 
 
 def ensure_server(
@@ -158,7 +174,8 @@ def server(
     logger.info(
         f"After application startup complete see http://{host}:{port}/docs for API."
     )
-    uvicorn.run(
+
+    config = Config(
         app,
         host=host,
         port=port,
@@ -166,6 +183,8 @@ def server(
         limit_concurrency=2,  # Make sure we only serve a single client at a time
         timeout_keep_alive=0,  # prevent clients holding connections open (we only have 1)
     )
+    s = Server(config)
+    s.run()
 
 
 def can_bind_to_port(host, port):
@@ -175,3 +194,8 @@ def can_bind_to_port(host, port):
             return True
         except socket.error:
             return False
+
+
+def is_temp_server_running():
+    """Check if the temp server is running."""
+    return multiprocessing.current_process().name != "MainProcess"


### PR DESCRIPTION
When we simply run `ilab chat`, a temporary server will run in the background and we can enjoy a great chat. However, if the chat response is interrupted with ctrl+C, the signal will be caught by uvicorn and then the server will be killed making further chat impossible and printing a large backtrace.

Another option was to run the temp server in a dedicated thread but this requires a bit more changes as well as the difficulty of handling the thread termination. This would have been handled by uvicorn natively since it is not setting up any signal handler but would still require us to handle it manually in our code.

Resolves: https://github.com/instructlab/instructlab/issues/883
Signed-off-by: Sébastien Han <seb@redhat.com>