### PR TITLE
Add ARM64 support to the Containerfile example

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -9,26 +9,14 @@ experience.
 ## Steps to build an image then run a container
 
 The [`Containerfile`](../containers/cuda/Containerfile)
-is based on Nvidia CUDA image, which lucky for us plugs
+is based on Nvidia CUDA image, which plugs
 directly into Podman via their `nvidia-container-toolkit`! The `ubi9` base
 image does not have most packages installed. The bulk of the `Containerfile` is
 spent configuring your system so `ilab` can be installed and run properly.
 `ubi9` as compared to `ubuntu` cannot install the entire `nvidia-12-4` toolkit.
 This did not impact performance during testing.
 
-```shell
-1. podman build -f <Containerfile_Path>
-2. curl -s -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo |   sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
-3. sudo yum-config-manager --enable nvidia-container-toolkit-experimental
-4. sudo dnf install -y nvidia-container-toolkit
-5. sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
-6. nvidia-ctk cdi list
-    Example output: 
-    INFO[0000] Found 2 CDI devices
-    nvidia.com/gpu=0
-    nvidia.com/gpu=all
-7. podman run --device nvidia.com/gpu=0  --security-opt=label=disable -it <IMAGE_ID>
-```
+The CUDA Containerfile is located [here](../containers/cuda/Containerfile).
 
 Voila! You now have a container with CUDA and GPUs enabled!
 

--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-FROM nvcr.io/nvidia/cuda:12.3.2-devel-ubi9
-RUN dnf install -y python3.11 git python3-pip make automake gcc gcc-c++
+FROM nvcr.io/nvidia/cuda:12.4.1-devel-ubi9
+RUN dnf install -y python3.11 python3.11-devel git python3-pip make automake gcc gcc-c++
 WORKDIR /instructlab
 RUN python3.11 -m ensurepip
-RUN dnf install -y gcc
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo && dnf repolist && dnf config-manager --set-enabled cuda-rhel9-x86_64 && dnf config-manager --set-enabled cuda && dnf config-manager --set-enabled epel && dnf update -y
 RUN dnf install -y libcudnn8 nvidia-driver-NVML nvidia-driver-cuda-libs
@@ -16,7 +15,8 @@ RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cu
     && export XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 
 ARG GIT_TAG=stable
-RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" CFLAGS="-mno-avx" python3.11 -m pip install -r https://raw.githubusercontent.com/instructlab/instructlab/${GIT_TAG}/requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
+RUN if [[ "$(uname -m)" != "aarch64" ]]; then export CFLAGS="-mno-avx"; fi && \
+    CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install -r https://raw.githubusercontent.com/instructlab/instructlab/${GIT_TAG}/requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
 RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@${GIT_TAG}
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
- Fixes ARM64 build for the containerfile
- Bump cuda:12.4.1-devel-ubi9 to the latest

