### PR TITLE
Use 'spawn' multiprocessing method instead of fork

### DIFF
--- a/src/instructlab/config.py
+++ b/src/instructlab/config.py
@@ -24,6 +24,8 @@ DEFAULT_NUM_INSTRUCTIONS = 100
 DEFAULT_PROMPT_FILE = "prompt.txt"
 DEFAULT_GENERATED_FILES_OUTPUT_DIR = "generated"
 DEFAULT_CONNECTION_TIMEOUT = httpx.Timeout(timeout=30.0)
+# use spawn start method, fork is not thread-safe
+DEFAULT_MULTIPROCESSING_START_METHOD = "spawn"
 
 
 class ConfigException(Exception):

--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -3,10 +3,10 @@
 # Standard
 from datetime import datetime
 from functools import partial
-from multiprocessing import Pool
 from pathlib import Path
 from typing import Optional
 import json
+import multiprocessing
 import os
 import random
 import re
@@ -20,6 +20,7 @@ import click
 import tqdm
 
 # Local
+from ..config import DEFAULT_MULTIPROCESSING_START_METHOD
 from ..utils import chunk_document, read_taxonomy
 from . import utils
 from .utils import GenerateException
@@ -418,6 +419,8 @@ def generate_data(
             "Synthesizing new instructions. If you aren't satisfied with the generated instructions, interrupt training (Ctrl-C) and try adjusting your YAML files. Adding more examples may help."
         )
 
+    mpctx = multiprocessing.get_context(DEFAULT_MULTIPROCESSING_START_METHOD)
+
     all_taxonomy_paths = list(set(e["taxonomy_path"] for e in seed_instruction_data))
     total_discarded = 0
     total_rouged = 0
@@ -460,7 +463,7 @@ def generate_data(
             new_instruction_tokens = scorer._tokenizer.tokenize(
                 instruction_data_entry["instruction"]
             )
-            with Pool(num_cpus) as p:
+            with mpctx.Pool(num_cpus) as p:
                 rouge_scores = p.map(
                     partial(rouge_scorer._score_lcs, new_instruction_tokens),
                     all_instruction_tokens,

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -18,11 +18,15 @@ from transformers import (
 from trl import DataCollatorForCompletionOnlyLM, SFTTrainer
 import torch
 
-# First Party
-from instructlab.chat.chat import CONTEXTS
+# Local
+from ..chat.chat import CONTEXTS
+from ..config import DEFAULT_MULTIPROCESSING_START_METHOD
 
 # TODO CPU: Look into using these extensions
 # import intel_extension_for_pytorch as ipex
+
+# 'fork' incompatible with some hardware accelerators
+torch.multiprocessing.set_start_method(DEFAULT_MULTIPROCESSING_START_METHOD)
 
 
 class StoppingCriteriaSub(StoppingCriteria):


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves #956

**Description of your changes:**

Multiprocessing uses `fork` as default start method on Linux. Windows and macOS default to `spawn`. The `fork` method is not safe in multi-threaded environments. It is also incompatible with some hardware accelerators.

Use `spawn` on all platforms.
