### PR TITLE
AMD ROCm 6.0 container on RHEL ubi9-python311

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -72,7 +72,9 @@ Quantizing
 Radeon
 RDNA
 README
+RHEL
 ROCm
+ROCm's
 RTX
 RX
 Salawu
@@ -91,6 +93,7 @@ th
 th
 tl
 tox
+UBI
 unquantized
 USM
 venv

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,18 @@ CUDA_DEPS = \
 	$(COMMON_DEPS) \
 	$(NULL)
 
-ROCM_CONTAINERFILE = containers/rocm/Containerfile
-ROCM_DEPS = \
-	$(ROCM_CONTAINERFILE) \
+ROCM_F40_CONTAINERFILE = containers/rocm/Containerfile.f40
+ROCM_F40_DEPS = \
+	$(ROCM_F40_CONTAINERFILE) \
 	$(COMMON_DEPS) \
 	containers/rocm/remove-gfx.sh \
+	$(NULL)
+
+ROCM_UBI9_CONTAINERFILE = containers/rocm/Containerfile.ubi9
+ROCM_UBI9_DEPS = \
+	$(ROCM_UBI9_UBICONTAINERFILE) \
+	$(COMMON_DEPS) \
+	containers/rocm/rocm60.repo \
 	$(NULL)
 
 # so users can do "make rocm-gfx1100 rocm-toolbox"
@@ -61,7 +68,7 @@ define build-rocm =
 		--build-arg HSA_OVERRIDE_GFX_VERSION=$(2) \
 		-t $(CONTAINER_PREFIX):rocm-$(1) \
 		-t $(CONTAINER_PREFIX):rocm \
-		-f $(ROCM_CONTAINERFILE) \
+		-f $(ROCM_F40_CONTAINERFILE) \
 		.
 endef
 
@@ -78,33 +85,40 @@ rocm:   ## Build container for AMD ROCm (auto-detect the ROCm GPU arch)
 .PHONY: rocm-gfx1100 rocm-rdna3 rocm-gfx1101 rocm-gfx1102
 rocm-rdna3 rocm-gfx1101 rocm-gfx1102: rocm-gfx1100
 
-rocm-gfx1100: $(ROCM_DEPS)  ## Build container for AMD ROCm RDNA3 (Radeon RX 7000 series)
+rocm-gfx1100: $(ROCM_F40_DEPS)  ## Build container for AMD ROCm RDNA3 (Radeon RX 7000 series)
 	$(call build-rocm,gfx1100,11.0.0)
 
 # RDNA2 / Radeon RX 6000 series
 .PHONY: rocm-gfx1030 rocm-rdna2 rocm-gfx1031
 rocm-rdna2 rocm-gfx1031: rocm-gfx1030
 
-rocm-gfx1030: $(ROCM_DEPS)  ## Build container for AMD ROCm RDNA2 (Radeon RX 6000 series)
+rocm-gfx1030: $(ROCM_F40_DEPS)  ## Build container for AMD ROCm RDNA2 (Radeon RX 6000 series)
 	$(call build-rocm,gfx1030,10.3.0)
 
 # untested older cards
 # Fedora
 .PHONY: rocm-gfx90a
-rocm-gfx90a: $(ROCM_DEPS)  ## Build container for AMD ROCm gfx90a (untested)
+rocm-gfx90a: $(ROCM_F40_DEPS)  ## Build container for AMD ROCm gfx90a (untested)
 	$(call build-rocm,gfx90a,9.0.10)
 
 .PHONY: rocm-gfx908
-rocm-gfx908: $(ROCM_DEPS)  ## Build container for AMD ROCm gfx908 (untested)
+rocm-gfx908: $(ROCM_F40_DEPS)  ## Build container for AMD ROCm gfx908 (untested)
 	$(call build-rocm,gfx908,9.0.8)
 
 .PHONY: rocm-gfx906
-rocm-gfx906: $(ROCM_DEPS)  ## Build container for AMD ROCm gfx906 (untested)
+rocm-gfx906: $(ROCM_F40_DEPS)  ## Build container for AMD ROCm gfx906 (untested)
 	$(call build-rocm,gfx906,9.0.6)
 
 .PHONY: rocm-gfx900
