### PR TITLE
Chunk docs on spaces for really long lines

### DIFF
--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -34,6 +34,8 @@ rules:
     max: 120
 """
 
+DEFAULT_CHUNK_OVERLAP = 100
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(levelname)s %(asctime)s %(filename)s:%(lineno)d %(message)s",
@@ -237,6 +239,14 @@ def git_clone_checkout(
     return repo
 
 
+def num_tokens_from_words(num_words) -> int:
+    return int(num_words * 1.3)  # 1 word ~ 1.3 token
+
+
+def num_chars_from_tokens(num_tokens) -> int:
+    return int(num_tokens * 4)  # 1 token ~ 4 English character
+
+
 def chunk_document(documents: List, server_ctx_size, chunk_word_count) -> List[str]:
     """
     Iterates over the documents and splits them into chunks based on the word count provided by the user.
@@ -247,7 +257,7 @@ def chunk_document(documents: List, server_ctx_size, chunk_word_count) -> List[s
     Returns:
          List[str]: List of chunked documents.
     """
-    no_tokens_per_doc = int(chunk_word_count * 1.3)  # 1 word ~ 1.3 token
+    no_tokens_per_doc = num_tokens_from_words(chunk_word_count)
     if no_tokens_per_doc > int(server_ctx_size - 1024):
         raise ValueError(
             "Error: {}".format(
@@ -259,8 +269,8 @@ def chunk_document(documents: List, server_ctx_size, chunk_word_count) -> List[s
     content = []
     text_splitter = RecursiveCharacterTextSplitter(
         separators=["\n\n", "\n", " "],
-        chunk_size=int(no_tokens_per_doc * 4),  # 1 token ~ 4 English character
-        chunk_overlap=100,
+        chunk_size=num_chars_from_tokens(no_tokens_per_doc),
+        chunk_overlap=DEFAULT_CHUNK_OVERLAP,
     )
 
     for docs in documents:

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -258,7 +258,7 @@ def chunk_document(documents: List, server_ctx_size, chunk_word_count) -> List[s
         )
     content = []
     text_splitter = RecursiveCharacterTextSplitter(
-        separators=["\n\n", "\n"],
+        separators=["\n\n", "\n", " "],
         chunk_size=int(no_tokens_per_doc * 4),  # 1 token ~ 4 English character
         chunk_overlap=100,
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -50,12 +50,12 @@ class TestUtils(unittest.TestCase):
             chunk_word_count=chunk_words,
             server_ctx_size=4096,
         )
-        # convert words to characters as done in chunk_document
-        max_chunk_length = chunk_words * 1.3 * 4
-        max_chunk_length += 100  # add in the chunk overlap
-        max_chunk_length += 50  # and a bit extra for some really long words
+        max_tokens = utils.num_tokens_from_words(chunk_words)
+        max_chars = utils.num_chars_from_tokens(max_tokens)
+        max_chars += utils.DEFAULT_CHUNK_OVERLAP  # add in the chunk overlap
+        max_chars += 50  # and a bit extra for some really long words
         for chunk in chunks:
-            assert len(chunk) <= max_chunk_length
+            assert len(chunk) <= max_chars
 
     @patch(
         "instructlab.utils.git_clone_checkout",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,6 +43,20 @@ class TestUtils(unittest.TestCase):
             f"{exc.exception}",
         )
 
+    def test_chunk_docs_long_lines(self):
+        chunk_words = 50
+        chunks = utils.chunk_document(
+            documents=testdata.long_line_documents,
+            chunk_word_count=chunk_words,
+            server_ctx_size=4096,
+        )
+        # convert words to characters as done in chunk_document
+        max_chunk_length = chunk_words * 1.3 * 4
+        max_chunk_length += 100  # add in the chunk overlap
+        max_chunk_length += 50  # and a bit extra for some really long words
+        for chunk in chunks:
+            assert len(chunk) <= max_chunk_length
+
     @patch(
         "instructlab.utils.git_clone_checkout",
         return_value=Mock(spec=git.Repo, working_dir="tests/testdata/temp_repo"),

--- a/tests/testdata/testdata.py
+++ b/tests/testdata/testdata.py
@@ -11,6 +11,19 @@ documents = [
       called Gettier cases that provoked alternative definitions."""
 ]
 
+long_line_documents = [
+    (
+        "Knowledge is an awareness of facts, a familiarity with individuals and situations,"
+        "or a practical skill. Knowledge of facts, also called propositional knowledge, is often characterized "
+        "as true belief that is distinct from opinion or guesswork by virtue of justification. "
+        "While there is wide agreement among philosophers that propositional knowledge is a form of true belief, "
+        "many controversies focus on justification. This includes questions like how to understand justification, "
+        "whether it is needed at all, and whether something else besides it is needed. "
+        "These controversies intensified in the latter half of the 20th century due to a series of thought experiments "
+        "called Gettier cases that provoked alternative definitions."
+    )
+]
+
 knowledge_seed_instruction = [
     {
         "instruction": "What is this knowledge about?",


### PR DESCRIPTION
While we still prefer chunking on paragraphs and newlines, also allow chunking documents on spaces to handle cases where markdown files have really long lines so that we don't blow up the context window.

This change adds a test for the same that asserts our chunked documents are under an expected size. The test failed before adding the chunking on spaces and passes afterwards.

Fixes #968

