### PR TITLE
Use matrix configuration for tox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           tox \
             -x testenv:unitcov.system_site_packages=True \
-            -e unitcov
+            -e py3-unitcov
 
       - name: Install the expect package
         run: |
@@ -84,4 +84,4 @@ jobs:
         run: |
           tox \
             -x testenv:functional.system_site_packages=True \
-            -e functional
+            -e py3-functional

--- a/CONTRIBUTING/CONTRIBUTING.md
+++ b/CONTRIBUTING/CONTRIBUTING.md
@@ -102,13 +102,13 @@ Unit tests are enforced by the CI system using [pytest](https://docs.pytest.org/
 Running unit tests can be done with:
 
 ```shell
-tox -e unit
+tox -e py3-unit
 ```
 
 By default, all tests found within the `tests` directory are run. However, specific unit tests can run by passing filenames, classes and/or methods to `pytest` using tox positional arguments.  The following example invokes a single test method `test_diff_invalid_base` within the `TestLabDiff` class that is declared in the `tests/test_lab_diff.py` file:
 
 ```shell
-tox -e unit -- tests/test_lab_diff.py::TestLabDiff::test_diff_invalid_base
+tox -e py3-unit -- tests/test_lab_diff.py::TestLabDiff::test_diff_invalid_base
 ```
 
 #### Functional tests
@@ -118,7 +118,7 @@ Functional tests are enforced by the CI system. When making changes, run the tes
 Running functional tests can be done with:
 
 ```shell
-tox -e functional
+tox -e py3-functional
 ```
 
 #### Coding style

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ toolbox-rm:  ## Stop and remove toolbox container
 
 .PHONY: tests
 tests: ## Run tox -e unit against code
-	tox -e unit
+	tox -e py3-unit
 
 .PHONY: verify
 verify: ## Run tox -e fmt,lint,spellcheck against code

--- a/tox.ini
+++ b/tox.ini
@@ -1,29 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tox]
-envlist = fmt, lint, unit, functional, spellcheck
+# py3-unit runs unit tests with 'python3'
+# py311-unit runs the same tests with 'python3.11'
+envlist = fmt, lint, spellcheck, py3-{unit, functional}
+minversion = 4.4
 
 [testenv]
+description = run tests (unit, unitcov, functional)
 # Use PyTorch CPU build instead of CUDA build in test envs. CUDA dependencies
 # are huge. This reduces venv from 5.7 GB to 1.5 GB.
 setenv =
     PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
-
-[testenv:unit]
-description = run unit tests
+package = wheel
+wheel_build_env = pkg
 deps = -r requirements-dev.txt
 commands =
     ilab --version
     {envpython} -m instructlab --version
-    {envpython} -m pytest {posargs:tests}
-
-[testenv:unitcov]
-description = run unit tests with coverage
-deps = -r requirements-dev.txt
-commands =
-    ilab --version
-    {envpython} -m instructlab --version
-    {envpython} -m pytest --cov=instructlab --cov-report term --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html {posargs:tests -m "not (examples or slow)"} -W error::UserWarning
+    unit: {envpython} -m pytest {posargs:tests}
+    unitcov: {envpython} -W error::UserWarning -m pytest --cov=instructlab --cov-report term --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html {posargs:tests -m "not (examples or slow)"}
+    functional: ./scripts/functional-tests.sh
+allowlist_externals =
+    functional: ./scripts/functional-tests.sh
 
 # "lint" and "fmt" targets don't build and install the project to speed up
 # testing. The "fmt" only needs pre-commit.


### PR DESCRIPTION
# Changes

**Description of your changes:**

The previous `tox.ini` used fixed testenvs that used the default `basepython`, which typically points to `python3`. It was not easily possible to run tests with another Python version.

The new configuration uses tox's matrix configuration feature. The default targets for tests are now `py3-unit`, `py3-unitcov`, and `py3-functional`. These targets use `python3` as base Python. With the new configurion it's now possible to run tests with different Python versions. For example `tox -e py39-unit` runs unit tests with `python3.9`.

Tox is also configured to use wheel with a common wheel env for sdist and binary wheel dist. This speeds up purelib wheel creation.
