### PR TITLE
ci: add stale issue/PR bot

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -1,0 +1,23 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-label: 'stale'
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had activity within 90 days.
+            It will be automatically closed if no further activity occurs within 30 days.
+          close-pr-message: >
+            This pull request has been automatically closed due to inactivity.
+          days-before-stale: 90
+          days-before-close: 30

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -13,11 +13,17 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
+          days-before-stale: 90
+          days-before-close: 30
           stale-pr-label: 'stale'
+          stale-issue-label: 'stale'
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had activity within 90 days.
             It will be automatically closed if no further activity occurs within 30 days.
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had activity within 90 days.
+            It will be automatically closed if no further activity occurs within 30 days.
           close-pr-message: >
-            This pull request has been automatically closed due to inactivity.
-          days-before-stale: 90
-          days-before-close: 30
+            This pull request has been automatically closed due to inactivity. Please feel free to reopen if you intend to continue working on it!
+          close-issue-message: >
+            This issue has been automatically closed due to inactivity. Please feel free to reopen if you feel it is still relevant!


### PR DESCRIPTION
This PR adds a stale issue bot similar to what we have in the `taxonomy` repo: https://github.com/instructlab/taxonomy/blob/main/.github/workflows/stale_bot.yml

This is also a proposal of sorts - if we feel this isn't something worth having in this repo, I'm happy to close it.