### PR TITLE
Don't dump test data on each generate iteration

### DIFF
--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -297,6 +297,34 @@ def get_instructions_from_model(
     return instruction_data, discarded
 
 
+def unescape(s):
+    return bytes(s, "utf-8").decode("utf-8")
+
+
+def dump_test_data(fname, data):
+    test_data = []
+    for seed_example in data:
+        user = seed_example["instruction"]
+
+        if len(seed_example["input"]) > 0:
+            user += "\n" + seed_example["input"]
+        try:
+            test_data.append(
+                {
+                    "system": utils.get_sysprompt(),
+                    "user": unescape(user),
+                    "assistant": unescape(seed_example["output"]),
+                }
+            )
+        except TypeError as exc:
+            click.secho(
+                f"Error reading seed examples: {exc}. Please make sure your answers are verbose enough.",
+                fg="red",
+            )
+            raise click.exceptions.Exit(1)
+    utils.dump_jsonl(fname, test_data)
+
+
 def generate_data(
     logger,
     api_base,
@@ -343,9 +371,6 @@ def generate_data(
     if not seeds:
         raise SystemExit("Nothing to generate. Exiting.")
 
-    def unescape(s):
-        return bytes(s, "utf-8").decode("utf-8")
-
     name = Path(model_name).stem  # Just in case it is a file path
     date_suffix = datetime.now().replace(microsecond=0).isoformat().replace(":", "_")
     output_file = f"generated_{name}_{date_suffix}.json"
@@ -356,11 +381,7 @@ def generate_data(
     )
     logger.debug(f"Generating to: {os.path.join(output_dir, output_file)}")
 
-    # Dump test data
-    test_data = []
     for seed_example in seed_instruction_data:
-        user = seed_example["instruction"]
-
         documents = seed_example["document"]
         if documents:
             seed_example["document"] = chunk_document(
@@ -369,23 +390,7 @@ def generate_data(
                 chunk_word_count=chunk_word_count,
             )
 
-        if len(seed_example["input"]) > 0:
-            user += "\n" + seed_example["input"]
-        try:
-            test_data.append(
-                {
-                    "system": utils.get_sysprompt(),
-                    "user": unescape(user),
-                    "assistant": unescape(seed_example["output"]),
-                }
-            )
-        except TypeError as exc:
-            click.secho(
-                f"Error reading seed examples: {exc}. Please make sure your answers are verbose enough.",
-                fg="red",
-            )
-            raise click.exceptions.Exit(1)
-    utils.dump_jsonl(os.path.join(output_dir, output_file_test), test_data)
+    dump_test_data(os.path.join(output_dir, output_file_test), seed_instruction_data)
 
     request_idx = 0
     # load the LM-generated instructions

--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from functools import partial
 from pathlib import Path
 from typing import Optional
-import json
 import multiprocessing
 import os
 import random
@@ -505,20 +504,8 @@ def generate_data(
                     "assistant": unescape(synth_example["output"]),
                 }
             )
-        # utils.jdump(train_data, os.path.join(output_dir, output_file_train))
-        with open(
-            os.path.join(output_dir, output_file_train), "w", encoding="utf-8"
-        ) as outfile:
-            for entry in train_data:
-                json.dump(entry, outfile, ensure_ascii=False)
-                outfile.write("\n")
-        # utils.jdump(test_data, os.path.join(output_dir, output_file_test))
-        with open(
-            os.path.join(output_dir, output_file_test), "w", encoding="utf-8"
-        ) as outfile:
-            for entry in test_data:
-                json.dump(entry, outfile, ensure_ascii=False)
-                outfile.write("\n")
+        utils.dump_jsonl(os.path.join(output_dir, output_file_train), train_data)
+        utils.dump_jsonl(os.path.join(output_dir, output_file_test), test_data)
 
     if total_discarded or total_rouged:
         logger.info(

--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -346,6 +346,17 @@ def generate_data(
     def unescape(s):
         return bytes(s, "utf-8").decode("utf-8")
 
+    name = Path(model_name).stem  # Just in case it is a file path
+    date_suffix = datetime.now().replace(microsecond=0).isoformat().replace(":", "_")
+    output_file = f"generated_{name}_{date_suffix}.json"
+    output_file_train = f"train_{name}_{date_suffix}.jsonl"
+    output_file_test = f"test_{name}_{date_suffix}.jsonl"
+    output_file_discarded = os.path.join(
+        output_dir, f"discarded_{name}_{date_suffix}.log"
+    )
+    logger.debug(f"Generating to: {os.path.join(output_dir, output_file)}")
+
+    # Dump test data
     test_data = []
     for seed_example in seed_instruction_data:
         user = seed_example["instruction"]
@@ -374,16 +385,7 @@ def generate_data(
                 fg="red",
             )
             raise click.exceptions.Exit(1)
-
-    name = Path(model_name).stem  # Just in case it is a file path
-    date_suffix = datetime.now().replace(microsecond=0).isoformat().replace(":", "_")
-    output_file = f"generated_{name}_{date_suffix}.json"
-    output_file_train = f"train_{name}_{date_suffix}.jsonl"
-    output_file_test = f"test_{name}_{date_suffix}.jsonl"
-    output_file_discarded = os.path.join(
-        output_dir, f"discarded_{name}_{date_suffix}.log"
-    )
-    logger.debug(f"Generating to: {os.path.join(output_dir, output_file)}")
+    utils.dump_jsonl(os.path.join(output_dir, output_file_test), test_data)
 
     request_idx = 0
     # load the LM-generated instructions
@@ -505,7 +507,6 @@ def generate_data(
                 }
             )
         utils.dump_jsonl(os.path.join(output_dir, output_file_train), train_data)
-        utils.dump_jsonl(os.path.join(output_dir, output_file_test), test_data)
 
     if total_discarded or total_rouged:
         logger.info(

--- a/src/instructlab/generator/utils.py
+++ b/src/instructlab/generator/utils.py
@@ -205,3 +205,10 @@ def jload(f, mode="r"):
     """Load a .json file into a dictionary."""
     with _make_r_io_base(f, mode) as f_:
         return json.load(f_)
+
+
+def dump_jsonl(fpath, data):
+    with open(fpath, "w", encoding="utf-8") as outfile:
+        for entry in data:
+            json.dump(entry, outfile, ensure_ascii=False)
+            outfile.write("\n")


### PR DESCRIPTION
**Description of your changes:**

The series makes generate function no longer write test data over and over on each iteration. Also consolidates some common code to dump jsonl data into different files.

NOTE: this PR does not change behavior for train_* and generated_* and discarded_* files, which are still dumped on every iteration. Only test_* (seed examples from qna taxonomy) is optimized.

This is https://github.com/instructlab/instructlab/pull/510 reposted.