-rocm-gfx900: $(ROCM_DEPS)  ## Build container for AMD ROCm gfx900 (untested)
+rocm-gfx900: $(ROCM_F40_DEPS)  ## Build container for AMD ROCm gfx900 (untested)
 	$(call build-rocm,gfx900,9.0.0)
+
+.PHONY: ubi9-rocm
+ubi9-rocm: $(ROCM_F40_DEPS)  ## Build container for AMD ROCm on UBI9 (requires subscription)
+	$(CENGINE) build $(BUILD_ARGS) \
+		-t $(CONTAINER_PREFIX):$@ \
+		-f $(ROCM_UBI9_CONTAINERFILE) \
+		.
 
 .PHONY: rocm-toolbox
 toolbox-rocm:  ## Create AMD ROCm toolbox from container

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-BUILD_ARGS = --ssh=default
+BUILD_ARGS =
 CENGINE ?= podman
 CONTAINER_PREFIX ?= localhost/instructlab
 TOOLBOX ?= instructlab

--- a/containers/rocm/Containerfile.f40
+++ b/containers/rocm/Containerfile.f40
@@ -57,7 +57,7 @@ COPY --chown=0:0 requirements.txt ${VIRTUAL_ENV}/
 RUN sed 's/\[.*\]//' ${VIRTUAL_ENV}/requirements.txt > ${VIRTUAL_ENV}/constraints.txt
 RUN --mount=type=cache,sharing=locked,id=pipcache,target=${PIP_CACHE_DIR},mode=777,z \
     umask 0000 && \
-    ${VIRTUAL_ENV}/bin/pip install torch --index-url https://download.pytorch.org/whl/rocm${PYTORCH_ROCM_VERSION} && \
+    ${VIRTUAL_ENV}/bin/pip install torch -c ${VIRTUAL_ENV}/constraints.txt --index-url https://download.pytorch.org/whl/rocm${PYTORCH_ROCM_VERSION} && \
     /tmp/remove-gfx.sh
 
 FROM pytorch AS llama

