### PR TITLE
Simplify generation code

### DIFF
--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -28,7 +28,6 @@ from ..utils import (
     read_taxonomy,
 )
 from . import utils
-from .utils import GenerateException
 
 DEFAULT_PROMPT_TEMPLATE_MERLINITE = """\
 You are asked to come up with a set of 5 diverse task instructions under {{taxonomy}}{{" for the task \\"%s\\""|format(task_description)  if task_description}}. These task instructions will be given to a GPT model and we will evaluate the GPT model for completing the instructions.
@@ -183,9 +182,7 @@ def writeline2file(logfile, line):
 def post_process_gpt3_response(num_prompt_instructions, response, discarded_file):
     if response is None:
         return [], 0
-    raw_instructions = (
-        f"* Task {num_prompt_instructions + 1}\n" + response.message.content
-    )
+    raw_instructions = f"* Task {num_prompt_instructions + 1}\n" + response
     raw_instructions = re.split(r"\* Task \d+", raw_instructions)
     instructions = []
     discarded = 0
@@ -269,7 +266,6 @@ def get_instructions_from_model(
     api_key,
     model_name,
     num_prompt_instructions,
-    request_batch_size,
     temperature,
     top_p,
     output_file_discarded,
@@ -278,45 +274,37 @@ def get_instructions_from_model(
     tls_client_key,
     tls_client_passwd,
 ):
-    batch_inputs = []
-    for _ in range(request_batch_size):
-        # only sampling from the seed tasks
-        try:
-            prompt_instructions = random.sample(
-                instruction_data_pool, num_prompt_instructions
-            )
-        except ValueError as exc:
-            raise GenerateException(
-                f"There was a problem with the new data, please make sure the "
-                f"yaml is formatted correctly, and there is enough "
-                f"new data({num_prompt_instructions}+ Q&A))"
-            ) from exc
-        prompt = encode_prompt(prompt_instructions, prompt_template)
-        batch_inputs.append(prompt)
+    # only sampling from the seed tasks
+    try:
+        prompt_instructions = random.sample(
+            instruction_data_pool, num_prompt_instructions
+        )
+    except ValueError as exc:
+        raise utils.GenerateException(
+            f"There was a problem with the new data, please make sure the yaml is formatted correctly, and there is enough new data({num_prompt_instructions}+ Q&A)"
+        ) from exc
+    prompt = encode_prompt(prompt_instructions, prompt_template)
     decoding_args = utils.OpenAIDecodingArguments(
         temperature=temperature,
-        n=1,
-        # Hard-coded to maximize length.
-        # Requests will be automatically adjusted.
+        # Hard-coded to maximize length. Requests will be automatically adjusted.
         max_tokens=3072,
         top_p=top_p,
         stop=["* Task 5"],
     )
     request_start = time.time()
     try:
-        results = utils.openai_completion(
+        result = utils.openai_completion(
             api_base=api_base,
             api_key=api_key,
-            prompts=batch_inputs,
+            prompt=prompt,
             model_name=model_name,
             tls_insecure=tls_insecure,
             tls_client_cert=tls_client_cert,
             tls_client_key=tls_client_key,
             tls_client_passwd=tls_client_passwd,
-            batch_size=request_batch_size,
             decoding_args=decoding_args,
         )
-    except GenerateException as exc:
+    except utils.GenerateException as exc:
         # Attempt to log and gracefully recover from exceeding the server's
         # maximum context length. This won't work for all servers.
         #
@@ -335,18 +323,16 @@ def get_instructions_from_model(
     request_duration = time.time() - request_start
 
     post_process_start = time.time()
-    instruction_data = []
-    for result in results:
-        new_instructions, discarded = post_process_gpt3_response(
-            num_prompt_instructions, result, output_file_discarded
-        )
-        # make sure the generated instruction carried over extra fields
-        prompt_ins_0 = prompt_instructions[0]
-        for new_ins in new_instructions:
-            new_ins["taxonomy_path"] = prompt_ins_0["taxonomy_path"]
-            new_ins["task_description"] = prompt_ins_0["task_description"]
-            new_ins["document"] = prompt_ins_0["document"]
-        instruction_data += new_instructions
+    instruction_data, discarded = post_process_gpt3_response(
+        num_prompt_instructions, result, output_file_discarded
+    )
+
+    # make sure the generated instruction carried over extra fields
+    prompt_ins_0 = prompt_instructions[0]
+    for new_ins in instruction_data:
+        new_ins["taxonomy_path"] = prompt_ins_0["taxonomy_path"]
+        new_ins["task_description"] = prompt_ins_0["task_description"]
+        new_ins["document"] = prompt_ins_0["document"]
 
     post_process_duration = time.time() - post_process_start
     logger.debug(
@@ -371,7 +357,6 @@ def generate_data(
     num_cpus: Optional[int] = None,
     num_instructions_to_generate: Optional[int] = None,
     num_prompt_instructions=2,
-    request_batch_size=5,
     temperature=1.0,
     top_p=1.0,
     rouge_threshold: Optional[float] = None,
@@ -519,7 +504,6 @@ def generate_data(
             api_key,
             model_name,
             num_prompt_instructions,
-            request_batch_size,
             temperature,
             top_p,
             output_file_discarded,

--- a/src/instructlab/generator/utils.py
+++ b/src/instructlab/generator/utils.py
@@ -2,14 +2,11 @@
 
 # Standard
 from typing import Optional, Sequence, Union
-import copy
 import dataclasses
 import io
 import json
 import logging
-import math
 import os
-import sys
 
 # Third Party
 from openai import OpenAI, OpenAIError
@@ -32,7 +29,6 @@ class OpenAIDecodingArguments:
     max_tokens: int = 1800
     temperature: float = 0.2
     top_p: float = 1.0
-    n: int = 1
     stream: bool = False
     stop: Optional[Sequence[str]] = None
     presence_penalty: float = 0.0
@@ -46,13 +42,9 @@ def openai_completion(
     tls_client_cert,
     tls_client_key,
     tls_client_passwd,
-    prompts: Union[str, Sequence[str], Sequence[dict[str, str]], dict[str, str]],
+    prompt: str,
     decoding_args: OpenAIDecodingArguments,
     model_name="ggml-merlinite-7b-lab-Q4_K_M",
-    batch_size=1,
-    max_instances=sys.maxsize,
-    max_batches=sys.maxsize,
-    return_text=False,
     api_key=DEFAULT_API_KEY,
     **decoding_kwargs,
 ) -> Union[
@@ -68,116 +60,69 @@ def openai_completion(
         tls_client_cert: Path to the TLS client certificate to use
         tls_client_key: Path to the TLS client key to use
         tls_client_passwd: TLS client certificate password
-        prompts: A string or a list of strings to complete. If it is a chat model the strings
-            should be formatted as explained here:
-            https://github.com/openai/openai-python/blob/main/chatml.md.
-            If it is a chat model it can also be a dictionary (or list thereof) as explained here:
-            https://github.com/openai/openai-cookbook/blob/main/examples/How_to_format_inputs_to_ChatGPT_models.ipynb
+        prompt: A string
         decoding_args: Decoding arguments.
         model_name: Model name. Can be either in the format of "org/model" or just "model".
-        batch_size: Number of prompts to send in a single request. Only for non chat model.
-        max_instances: Maximum number of prompts to decode.
-        max_batches: Maximum number of batches to decode. This will be deprecated in the future.
-        return_text: If True, return text instead of full completion object (e.g. includes logprob).
         api_key: API key API key for API endpoint where model is hosted
         decoding_kwargs: Extra decoding arguments. Pass in `best_of` and `logit_bias` if needed.
 
     Returns:
-        A completion or a list of completions. Depending on return_text, return_openai_object,
-        and decoding_args.n, the completion type can be one of:
-            - a string (if return_text is True)
-            - an openai_object.OpenAIObject object (if return_text is False)
-            - a list of objects of the above types (if decoding_args.n > 1)
+            - a string
     """
