### PR TITLE
chat: fix AttributeError crash on -qq with short context

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -21,6 +21,8 @@ done
 PID_SERVE=
 PID_CHAT=
 
+chat_shot="ilab chat -qq"
+
 cleanup() {
     set +e
     if [ "${1:-0}" -ne 0 ]; then
@@ -117,12 +119,10 @@ test_ctx_size(){
     wait_for_server
 
     # Should succeed
-    ilab chat -qq "Hello"
+    ${chat_shot} "Hello"
 
     # now chat with the server and exceed the context size
-    ilab chat &> "$TEST_CTX_SIZE_LAB_CHAT_LOG_FILE" <<EOF &
-hello, I am a ci message that should not finish because I am too long for the context window, tell me about your day please, I love to hear all about it, tell me about the time you could only take 55 tokens
-EOF
+    ${chat_shot} "hello, I am a ci message that should not finish because I am too long for the context window, tell me about your day please, I love to hear all about it, tell me about the time you could only take 55 tokens" > "$TEST_CTX_SIZE_LAB_CHAT_LOG_FILE" &
     PID_CHAT=$!
 
     # look for the context size error in the server logs

--- a/src/instructlab/chat/chat.py
+++ b/src/instructlab/chat/chat.py
@@ -305,7 +305,7 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
         message = {"role": role, "content": content}
         self.info["messages"].append(message)
 
-    def start_prompt(self, content=None, box=True, logger=None):
+    def start_prompt(self, logger, content=None, box=True):
         handlers = {
             "/q": self._handle_quit,
             "quit": self._handle_quit,
@@ -523,7 +523,7 @@ def chat_cli(
         if not qq:
             print(f"{PROMPT_PREFIX}{question}")
         try:
-            ccb.start_prompt(question, box=(not qq))
+            ccb.start_prompt(logger, content=question, box=(not qq))
         except ChatException as exc:
             raise ChatException(f"API issue found while executing chat: {exc}")
         except KeyboardInterrupt:
@@ -539,7 +539,7 @@ def chat_cli(
     # Start chatting
     while True:
         try:
-            ccb.start_prompt(logger=logger)
+            ccb.start_prompt(logger)
         except KeyboardInterrupt:
             continue
         except ChatException as exc:


### PR DESCRIPTION
Closes #948

Always pass logger to `start_prompt`.