### PR TITLE
fix four_bit_quant VRAM check for cuda

### DIFF
--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -114,6 +114,10 @@ def linux_train(
     if device.type == "cuda":
         # estimated by watching nvtop / radeontop during training
         min_vram = 11 if four_bit_quant else 17
+
+        # convert from gibibytes to bytes, torch.cuda.mem_get_info() returns bytes
+        min_vram = min_vram * 1024**3
+
         report_cuda_device(device, min_vram)
 
     print("LINUX_TRAIN.PY: LOADING DATASETS")


### PR DESCRIPTION
# Changes

When using cuda and performing the VRAM check, the value was being passed was either 11 or 17 and was meant to be an expession of gibibytes. However, it was never converted to bytes before the comparison and therefore always evaluated to true because torch.cuda.mem_get_info(device)[0] returns a value expressed in bytes. This patch does the conversion to bytes before the comparison.

