### PR TITLE
Allow arbitary trainging args to be overridden

### DIFF
--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -380,7 +380,7 @@ class TestLabTrain:
             assert linux_train_mock.call_args[1]["num_epochs"] == 1
             assert linux_train_mock.call_args[1]["device"] is not None
             assert not linux_train_mock.call_args[1]["four_bit_quant"]
-            assert len(linux_train_mock.call_args[1]) == 7
+            assert len(linux_train_mock.call_args[1]) == 8
             is_macos_with_m_chip_mock.assert_called_once()
             assert not os.path.isfile(LINUX_GGUF_FILE)
 


### PR DESCRIPTION
Adding as a hidden argument to allow experimentation on various devices. Eventually once we know whats needed we can add something more permanent.

Fixes #1007


With this PR and  https://github.com/instructlab/instructlab/pull/1012 , running ilab e2e including training works on colab
> !ilab train --device cuda --override-training-args '{"bf16":false, "gradient_checkpointing":true, "gradient_accumulation_steps":8}'