### PR TITLE
diff: Rework --quiet logic and handle file without needing --quiet

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -249,34 +249,36 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
         logger = logging.getLogger(__name__)
     else:
         logger = ctx.obj.logger
-    if quiet:
-        try:
-            read_taxonomy(logger, taxonomy_path, taxonomy_base, yaml_rules)
-        except (SystemExit, yaml.YAMLError) as exc:
-            raise SystemExit(1) from exc
-        return
-    try:
-        updated_taxonomy_files = get_taxonomy_diff(taxonomy_path, taxonomy_base)
-    except (SystemExit, GitError) as exc:
-        click.secho(
-            f"Reading taxonomy failed with the following error: {exc}",
-            fg="red",
-        )
-        raise SystemExit(1) from exc
-    for f in updated_taxonomy_files:
-        click.echo(f)
+
+    if not quiet:
+        is_file = os.path.isfile(taxonomy_path)
+        if is_file:  # taxonomy_path is file
+            click.echo(taxonomy_path)
+        else:  # taxonomy_path is dir
+            try:
+                updated_taxonomy_files = get_taxonomy_diff(taxonomy_path, taxonomy_base)
+            except (SystemExit, GitError) as exc:
+                click.secho(
+                    f"Reading taxonomy failed with the following error: {exc}",
+                    fg="red",
+                )
+                raise SystemExit(1) from exc
+            for f in updated_taxonomy_files:
+                click.echo(f)
     try:
         read_taxonomy(logger, taxonomy_path, taxonomy_base, yaml_rules)
     except (SystemExit, yaml.YAMLError) as exc:
-        click.secho(
-            f"Reading taxonomy failed with the following error: {exc}",
-            fg="red",
-        )
+        if not quiet:
+            click.secho(
+                f"Reading taxonomy failed with the following error: {exc}",
+                fg="red",
+            )
         raise SystemExit(1) from exc
-    click.secho(
-        f"Taxonomy in /{taxonomy_path}/ is valid :)",
-        fg="green",
-    )
+    if not quiet:
+        click.secho(
+            f"Taxonomy in /{taxonomy_path}/ is valid :)",
+            fg="green",
+        )
 
 
 # ilab list => ilab diff

--- a/tests/taxonomy.py
+++ b/tests/taxonomy.py
@@ -46,12 +46,14 @@ class MockTaxonomy:
         """List untracked files in the repository"""
         return self._repo.untracked_files
 
-    def create_untracked(self, rel_path: str, contents: Optional[bytes] = None) -> None:
+    def create_untracked(self, rel_path: str, contents: Optional[bytes] = None) -> Path:
         """Create a new untracked file in the repository.
 
         Args:
             rel_path (str): Relative path (from repository root) to the file.
             contents (bytes): (optional) Byte string to be written to the file.
+        Returns:
+            file_path: The path to the created file.
         """
         taxonomy_path = Path(rel_path)
         assert not taxonomy_path.is_absolute()
@@ -62,16 +64,20 @@ class MockTaxonomy:
             file_path.write_text(TEST_VALID_COMPOSITIONAL_SKILL_YAML, encoding="utf-8")
         else:
             file_path.write_bytes(contents)
+        return file_path
 
-    def add_tracked(self, rel_path: str) -> None:
+    def add_tracked(self, rel_path: str) -> Path:
         """Add a new tracked file to the repository (and commits it).
 
         Args:
             rel_path (str): Relative path (from repository root) to the file.
+        Returns:
+            file_path: The path to the added file.
         """
-        self.create_untracked(rel_path)
+        file_path = self.create_untracked(rel_path)
         self._repo.index.add([rel_path])
         self._repo.index.commit("new commit")
+        return file_path
 
     def remove_file(self, rel_path: str) -> None:
         """Remove a file in the repository (tracked or not)

--- a/tests/test_lab_diff.py
+++ b/tests/test_lab_diff.py
@@ -149,6 +149,25 @@ class TestLabDiff:
             assert f"Taxonomy in /{self.taxonomy.root}/ is valid :)" in result.output
             assert result.exit_code == 0
 
+    def test_diff_valid_yaml_file(self):
+        with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
+            valid_yaml_file = "compositional_skills/qna_valid.yaml"
+            file_path = self.taxonomy.create_untracked(valid_yaml_file, qnafile.read())
+            runner = CliRunner()
+            result = runner.invoke(
+                lab.cli,
+                [
+                    "--config=DEFAULT",
+                    "diff",
+                    "--taxonomy-base",
+                    TAXONOMY_BASE,
+                    "--taxonomy-path",
+                    file_path,
+                ],
+            )
+            assert f"Taxonomy in /{file_path}/ is valid :)" in result.output
+            assert result.exit_code == 0
+
     def test_diff_valid_yaml_quiet(self):
         with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
             valid_yaml_file = "compositional_skills/qna_valid.yaml"
@@ -163,6 +182,26 @@ class TestLabDiff:
                     TAXONOMY_BASE,
                     "--taxonomy-path",
                     self.taxonomy.root,
+                    "--quiet",
+                ],
+            )
+            assert result.output == ""
+            assert result.exit_code == 0
+
+    def test_diff_valid_yaml_quiet_file(self):
+        with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
+            valid_yaml_file = "compositional_skills/qna_valid.yaml"
+            file_path = self.taxonomy.create_untracked(valid_yaml_file, qnafile.read())
+            runner = CliRunner()
+            result = runner.invoke(
+                lab.cli,
+                [
+                    "--config=DEFAULT",
+                    "diff",
+                    "--taxonomy-base",
+                    TAXONOMY_BASE,
+                    "--taxonomy-path",
+                    file_path,
                     "--quiet",
                 ],
             )


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves #796

**Description of your changes:**

The logic is organized so there is not separate work paths for quiet and non-quiet. The code now properly identifies and handles single files.

An exception in the non-quiet code when reading the repo now results in a failing exit code.


