### PR TITLE
fix: force aspell spellchecker

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -57,10 +57,12 @@ commands =
 allowlist_externals = ./scripts/ruff.sh
 
 [testenv:spellcheck]
-description = spell check (needs 'aspell' or 'hunspell' command)
+description = spell check (needs 'aspell' command)
 skip_install = true
 skipsdist = true
 deps =
     pyspelling
 commands =
-    {envpython} -m pyspelling --config {toxinidir}/.spellcheck.yml
+    sh -c 'command -v aspell || (echo "aspell is not installed. Please install it." && exit 1)'
+    "{envpython} -m pyspelling --config {toxinidir}/.spellcheck.yml" --spellchecker aspell
+allowlist_externals = sh


### PR DESCRIPTION
pyspelling defaults to aspell, although it supports both 'aspell' and 'hunspell'. However 'hunspell' reports a lot more issues than 'aspell'. It will be hard to maintain both, so let's enforce 'aspell'. Also, the GitHub action uses 'aspell'.

Signed-off-by: Sébastien Han <seb@redhat.com>
