### PR TITLE
containers: Fix the CUDA build to not use an SSH URL

### DIFF
--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -15,6 +15,6 @@ RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cu
     && export XLA_TARGET=cuda120 \
     && export XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 RUN --mount=type=ssh,id=default CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-cache-dir llama-cpp-python 
-RUN --mount=type=ssh,id=default python3.11 -m pip install git+ssh://git@github.com/instructlab/instructlab.git@stable
+RUN --mount=type=ssh,id=default python3.11 -m pip install git+https://github.com/instructlab/instructlab@stable
 CMD ["/bin/bash"]
 


### PR DESCRIPTION
This was failing during the build process:

    Cloning ssh://****@github.com/instructlab/instructlab.git (to revision stable) to /tmp/pip-req-build-en5sp88r
    Running command git clone --filter=blob:none --quiet 'ssh://****@github.com/instructlab/instructlab.git' /tmp/pip-req-build-en5sp88r
    git@github.com: Permission denied (publickey).

Switch to an HTTP URL instead fixes the problem.

# Changes

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