--- a/containers/rocm/Containerfile.ubi9
+++ b/containers/rocm/Containerfile.ubi9
@@ -1,0 +1,102 @@
+FROM registry.access.redhat.com/ubi9/python-311 as runtime
+# same targets and ROCm version as upstream PyTorch
+ARG LLAMA_AMDGPU_TARGETS=gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx1030;gfx1100
+ARG PYTORCH_ROCM_VERSION=6.0
+# PyTorch 2.2.1 does not support torch_compile with 3.12
+ARG PYTHON=python3.11
+ENV LLAMA_AMDGPU_TARGETS="${LLAMA_AMDGPU_TARGETS}" \
+    PYTORCH_ROCM_VERSION="${PYTORCH_ROCM_VERSION}" \
+    PYTHON="${PYTHON}" \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    VIRTUAL_ENV="/opt/app-root"
+ENV PIP_CACHE_DIR="${VIRTUAL_ENV}/.cache/pip"
+RUN mkdir -p -m777 ${PIP_CACHE_DIR}
+COPY --chown=0:0 containers/sitecustomize.py ${VIRTUAL_ENV}/lib/${PYTHON}/site-packages
+COPY --chown=0:0 containers/bin/debug-* ${VIRTUAL_ENV}/bin
+USER 0
+COPY --chown=0:0 containers/rocm/rocm60.repo /etc/yum.repos.d/
+RUN --mount=type=cache,target=/var/cache/dnf,z \
+    dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=keepcache=True \
+        'dnf-command(config-manager)' \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    dnf config-manager --enable codeready-builder-for-rhel-9-x86_64-rpms
+RUN --mount=type=cache,target=/var/cache/dnf,z \
+    dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=keepcache=True \
+        rocm-runtime rocm-smi hipblas hiprand hipsparse lld-libs nvtop make git
+
+# build env contains compilers and build dependencies
+FROM runtime AS buildenv
+RUN --mount=type=cache,sharing=locked,target=/var/cache/dnf,z \
+    dnf install -y --nodocs --setopt=keepcache=True \
+        llvm clang compiler-rt clang-tools-extra \
+        lld cmake ninja-build gcc \
+        rocblas-devel hip-devel hipblas-devel rocprim-devel rocthrust-devel hipsparse-devel hipcub-devel hiprand-devel \
+        rocm-device-libs hsa-rocr-devel
+
+FROM buildenv AS pytorch
+# build as root, so caching works
+USER 0
+# cache downloads in cache mount and don't byte compile Python files
+ENV PIP_NO_CACHE_DIR= \
+    PIP_NO_COMPILE=1
+COPY --chown=0:0 requirements.txt ${VIRTUAL_ENV}/
+# pip constraint does not support optional dependencies.
+RUN sed 's/\[.*\]//' ${VIRTUAL_ENV}/requirements.txt > ${VIRTUAL_ENV}/constraints.txt
+RUN --mount=type=cache,sharing=locked,id=pipcache,target=${PIP_CACHE_DIR},mode=777,z \
+    umask 0000 && \
+    ${VIRTUAL_ENV}/bin/pip install torch -c ${VIRTUAL_ENV}/constraints.txt --index-url https://download.pytorch.org/whl/rocm${PYTORCH_ROCM_VERSION}
+
+
+FROM pytorch AS llama
+# remove cached wheel to force rebuild
+# Force AVX off, https://github.com/ggerganov/llama.cpp/issues/5316
+# same AMDGPU targets as PyTorch
+RUN --mount=type=cache,sharing=locked,id=pipcache,target=${PIP_CACHE_DIR},mode=777 \
+    umask 0000 && \
+    pip cache remove llama_cpp_python && \
+    CFLAGS="-mno-avx" \
+    CMAKE_ARGS="-DAMDGPU_TARGETS=${LLAMA_AMDGPU_TARGETS} -DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++" \
+        FORCE_CMAKE=1 \
+        ${VIRTUAL_ENV}/bin/pip install -c ${VIRTUAL_ENV}/constraints.txt llama-cpp-python
+
+
+#FROM llama as flash_attention
+#RUN \
+#    umask 0000 && \
+#    pip cache remove flash_attention && \
+#    export GPU_ARCHS="gfx90a;gfx942" && \
+#    git clone --recurse-submodules -b 2554f490 https://github.com/ROCm/flash-attention.git /tmp/flash-attention && \
+#    pip install /tmp/flash-attention
+
+
+# install from requirements.txt last. pip does not override installed
+# packages unless there is a version conflict.
+FROM llama AS pip-install
+RUN --mount=type=cache,sharing=locked,id=pipcache,target=${PIP_CACHE_DIR},mode=777 \
+    umask 0000 && \
+    ${VIRTUAL_ENV}/bin/pip install wheel setuptools-scm && \
+    ${VIRTUAL_ENV}/bin/pip install -r ${VIRTUAL_ENV}/requirements.txt
+
+# install instructlab last
+FROM pip-install AS instructlab
+COPY --chown=0:0 . /tmp/instructlab/
+RUN --mount=type=cache,sharing=locked,id=pipcache,target=${PIP_CACHE_DIR},mode=777 \
+    umask 0000 && \
+    ${VIRTUAL_ENV}/bin/pip install --no-deps /tmp/instructlab
+RUN find ${VIRTUAL_ENV} -name __pycache__ | xargs rm -rf
+
+
+# create final image from base runtime, copy virtual env into final stage
+FROM runtime as final
+COPY --from=instructlab ${VIRTUAL_ENV}/lib/${PYTHON}/site-packages ${VIRTUAL_ENV}/lib/${PYTHON}/site-packages
+COPY --from=instructlab ${VIRTUAL_ENV}/bin ${VIRTUAL_ENV}/bin
+# contains ilab config.yaml, .cache/huggingface, and training data
+VOLUME ["/opt/app-root/src"]
+CMD ["/bin/bash"]
+USER 1001
+LABEL com.github.instructlab.instructlab.target="rocm" \
+      com.github.instructlab.instructlab.amdgpu-targets="${LLAMA_AMDGPU_TARGETS}" \
+      name="instructlab-ubi9-rocm" \
+      usage="podman run -v./data:/opt/app-root/src:z --device /dev/dri --device /dev/kfd ..." \
+      summary="PyTorch, llama.cpp, and InstructLab dependencies for AMD ROCm GPUs on UBI9 (${LLAMA_AMDGPU_TARGETS})" \
+      maintainer="Christian Heimes <cheimes@redhat.com>"

