### PR TITLE
Remove the interaction test about "Barter Town"

### DIFF
--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -196,9 +196,6 @@ def linux_train(
         )
         return tokenizer.batch_decode([o[:-1] for o in outputs])[0]
 
-    model_generate(
-        "In excruciating detail, explain to me the nuances of who runs Barter Town."
-    )
     assistant_old_lst = [
         model_generate(d["user"]).split(response_template.strip())[-1].strip()
         for d in test_dataset


### PR DESCRIPTION
Remove this interaction from linux train, it was part of the Notebook that linux_train.py was based on, we're not looking at the output so it shouldn't be needed.

Fixes #897
