### PR TITLE
Use default context for ensure_server

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -510,6 +510,7 @@ def generate(
     finally:
         if server_process:
             server_process.terminate()
+            server_process.join(timeout=30)
 
 
 @cli.command()
@@ -648,6 +649,7 @@ def chat(
     finally:
         if server_process:
             server_process.terminate()
+            server_process.join(timeout=30)
 
 
 @cli.command()

--- a/src/instructlab/server.py
+++ b/src/instructlab/server.py
@@ -18,7 +18,7 @@ import uvicorn
 
 # Local
 from .client import ClientException, list_models
-from .config import DEFAULT_MULTIPROCESSING_START_METHOD, get_api_base
+from .config import get_api_base
 
 
 class ServerException(Exception):
@@ -62,8 +62,8 @@ def ensure_server(
         return (None, None)
     except ClientException:
         tried_ports = set()
-        # use spawn start method, fork is not thread-safe
-        mpctx = multiprocessing.get_context(DEFAULT_MULTIPROCESSING_START_METHOD)
+        # TODO: use default server, "spawn" doesn't work?
+        mpctx = multiprocessing.get_context(None)
         # use a queue to communicate between the main process and the server process
         queue = mpctx.Queue()
         port = random.randint(1024, 65535)


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Related to #957

**Description of your changes:**

Use default multiprocessing default context for `ensure_server` to unblock contributors. For some unknown reasons, `spawn` does not work.

`ensure_server` uses a multiprocessing Process to run a server process. The exit path must wait for the process to finish after `p.terminate()`. Otherwise the parent process might go away before the client can signal the parent that it is gone.