--- a/containers/rocm/Containerfile.ubi9
+++ b/containers/rocm/Containerfile.ubi9
@@ -1,10 +1,12 @@
 FROM registry.access.redhat.com/ubi9/python-311 as runtime
 # same targets and ROCm version as upstream PyTorch
 ARG LLAMA_AMDGPU_TARGETS=gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx1030;gfx1100
+ARG FLASH_ATTN_AMDGPU_TARGETS=""
 ARG PYTORCH_ROCM_VERSION=6.0
 # PyTorch 2.2.1 does not support torch_compile with 3.12
 ARG PYTHON=python3.11
 ENV LLAMA_AMDGPU_TARGETS="${LLAMA_AMDGPU_TARGETS}" \
+    FLASH_ATTN_AMDGPU_TARGETS="${FLASH_ATTN_AMDGPU_TARGETS}"
     PYTORCH_ROCM_VERSION="${PYTORCH_ROCM_VERSION}" \
     PYTHON="${PYTHON}" \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -13,20 +15,21 @@ ENV PIP_CACHE_DIR="${VIRTUAL_ENV}/.cache/pip"
 RUN mkdir -p -m777 ${PIP_CACHE_DIR}
 COPY --chown=0:0 containers/sitecustomize.py ${VIRTUAL_ENV}/lib/${PYTHON}/site-packages
 COPY --chown=0:0 containers/bin/debug-* ${VIRTUAL_ENV}/bin
+RUN ${VIRTUAL_ENV}/bin/pip install wheel packaging
 USER 0
 COPY --chown=0:0 containers/rocm/rocm60.repo /etc/yum.repos.d/
-RUN --mount=type=cache,target=/var/cache/dnf,z \
+RUN --mount=type=cache,sharing=locked,id=dnf-ubi9,target=/var/cache/dnf,z \
     dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=keepcache=True \
         'dnf-command(config-manager)' \
         https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     dnf config-manager --enable codeready-builder-for-rhel-9-x86_64-rpms
-RUN --mount=type=cache,target=/var/cache/dnf,z \
+RUN --mount=type=cache,sharing=locked,id=dnf-ubi9,target=/var/cache/dnf,z \
     dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=keepcache=True \
         rocm-runtime rocm-smi hipblas hiprand hipsparse lld-libs nvtop make git
 
 # build env contains compilers and build dependencies
 FROM runtime AS buildenv
-RUN --mount=type=cache,sharing=locked,target=/var/cache/dnf,z \
+RUN --mount=type=cache,sharing=locked,id=dnf-ubi9,target=/var/cache/dnf,z \
     dnf install -y --nodocs --setopt=keepcache=True \
         llvm clang compiler-rt clang-tools-extra \
         lld cmake ninja-build gcc \
@@ -60,22 +63,29 @@ RUN --mount=type=cache,sharing=locked,id=pipcache,target=${PIP_CACHE_DIR},mode=7
         ${VIRTUAL_ENV}/bin/pip install -c ${VIRTUAL_ENV}/constraints.txt llama-cpp-python
 
 
