### PR TITLE
#1006 - Optimize CPU training on Linux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ langchain-text-splitters
 # the below library should NOT be imported into any python files
 # it is for CLI usage ONLY
 yamllint>=1.35.1,<1.36.0
+psutil>=5.9.8

--- a/src/instructlab/config.py
+++ b/src/instructlab/config.py
@@ -23,7 +23,7 @@ DEFAULT_CHUNK_WORD_COUNT = 1000
 DEFAULT_NUM_INSTRUCTIONS = 100
 DEFAULT_PROMPT_FILE = "prompt.txt"
 DEFAULT_GENERATED_FILES_OUTPUT_DIR = "generated"
-DEFAULT_CONNECTION_TIMEOUT = httpx.Timeout(timeout=30.0)
+DEFAULT_CONNECTION_TIMEOUT = httpx.Timeout(timeout=300.0)
 # use spawn start method, fork is not thread-safe
 DEFAULT_MULTIPROCESSING_START_METHOD = "spawn"
 

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -950,14 +950,14 @@ def train(
             shutil.copy(file, final_results_dir)
             print("Copied ", file, "to ", final_results_dir)
 
-        convert_llama_to_gguf(model=final_results_dir, pad_vocab=True)
+        outfile = convert_llama_to_gguf(model=final_results_dir, pad_vocab=True)
 
         gguf_models_dir = "./models"
         if not os.path.isdir(gguf_models_dir):
             os.mkdir(gguf_models_dir)
-        shutil.copy(final_results_dir + "/ggml-model-f16.gguf", gguf_models_dir)
+        shutil.copy(outfile, gguf_models_dir)
         # cleanup original copy of model
-        os.remove(final_results_dir + "/ggml-model-f16.gguf")
+        os.remove(outfile)
         # cleanup checkpoint dir since it's name is unpredictable
         # TODO: figure out how checkpoint dirs should be cleaned up
         # checkpoint_dirs = glob(training_results_dir + "/checkpoint*")

--- a/src/instructlab/llamacpp/llamacpp_convert_to_gguf.py
+++ b/src/instructlab/llamacpp/llamacpp_convert_to_gguf.py
@@ -1743,3 +1743,4 @@ def convert_llama_to_gguf(
         pad_vocab=pad_vocab,
     )
     print(f"Wrote {outfile}")
+    return outfile

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+import psutil # to determine system memory
 from typing import Optional
 
 # Third Party
@@ -17,6 +18,7 @@ from transformers import (
 )
 from trl import DataCollatorForCompletionOnlyLM, SFTTrainer
 import torch
+from tqdm import tqdm
 
 # Local
 from ..chat.chat import CONTEXTS
@@ -100,6 +102,17 @@ def report_cuda_device(args_device, min_vram=0):
             "stopping the server to free up about 5 GiB of GPU memory."
         )
 
+def determine_batch_size(device):
+    if device.type == "cpu":
+        # Gets the total system memory, excluding swap
+        mem_bytes = psutil.virtual_memory().total
+        mem_gb = mem_bytes / 1024 / 1024 / 1024
+        return 2 if mem_gb < 60 else 4
+    else:
+        # Defaulting for now... should check and return
+        # more for very large GPUs
+        return 1
+
 
 def linux_train(
     train_file: str,
@@ -159,9 +172,14 @@ def linux_train(
         model_name, torchscript=True, trust_remote_code=True
     )
 
+    model_torch_dtype = "auto"
+    if device.type == "cpu":
+        # Setting to None to improve inference performance on cpu
+        model_torch_dtype = None
+
     model = AutoModelForCausalLM.from_pretrained(
         model_name,
-        torch_dtype="auto",
+        torch_dtype=model_torch_dtype,
         quantization_config=bnb_config,
         config=config,
         trust_remote_code=True,
@@ -202,7 +220,7 @@ def linux_train(
 
     assistant_old_lst = [
         model_generate(d["user"]).split(response_template.strip())[-1].strip()
-        for d in test_dataset
+        for d in tqdm(test_dataset)
     ]
     attention_layers = [
         module for module in model.modules() if "attention" in str(type(module)).lower()
@@ -235,14 +253,24 @@ def linux_train(
     )
 
     output_dir = "./training_results"
-    per_device_train_batch_size = 1
+    per_device_train_batch_size = determine_batch_size(device)
+    print(f"LINUX_TRAIN.PY: Training with batch size: {per_device_train_batch_size}")
 
+    use_bf16 = not use_fp16
+
+    if device.type == "cpu":
+        print("LINUX_TRAIN.PY: Disabling fp16 and bf16 for cpu training")
+        # CPU performance is very bad with fp16 or bf16, so disable both
+        use_fp16 = use_bf16 = False
+    
     training_arguments = TrainingArguments(
         output_dir=output_dir,
         num_train_epochs=num_epochs,
         per_device_train_batch_size=per_device_train_batch_size,
         fp16=use_fp16,
-        bf16=not use_fp16,
+        bf16=use_bf16,
+        include_tokens_per_second=True,
+        include_num_input_tokens_seen=True,
         # use_ipex=True, # TODO CPU test this possible optimization
         use_cpu=model.device.type == "cpu",
         save_strategy="epoch",
@@ -285,7 +313,7 @@ def linux_train(
         )
         assistant_expected = d["assistant"]
 
-        print(f"\n===\ntest {i}\n===\n")
+        print(f"\n===\ntest {i+1}\n===\n")
         print("\n===\nuser\n===\n")
         print(d["user"])
         print("\n===\nassistant_old\n===\n")


### PR DESCRIPTION
 - Timeout for chat mode increased to 300 seconds. Without this, it fails in a nearly silent manner in 30 seconds. This causes issues for CPU chat
 - Return the filename when converting the final resulting file and use this for copying. This is important when using f32, as llamam_to_gguf will have a different filename from expected (f16).
 - Determine the system memory available and use this to determine the batch size in cpu mode. This enables more parallelization on smaller systems.
 - Disable fp16 and bf16 in cpu mode. This also enables paralleization. Without it, training is unusable on my i7 with 64GB ram. With it, training takes <30 minutes for one epoch of ~26 iterations.
 - Turn off auto for dtype when loading the model. This greatly improved inference performance on my i7 as well. It went from single threaded to fully utilizing the CPU.
 - Updated the logging to be 1 based instead of zero based :)

# Changes

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
