### PR TITLE
Use pytest fixture to mock mlx package

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Standard
+from unittest import mock
+import sys
+
 # Third Party
 import pytest
 
@@ -11,3 +15,19 @@ from .taxonomy import MockTaxonomy
 def taxonomy_dir(tmp_path):
     with MockTaxonomy(tmp_path) as taxonomy:
         yield taxonomy
+
+
+@pytest.fixture(scope="class")
+def mock_mlx_package():
+    """Add mocked 'mlx' modules to sys.path
+
+    The 'mlx' package is only available on Apple Silicon. This fixture
+    patches sys.modules so local imports and mock-patching of 'mlx' attributes
+    works.
+    """
+    mlx_modules = {
+        name: mock.MagicMock()
+        for name in ["mlx", "mlx.core", "mlx.nn", "mlx.optimizers", "mlx.utils"]
+    }
+    with mock.patch.dict(sys.modules, mlx_modules):
+        yield


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
See #814

**Description of your changes:**

Tests now use a pytest fixture to mock-patch the mlx package. This resolves a problem with my old `mock_mlx` wrapper, which broke testing with Python 3.9 and 3.10

Kudos to Ihar Hrachyshka for discovering the problem and reporting it in issue #814.