-#FROM llama as flash_attention
-#RUN \
-#    umask 0000 && \
-#    pip cache remove flash_attention && \
-#    export GPU_ARCHS="gfx90a;gfx942" && \
-#    git clone --recurse-submodules -b 2554f490 https://github.com/ROCm/flash-attention.git /tmp/flash-attention && \
-#    pip install /tmp/flash-attention
+# flash-attention supports only MI200/300 cards
+# build is untested and may not work
+FROM llama as flash_attn
+RUN --mount=type=cache,sharing=locked,id=pipcache,target=${PIP_CACHE_DIR},mode=777 \
+    if test -n "${FLASH_ATTN_AMDGPU_TARGETS}"; then \
+        umask 0000 && \
+        pip cache remove flash_attn && \
+        git clone --recurse-submodules https://github.com/ROCm/flash-attention.git /tmp/flash_attn && \
+        git -C /tmp/flash_attn checkout --recurse-submodules 2554f490101742ccdc56620a938f847f61754be6 && \
+        GPU_ARCHS="${FLASH_ATTN_AMDGPU_TARGETS}" \
+            MAX_JOBS="$(( $(nproc) < 8 ? 4 : 8 ))" \
+            ${VIRTUAL_ENV}/bin/pip install -c ${VIRTUAL_ENV}/constraints.txt /tmp/flash_attn \
+    fi
 
 
 # install from requirements.txt last. pip does not override installed
 # packages unless there is a version conflict.
-FROM llama AS pip-install
+FROM flash_attn AS pip-install
 RUN --mount=type=cache,sharing=locked,id=pipcache,target=${PIP_CACHE_DIR},mode=777 \
     umask 0000 && \
     ${VIRTUAL_ENV}/bin/pip install wheel setuptools-scm && \
     ${VIRTUAL_ENV}/bin/pip install -r ${VIRTUAL_ENV}/requirements.txt
+
 
 # install instructlab last
 FROM pip-install AS instructlab

--- a/containers/rocm/README.md
+++ b/containers/rocm/README.md
@@ -45,7 +45,7 @@ Map the name to a LLVM GPU target and an override GFX version. PyTorch 2.2.1+roc
 | `gfx90a`  | `xnack+`  | `9.0.10` | ✅      | ✅     |
 | `gfx940`  |           |          | ❌      | ✅     |
 | `gfx941`  |           |          | ❌      | ✅     |
-| `gfx942`  |           |          | ❌      | ✅     |
+| `gfx942`  |           |          | ⚠️ (6.0)| ✅     |
 | `gfx1010` |           |          | ❌      | ✅     |
 | `gfx1012` |           |          | ❌      | ✅     |
 | `gfx1030` |           | `10.3.0` | ✅      | ✅     |
@@ -70,3 +70,29 @@ make rocm-gfx1100 BUILD_ARGS=
 ## Known issues
 
 AMD Instinct MI210 with ISA `amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack-` is not supported by Fedora build `rocblas-6.0.2-3`. As of late April 2024, Fedora has `gfx90a:xnack+` and `gfx90a:xnack-` but lacks `gfx90a:sramecc+:xnack-`.
+
+## UBI 9 image
+
+The ROCm UBI9 image is based on `ubi9-python311` and uses AMD's ROCm repository. The container file requires a Red Hat subscription to build. A [No-cost RHEL Individual Developer Subscription](https://developers.redhat.com/articles/faqs-no-cost-red-hat-enterprise-linux) is sufficient. On Fedora, `subscription-manager` and `subscription-manager-plugin-container` must be installed and the host system must be registered.
+
+The resulting container image is rather large, because it contains Kernels for all supported AMD GPU ISAs and comes with ROCm's LLVM / clang stack. Currently the image is about 26 GB on disk.
+
+Register host:
+```shell
+sudo dnf install subscription-manager subscription-manager-plugin-container
+sudo subscription-manager register ...
+```
+
+Build image:
+```shell
+make ubi9-rocm BUILD_ARGS=
+```
+
+Run image:
+```shell
+mkdir -p src
+podman run -v./data:/opt/app-root/src:z --device /dev/dri --device /dev/kfd -ti --rm localhost/instructlab:ubi9-rocm
+(app-root) ilab init
+(app-root) ilab download
+(app-root) ilab chat
+```

--- a/containers/rocm/remove-gfx.sh
+++ b/containers/rocm/remove-gfx.sh
@@ -5,39 +5,26 @@ set -e
 
 TORCH="${VIRTUAL_ENV:-/opt/rocm-venv}/lib/${PYTHON:-python3.1?}/site-packages/torch"
 
