### PR TITLE
fix: remove useless nc command

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -28,7 +28,8 @@ cleanup() {
     fi
     for pid in $PID_SERVE $PID_CHAT; do
         if [ -n "$pid" ]; then
-            kill $pid
+            kill "$pid"
+            wait "$pid"
         fi
     done
     rm -f "$TEST_CTX_SIZE_LAB_SERVE_LOG_FILE" \

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -234,8 +234,6 @@ EOF
 }
 
 test_temp_server(){
-    nc -l 8000 --keep-open &
-    PID_SERVE=$!
     sed -i 's/INFO/DEBUG/g' config.yaml
     expect -c '
         set timeout 120


### PR DESCRIPTION
The test does not need to listen on 8000 to active the temp server. The
temp server will run if 8000 is not present and choose a random port to
listen on. The `nc` line was not needed.

Fixes: https://github.com/instructlab/instructlab/issues/977
Signed-off-by: Sébastien Han <seb@redhat.com>
