### PR TITLE
Define a relaxed schema as v1 and move current schema to v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,12 @@ dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["instructlab", "instructlab.chat", "instructlab.generator", "instructlab.train", "instructlab.train.lora_mlx", "instructlab.train.lora_mlx.models", "instructlab.llamacpp", "instructlab.mlx_explore", "instructlab.schema.v1"]
+include = ["instructlab", "instructlab.chat", "instructlab.generator", "instructlab.train", "instructlab.train.lora_mlx", "instructlab.train.lora_mlx.models", "instructlab.llamacpp", "instructlab.mlx_explore", "instructlab.schema.v1", "instructlab.schema.v2"]
 
 [tool.setuptools.package-data]
 "instructlab.llamacpp" = ["quantize"]
 "instructlab.schema.v1" = ["*.json"]
+"instructlab.schema.v2" = ["*.json"]
 
 [tool.check-wheel-contents]
 # W002 - Wheel contains duplicate files:

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -205,6 +205,7 @@ test_generate(){
     mkdir -p test_taxonomy/compositional_skills
     cat - <<EOF >  test_taxonomy/compositional_skills/simple_math.yaml
 created_by: ci
+version: 2
 seed_examples:
   - question: what is 1+1
     answer: it is 2

--- a/tests/testdata/invalid_yaml.yaml
+++ b/tests/testdata/invalid_yaml.yaml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 created_by: test-bot
+version: 2
 seed_examples:
 - question: What is this skill about?
   answer: It's a skill that makes the tests more skillful

--- a/tests/testdata/knowledge_valid.yaml
+++ b/tests/testdata/knowledge_valid.yaml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 created_by: test-bot
+version: 2
 domain: test-domain
 seed_examples:
 - question: What is this knowledge about?

--- a/tests/testdata/skill_incomplete.yaml
+++ b/tests/testdata/skill_incomplete.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 created_by: test
-version: 1
+version: 2
 seed_examples:
 - question: "Does this yaml pass schema validation?"
   answer: "No, it does not! It should have 5 examples."

--- a/tests/testdata/skill_invalid_answer.yaml
+++ b/tests/testdata/skill_invalid_answer.yaml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 created_by: test-bot
+version: 2
 seed_examples:
 - answer: Yes
   question: Is this for a test?

--- a/tests/testdata/skill_valid_answer.yaml
+++ b/tests/testdata/skill_valid_answer.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 created_by: test-bot
-version: 1
+version: 2
 seed_examples:
 - answer: Yes, it is.
   question: Is this for a test?


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves #989

**Description of your changes:**

We introduce a relaxed schema as v1 which will accept all existing
taxonomy files in the main branch of the taxonomy repo. The current
v1 schema is renamed to v2 and will be used for future contributions
to the taxonomy repo.

Fixes https://github.com/instructlab/instructlab/issues/989

Depends on https://github.com/instructlab/instructlab/pull/913
and https://github.com/instructlab/schema/pull/11