### PR TITLE
Prefer https over git and ssh protocols for repo cloning.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-BUILD_ARGS = --ssh=default
+BUILD_ARGS =
 CENGINE ?= podman
 CONTAINER_PREFIX ?= localhost/instructlab
 TOOLBOX ?= instructlab

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The full process is described graphically in the [workflow diagram](./docs/workf
    ```shell
    python3 -m venv venv
    source venv/bin/activate
-   pip install git+ssh://git@github.com/instructlab/instructlab.git@stable
+   pip install git+https://github.com/instructlab/instructlab.git@stable
    ```
    > **NOTE**: ⏳ `pip install` may take some time, depending on your internet connection.
 

--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -1,20 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM nvcr.io/nvidia/cuda:12.3.2-devel-ubi9
-RUN dnf install -y python3.11 && dnf install -y openssh && dnf install -y git && dnf install -y python3-pip && dnf install -y make automake gcc gcc-c++
-RUN ssh-keyscan github.com > ~/.ssh/known_hosts
+RUN dnf install -y python3.11 git python3-pip make automake gcc gcc-c++
 WORKDIR /instructlab
 RUN python3.11 -m ensurepip
 RUN dnf install -y gcc
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo && dnf repolist && dnf config-manager --set-enabled cuda-rhel9-x86_64 && dnf config-manager --set-enabled cuda && dnf config-manager --set-enabled epel && dnf update -y
-RUN --mount=type=ssh,id=default python3.11 -m pip install --force-reinstall nvidia-cuda-nvcc-cu12 
+RUN python3.11 -m pip install --force-reinstall nvidia-cuda-nvcc-cu12
 RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64" \
     && export CUDA_HOME=/usr/local/cuda \
     && export PATH="/usr/local/cuda/bin:$PATH" \
     && export XLA_TARGET=cuda120 \
     && export XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
-RUN --mount=type=ssh,id=default CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-cache-dir llama-cpp-python 
-RUN --mount=type=ssh,id=default python3.11 -m pip install git+ssh://git@github.com/instructlab/instructlab.git@stable
+RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-cache-dir llama-cpp-python
+RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@stable
 CMD ["/bin/bash"]
 

--- a/docs/containerization.md
+++ b/docs/containerization.md
@@ -12,21 +12,20 @@ experience.
 
 ```dockerfile
 FROM nvcr.io/nvidia/cuda:12.3.2-devel-ubi9
-RUN dnf install -y python3.11 && dnf install -y openssh && dnf install -y git && dnf install -y python3-pip && dnf install -y make automake gcc gcc-c++
-RUN ssh-keyscan github.com > ~/.ssh/known_hosts
+RUN dnf install -y python3.11 git python3-pip make automake gcc gcc-c++
 WORKDIR /instructlab
 RUN python3.11 -m ensurepip
 RUN dnf install -y gcc
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo && dnf repolist && dnf config-manager --set-enabled cuda-rhel9-x86_64 && dnf config-manager --set-enabled cuda && dnf config-manager --set-enabled epel && dnf update -y
-RUN --mount=type=ssh,id=default python3.11 -m pip install --force-reinstall nvidia-cuda-nvcc-cu12 
+RUN python3.11 -m pip install --force-reinstall nvidia-cuda-nvcc-cu12
 RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64" \
     && export CUDA_HOME=/usr/local/cuda \
     && export PATH="/usr/local/cuda/bin:$PATH" \
     && export XLA_TARGET=cuda120 \
     && export XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
-RUN --mount=type=ssh,id=default CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-cache-dir llama-cpp-python 
-RUN --mount=type=ssh,id=default python3.11 -m pip install git+ssh://git@github.com/instructlab/instructlab.git@stable
+RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-cache-dir llama-cpp-python
+RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@stable
 CMD ["/bin/bash"]
 ```
 
@@ -40,7 +39,7 @@ spent configuring your system so `ilab` can be installed and run properly.
 This did not impact performance during testing.
 
 ```shell
-1. podman build –ssh=default -f <Containerfile_Path>
+1. podman build -f <Containerfile_Path>
 2. curl -s -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo |   sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
 3. sudo yum-config-manager --enable nvidia-container-toolkit-experimental
 4. sudo dnf install -y nvidia-container-toolkit
@@ -60,7 +59,3 @@ Voila! You now have a container with CUDA and GPUs enabled!
 [Nvidia Container Toolkit Install Guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 
 [Podman Support for Container Device Interface](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html)
-
-### Notes
-
-Thanks to Taj Salawu for figuring out how to pass the git ssh keys properly!

--- a/docs/demo-slides.md
+++ b/docs/demo-slides.md
@@ -31,7 +31,7 @@ source venv/bin/activate.fish
 <!-- pause -->
 Install CLI
 ```fish
-pip install git+ssh://git@github.com/instruct-lab/cli.git@v0.13.0
+pip install git+https://github.com/instruct-lab/cli.git@v0.13.0
 ```
 <!-- pause -->
 Initialize workspace
@@ -154,7 +154,7 @@ Commit change and push to fork
 ```fish
 cd taxonomy
 git status
-git remote add xukai92 git@github.com:instruct-lab/taxonomy.git
+git remote add xukai92 https://github.com/instruct-lab/taxonomy.git
 git add knowledge/instruct-lab/cli
 git commit -sm "feat(knowledge): InstructLab CLI usage"
 git checkout -b demo

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -36,7 +36,7 @@ how to do that on Fedora with `dnf`:
   # Install lab (assumes a locally-cloned repo)
   # You can clone the repo if you haven't already done so (either one)
   # gh repo clone instructlab/instructlab
-  # git clone git@github.com:instructlab/instructlab.git
+  # git clone https://github.com/instructlab/instructlab.git
   pip3 install ./instructlab/
   ```
 


### PR DESCRIPTION
# Changes

HTTPS has much lower chances to be blocked in certain internal networks as well as more resilient to having issues with changing ssh keys on a GitHub server side.  HTTPS is also the default method recommended by GitHub.

Passing around ssh keys is also not needed anymore.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

SSH access replaced with HTTPS everywhere in docs and the code.

This was originally submitted as https://github.com/instructlab/instructlab/pull/663 , but since the org and the repo got renamed I couldn't re-open that PR, so sending a new one.