-    is_single_prompt = isinstance(prompts, (str, dict))
-    if is_single_prompt:
-        prompts = [prompts]
+    shared_kwargs = {
+        "model": model_name,
+        **decoding_args.__dict__,
+        **decoding_kwargs,
+    }
 
-    if max_batches < sys.maxsize:
-        logging.warning(
-            "`max_batches` will be deprecated in the future, please use `max_instances` instead."
-            "Setting `max_instances` to `max_batches * batch_size` for now."
+    if not api_key:
+        # we need to explicitly set non-empty api-key, to ensure generate
+        # connects to our local server
+        api_key = "no_api_key"
+
+    # do not pass a lower timeout to this client since generating a dataset takes some time
+    # pylint: disable=R0801
+    orig_cert = (tls_client_cert, tls_client_key, tls_client_passwd)
+    cert = tuple(item for item in orig_cert if item)
+    verify = not tls_insecure
+    client = OpenAI(
+        base_url=api_base,
+        api_key=api_key,
+        http_client=httpx.Client(cert=cert, verify=verify),
+    )
+
+    # ensure the model specified exists on the server. with backends like vllm, this is crucial.
+    model_list = client.models.list().data
+    model_ids = []
+    for model in model_list:
+        model_ids.append(model.id)
+    if not any(model_name == m for m in model_ids):
+        if model_name == DEFAULT_MODEL_OLD:
+            logging.info(
+                "Model %s is not a full path. Try running ilab init or edit your config to have the full model path for serving, chatting, and generation.",
+                model_name,
+            )
+        raise GenerateException(
+            f"Model {model_name} is not served by the server. These are the served models {model_ids}"
         )
-        max_instances = max_batches * batch_size
 
-    prompts = prompts[:max_instances]
-    num_prompts = len(prompts)
-    prompt_batches = [
-        prompts[batch_id * batch_size : (batch_id + 1) * batch_size]
-        for batch_id in range(int(math.ceil(num_prompts / batch_size)))
+    messages = [
+        {"role": "system", "content": get_sysprompt()},
+        {"role": "user", "content": prompt},
     ]
 
-    completions = []
-    for batch_id, prompt_batch in enumerate(prompt_batches):
-        batch_decoding_args = copy.deepcopy(decoding_args)  # cloning the decoding_args
-
-        shared_kwargs = {
-            "model": model_name,
-            **batch_decoding_args.__dict__,
-            **decoding_kwargs,
-        }
-
-        if not api_key:
-            # we need to explicitly set non-empty api-key, to ensure generate
-            # connects to our local server
-            api_key = "no_api_key"
-
-        # do not pass a lower timeout to this client since generating a dataset takes some time
-        # pylint: disable=R0801
-        orig_cert = (tls_client_cert, tls_client_key, tls_client_passwd)
-        cert = tuple(item for item in orig_cert if item)
-        verify = not tls_insecure
-        client = OpenAI(
-            base_url=api_base,
-            api_key=api_key,
-            http_client=httpx.Client(cert=cert, verify=verify),
+    # Inference the model
+    try:
+        response = client.chat.completions.create(
+            messages=messages,
+            **shared_kwargs,
         )
+    except OpenAIError as exc:
+        raise GenerateException(
+            f"There was a problem connecting to the server {exc}"
+        ) from exc
 
-        # ensure the model specified exists on the server. with backends like vllm, this is crucial.
-        model_list = client.models.list().data
-        model_ids = []
-        for model in model_list:
-            model_ids.append(model.id)
-        if not any(model_name == m for m in model_ids):
-            if model_name == DEFAULT_MODEL_OLD:
-                logging.info(
-                    "Model %s is not a full path. Try running ilab init or edit your config to have the full model path for serving, chatting, and generation.",
-                    model_name,
-                )
-            raise GenerateException(
-                f"Model {model_name} is not served by the server. These are the served models {model_ids}"
-            )
-
-        messages = [
-            {"role": "system", "content": get_sysprompt()},
-            {"role": "user", "content": prompt_batch[batch_id]},
-        ]
-
-        # Inference the model
-        try:
-            response = client.chat.completions.create(
-                messages=messages,
-                **shared_kwargs,
-            )
-        except OpenAIError as exc:
-            raise GenerateException(
-                f"There was a problem connecting to the server {exc}"
-            ) from exc
-
-        completions.extend(response.choices)
-
-    if return_text:
-        completions = [completion.text for completion in completions]
-    if decoding_args.n > 1:
-        # make a nested list, where each entry is consecutive decoding_args.n of original entries.
-        completions = [
-            completions[i : i + decoding_args.n]
-            for i in range(0, len(completions), decoding_args.n)
-        ]
-    if is_single_prompt:
-        # Return non-tuple if only 1 input and 1 generation.
-        (completions,) = completions
-    return completions
+    return response.choices[0].message.content
 
 
 def _make_w_io_base(f, mode: str):


### PR DESCRIPTION
The post_process_gpt3_response function takes a lot of params that we don't use and returns a format we need to convert. Because of this we're looping on
datastructures for no reason. Remove it to simplify generation code.

Fixes: #485

