### PR TITLE
fix: 'ilab init --non-interactive' does not ask questions anymore

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -131,15 +131,15 @@ def init(
     min_taxonomy,
 ):
     """Initializes environment for InstructLab"""
-    if exists(config.DEFAULT_CONFIG):
-        overwrite = click.confirm(
-            f"Found {config.DEFAULT_CONFIG} in the current directory, do you still want to continue?"
-        )
-        if not overwrite:
-            return
 
     clone_taxonomy_repo = True
     if interactive:
+        if exists(config.DEFAULT_CONFIG):
+            overwrite = click.confirm(
+                f"Found {config.DEFAULT_CONFIG} in the current directory, do you still want to continue?"
+            )
+            if not overwrite:
+                return
         click.echo(
             "Welcome to InstructLab CLI. This guide will help you to setup your environment."
         )


### PR DESCRIPTION
Previously when running `ilab init --non-interactive`, if a `config.yaml` was present it would ask whether it should be overwritten or not.
Now if the non-interactive mode is enabled the `config.yaml` will be overwritten.

Resolves https://github.com/instructlab/instructlab/issues/907
Signed-off-by: Sébastien Han [seb@redhat.com](mailto:seb@redhat.com)