+rmgfx() {
+	for GFX in "$@"; do
+		echo "Removing ${GFX} files"
+		rm -rfv "/usr/lib*/rocm/${GFX}"
+		rm -fv "/usr/lib*/rocblas/library/*${GFX}*"
+		rm -fv "/opt/rocm/lib/rocblas/library/*${GFX}*"
+		rm -fv "${TORCH}/lib/rocblas/library/*${GFX}*"
+		rm -fv "${TORCH}/lib/hipblaslt/library/*${GFX}*"
+	done
+}
+
 case "$AMDGPU_ARCH" in
 	gfx9*)
-		rm -rf /usr/lib*/rocm/gfx8
-		rm -rf /usr/lib*/rocm/gfx10
-		rm -rf /usr/lib*/rocm/gfx11
-		rm -f /usr/lib*/rocblas/library/*gfx8*
-		rm -f /usr/lib*/rocblas/library/*gfx10*
-		rm -f /usr/lib*/rocblas/library/*gfx11*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx8*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx10*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx11*
+		rmgfx gfx8 gfx10 gfx11
 		;;
 	gfx10*)
-		rm -rf /usr/lib*/rocm/gfx8
-		rm -rf /usr/lib*/rocm/gfx9
-		rm -rf /usr/lib*/rocm/gfx11
-		rm -f /usr/lib*/rocblas/library/*gfx8*
-		rm -f /usr/lib*/rocblas/library/*gfx9*
-		rm -f /usr/lib*/rocblas/library/*gfx11*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx8*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx9*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx11*
+		rmgfx gfx8 gfx9 gfx11
 		;;
 	gfx11*)
-		rm -rf /usr/lib*/rocm/gfx8
-		rm -rf /usr/lib*/rocm/gfx9
-		rm -rf /usr/lib*/rocm/gfx10
-		rm -f /usr/lib*/rocblas/library/*gfx8*
-		rm -f /usr/lib*/rocblas/library/*gfx9*
-		rm -f /usr/lib*/rocblas/library/*gfx10*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx8*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx9*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx10*
+		rmgfx gfx8 gfx9 gfx10
 		;;
 	*)
 		echo "ERROR: $0 unknown AMDGPU_ARCH=$AMDGPU_ARCH"

--- a/containers/rocm/rocm60.repo
+++ b/containers/rocm/rocm60.repo
@@ -1,0 +1,7 @@
+[ROCm-6.0]
+name=ROCm6.0
+baseurl=https://repo.radeon.com/rocm/rhel$releasever/6.0/main
+enabled=1
+priority=50
+gpgcheck=1
+gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key

--- a/containers/rocm/rocm60.repo
+++ b/containers/rocm/rocm60.repo
@@ -1,6 +1,6 @@
-[ROCm-6.0]
-name=ROCm6.0
-baseurl=https://repo.radeon.com/rocm/rhel$releasever/6.0/main
+[ROCm-6.0.2]
+name=ROCm6.0.2
+baseurl=https://repo.radeon.com/rocm/rhel$releasever/6.0.2/main
 enabled=1
 priority=50
 gpgcheck=1

--- a/tox.ini
+++ b/tox.ini
@@ -64,5 +64,5 @@ deps =
     pyspelling
 commands =
     sh -c 'command -v aspell || (echo "aspell is not installed. Please install it." && exit 1)'
-    "{envpython} -m pyspelling --config {toxinidir}/.spellcheck.yml" --spellchecker aspell
+    {envpython} -m pyspelling --config {toxinidir}/.spellcheck.yml --spellchecker aspell
 allowlist_externals = sh


### PR DESCRIPTION
# Changes

**Description of your changes:**

The new `ubi9-rocm` container file is based on Red Hat's Universal Base Image for RHEL 9. It uses AMD's upstream ROCm 6.0 repositories for ROCm libraries and tool chain.

The container is not yet optimized for size. It comes with all AMD GPU Kernels and supports all ISAs that are supported by PyTorch and ROCm.

I have successfully tested the image on my AMD Radeon 7900 XT GPU.