### PR TITLE
Introduce an end-to-end CI job on Linux

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+  - ubuntu-gpu

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,12 +15,6 @@ jobs:
     runs-on: ubuntu-gpu
 
     steps:
-      - name: Setup
-        run: |
-          sudo apt-get install -y cuda-toolkit python3 git python3-pip cmake build-essential virtualenv
-          nvidia-smi
-          ls -l /dev/nvidia*
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -46,6 +40,28 @@ jobs:
       - name: Checkout branch
         if: steps.check_pr.outputs.is_pr == 'false'
         run: git checkout ${{ github.event.inputs.pr_or_branch }}
+
+      - name: Install Packages
+        run: |
+          sudo apt-get install -y cuda-toolkit git cmake build-essential virtualenv
+          nvidia-smi
+          ls -l /dev/nvidia*
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            **/pyproject.toml
+            **/requirements*.txt
+
+      - name: Cache huggingface
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          # config contains DEFAULT_MODEL
+          key: huggingface-${{ hashFiles('src/instructlab/config.py') }}
 
       - name: Install ilab
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: E2E test
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_or_branch:
+        description: 'pull request number or branch name'
+        required: true
+        default: 'main'
+
+jobs:
+  e2e:
+    runs-on: ubuntu-gpu
+
+    steps:
+      - name: Setup
+        run: |
+          sudo apt-get install -y cuda-toolkit python3 git python3-pip cmake build-essential virtualenv
+          nvidia-smi
+          ls -l /dev/nvidia*
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # https://github.com/actions/checkout/issues/249
+          fetch-depth: 0
+          submodules: 'true'
+
+      - name: Determine if pr_or_branch is a PR number
+        id: check_pr
+        run: |
+          if [[ "${{ github.event.inputs.pr_or_branch }}" =~ ^[0-9]+$ ]]; then
+            echo "is_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch and checkout PR
+        if: steps.check_pr.outputs.is_pr == 'true'
+        run: |
+          git fetch origin pull/${{ github.event.inputs.pr_or_branch }}/head:pr-${{ github.event.inputs.pr_or_branch }}
+          git checkout pr-${{ github.event.inputs.pr_or_branch }}
+
+      - name: Checkout branch
+        if: steps.check_pr.outputs.is_pr == 'false'
+        run: git checkout ${{ github.event.inputs.pr_or_branch }}
+
+      - name: Install and run e2e test
+        run: |
+          export PATH="/home/runner/.local/bin:/usr/local/cuda-12.4/bin:$PATH"
+          python3 -m venv venv
+          . venv/bin/activate
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3 -m pip install -r requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
+          # needed for --4-bit-quant option to ilab train
+          python3 -m pip install bitsandbytes
+          python3 -m pip install .
+          ./scripts/basic-workflow-tests.sh -cm

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,13 +47,19 @@ jobs:
         if: steps.check_pr.outputs.is_pr == 'false'
         run: git checkout ${{ github.event.inputs.pr_or_branch }}
 
-      - name: Install and run e2e test
+      - name: Install ilab
         run: |
           export PATH="/home/runner/.local/bin:/usr/local/cuda-12.4/bin:$PATH"
           python3 -m venv venv
           . venv/bin/activate
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3 -m pip install -r requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
+          sed 's/\[.*\]//' requirements.txt > constraints.txt
+          python3 -m pip cache remove llama_cpp_python
+          CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3 -m pip install --no-binary llama_cpp_python -c constraints.txt llama_cpp_python
           # needed for --4-bit-quant option to ilab train
           python3 -m pip install bitsandbytes
           python3 -m pip install .
+
+      - name: Run e2e test
+        run: |
+          . venv/bin/activate
           ./scripts/basic-workflow-tests.sh -cm

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,14 @@
+# CI for InstructLab
+
+## End-to-end CI Job
+
+This CI job is manually triggered by `instructlab` repo maintainers. It runs as
+much of the `ilab` workflow as it can on the GPU-enabled worker we have
+available through GitHub Actions.
+
+1. Visit the [Actions tab](https://github.com/instructlab/instructlab/actions).
+2. Click on the [E2E test](https://github.com/instructlab/instructlab/actions/workflows/e2e.yml)
+   workflow on the left side of the page.
+3. Click on the `Run workflow` button on the right side of the page.
+4. Enter a branch name or a PR number in the input field.
+5. Click the green `Run workflow` button.

--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -160,6 +160,12 @@ test_exec() {
     test_chat
     test_taxonomy
     test_generate
+
+    # Kill the serve process
+    task Stopping the ilab serve
+    step Kill ilab serve $PID
+    kill $PID
+
     test_train
 
     if [ "$CI" -eq 1 ]; then
@@ -172,11 +178,6 @@ test_exec() {
     # When you run this --
     #   `ilab convert` is only implemented for macOS with M-series chips for now
     #test_convert
-
-    # Kill the serve process
-    task Stopping the ilab serve
-    step Kill ilab serve $PID
-    kill $PID
 
     # TODO: chat with the new model
     test_serve /tmp/somemodelthatispretrained.gguf

--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -1,0 +1,232 @@
+#!/bin/sh
+set -euf
+# set -x
+
+# This is a basic workflow test of the ilab CLI.
+#
+# We expect it to be run anywhere `ilab` would run, including the instructlab
+# container images.
+#
+# It represents the tasks a typical user would run through to get familiar with ilab.
+#
+# It is written in shell script because this basic workflow *is* a shell
+# workflow, run through step by step at a shell prompt by a user.
+
+MINIMAL=0
+NUM_INSTRUCTIONS=5
+GENERATE_ARGS=
+TRAIN_ARGS=
+CI=0
+GRANITE=0
+
+export GREP_COLORS='mt=1;33'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+SCRIPTDIR=$(dirname "$0")
+
+step() {
+    echo -e "$BOLD$@$NC"
+}
+
+task() {
+    echo -e "$BOLD------------------------------------------------------$NC"
+    step $@
+}
+
+set_defaults() {
+    if [ "$MINIMAL" -eq 0 ]; then
+        return
+    fi
+
+    NUM_INSTRUCTIONS=1
+    GENERATE_ARGS="--num-cpus $(nproc)"
+    TRAIN_ARGS="--num-epochs 1"
+}
+
+test_smoke() {
+    task Smoke test InstructLab
+    ilab | grep --color 'Usage: ilab'
+}
+
+test_init() {
+    task Initializing ilab
+    [ -f config.yaml ] || printf "taxonomy\ny" | ilab init
+
+    step Checking config.yaml
+    cat config.yaml | grep merlinite
+}
+
+test_download() {
+    task Download the model
+
+    if [ "$GRANITE" -eq 1 ]; then
+        step Downloading the granite model
+        ilab download --repository instructlab/granite-7b-lab-GGUF --filename granite-7b-lab-Q4_K_M.gguf
+    else
+        step Downloading the default model
+        ilab download
+    fi
+}
+
+test_serve() {
+    # Accepts an argument of the model, or default here
+    if [ "$GRANITE" -eq 1 ]; then
+        model="${1:-./models/granite-7b-lab-Q4_K_M.gguf}"
+    else
+        model="${1:-}"
+    fi
+    SERVE_ARGS=""
+    if [ -n "$model" ]; then
+        SERVE_ARGS="--model-path ${model}"
+    fi
+
+    task Serve the model
+    ilab serve ${SERVE_ARGS} &
+
+    ret=1
+    for i in $(seq 1 10); do
+        sleep 5
+    	step $i/10: Waiting for model to start
+        if curl -sS http://localhost:8000/docs > /dev/null; then
+            ret=0
+            break
+        fi
+    done
+
+    return $ret
+}
+
+test_chat() {
+    task Chat with the model
+    CHAT_ARGS=""
+    if [ "$GRANITE" -eq 1 ]; then
+        CHAT_ARGS="-m models/granite-7b-lab-Q4_K_M.gguf"
+    fi
+    printf 'Say "Hello"\n' | ilab chat ${CHAT_ARGS} | grep --color 'Hello'
+}
+
+test_taxonomy() {
+    task Update the taxonomy
+
+    test -d taxonomy || git clone https://github.com/instructlab/taxonomy || true
+
+    step Make new taxonomy
+    mkdir -p taxonomy/knowledge/sports/overview/softball
+
+    step Put new qna file into place
+    cp $SCRIPTDIR/test-data/basic-workflow-fixture-qna.yaml taxonomy/knowledge/sports/overview/softball/qna.yaml
+    head taxonomy/knowledge/sports/overview/softball/qna.yaml | grep --color '1st base'
+
+    step Verification
+    ilab diff
+}
+
+test_generate() {
+    task Generate synthetic data
+    if [ "$GRANITE" -eq 1 ]; then
+        GENERATE_ARGS="--model ./models/granite-7b-lab-Q4_K_M.gguf ${GENERATE_ARGS}"
+    fi
+    ilab generate --num-instructions ${NUM_INSTRUCTIONS} ${GENERATE_ARGS}
+}
+
+test_train() {
+    task Train the model
+
+    # TODO Only cuda for now
+    TRAIN_ARGS="--device=cuda --4-bit-quant"
+    if [ "$GRANITE" -eq 1 ]; then
+        TRAIN_ARGS="--gguf-model-path models/granite-7b-lab-Q4_K_M.gguf ${TRAIN_ARGS}"
+    fi
+
+    ilab train ${TRAIN_ARGS}
+}
+
+test_convert() {
+    task Converting the trained model and serving it
+    ilab convert
+}
+
+test_exec() {
+    # The list of actual tests to run through in workflow order
+    test_smoke
+    test_init
+    test_download
+
+    # See below for cleanup, this runs an ilab serve in the background
+    test_serve
+    PID=$!
+
+    test_chat
+    test_taxonomy
+    test_generate
+    test_train
+
+    if [ "$CI" -eq 1 ]; then
+        # This is what we expect to work in our CI runner so far
+        return
+    fi
+
+    # The rest is TODO when we can make it work on our CI runner
+
+    # When you run this --
+    #   `ilab convert` is only implemented for macOS with M-series chips for now
+    #test_convert
+
+    # Kill the serve process
+    task Stopping the ilab serve
+    step Kill ilab serve $PID
+    kill $PID
+
+    # TODO: chat with the new model
+    test_serve /tmp/somemodelthatispretrained.gguf
+    PID=$!
+
+    # TODO: Ask a qestion about softball
+    test_chat
+
+    # Kill the serve process
+    task Stopping the ilab serve
+    step Kill ilab serve $PID
+    kill $PID
+}
+
+usage() {
+    echo "Usage: $0 [-m] [-h]"
+    echo "  -m  Run minimal configuration (run quicker when you have no GPU)"
+    echo "  -c  Run in CI mode (explicitly skip steps we know will fail in linux CI)"
+    echo "  -g  Use the granite model"
+    echo "  -h  Show this help text"
+
+}
+
+# Process command line arguments
+task "Configuring ..."
+while getopts "cmgh" opt; do
+    case $opt in
+        c)
+            CI=1
+            step "Running in CI mode."
+            ;;
+        m)
+            MINIMAL=1
+            step "Running minimal configuration."
+            ;;
+        g)
+            GRANITE=1
+            step "Running with granite model."
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+set_defaults
+test_exec

--- a/scripts/test-data/basic-workflow-fixture-qna.yaml
+++ b/scripts/test-data/basic-workflow-fixture-qna.yaml
@@ -1,0 +1,77 @@
+created_by: jjasghar
+domain: sports
+seed_examples:
+- answer: |
+    1st base, 2nd base, 3rd base, and Home
+  question: |
+    What are the 4 bases in softball?
+- answer: |
+    Kitten ball was the first version of modern day softball.
+  question: |
+    What was the first iteration of softball in 1895 invented by Lewis Rober?
+- answer: |
+    12 inches or 30 cms
+  question: |
+    What was the size of the ball in the version of kitten ball created by Lewis Rober?
+- answer: |
+    Thanksgiving Day, 1887 in Chicago, Illinois.
+  question: |
+    When was the first, or earliest known game of softball played?
+- answer: |
+    Softball was originally envisioned for a way for baseball players to maintain their skills during the winter.
+  question: |
+    What was the original envisioning of softball for baseball players?
+- answer: |
+    indoor baseball, kitten ball, diamond ball, mush ball, pumpkinball
+  question: |
+    What was softball also known or named as?
+- answer: |
+    1953
+  question: |
+    When was the first British women's softball leauge established?
+- answer: |
+    7 innings, with a possibilty of 1 or 2 more, with a sudden death round
+  question: |
+    What is the typicial number of innings in a full league softball game?
+- answer: |
+    Home plate.
+  question: |
+    Where does the batter hit from on the field in softball?
+- answer: |
+    43 feet (13.11 m)
+  question: |
+    What is the fastball softball pitching distance for adult (over 16 years) female distance?
+- answer: |
+    43 feet (13.11 m)
+  question: |
+    What is the fastball softball pitching distance for under 16 years but older then 13 female distance?
+- answer: |
+    35 feet (10.67 m)
+  question: |
+    What is the fastball softball pitching distance for under 10 years but older then 8 female distance?
+- answer: |
+    wood, aluminum, or composite materials such as carbon fiber
+  question: |
+    What are the officially approved materials a softball bat can be made out of?
+- answer: |
+    Helmets must be worn by batters and runners.
+  question: |
+    Who on the field must wear a helmet in softball?
+- answer: |
+    Most of the time, the game starts with the umpire saying "play ball"
+  question: |
+    How do you know the softball game has started?
+- answer: |
+    When a throw goes out of the designated play area.
+  question: |
+    What is an overthrow or a "wild throw" in softball?
+- answer: |
+    A player that hits in place of one of the position players but does not play defense.
+  question: |
+    What is the "Designated player" in softball?
+task_description: 'Overview of the sport of softball'
+document:
+  repo: https://github.com/asgharlabs/softball_knowledge
+  commit: aff70ecee013899250f7e28bcbff3fdd6c788a6e
+  patterns:
+  - softball.md


### PR DESCRIPTION
This PR introduces a new job that runs in CI that performs a minimal
configuration of the `ilab` workflow:

- `ilab init`
- `ilab download`
- `ilab serve`
- `ilab generate`
- `ilab train`

It runs on a GPU-enabled github actions runner. This is a Linux VM
with a single Tesla T4 GPU.

Given the resources required to run this job, we do not propose that
it runs automatically on every PR. Instead, it is a workflow that must
be manually launched. When launching it manually, you can specify
which branch or pull request to run it against.

Signed-off-by: Stef Walter <stefw@redhat.com>
Co-authored-by: Russell Bryant <rbryant@redhat.com>
Signed-off-by: Russell Bryant <rbryant@redhat.com>

---

Depends on:

- [x] #1050 
- [x] #1058 

Related:

- [ ] Scope of what can be tested is limited by #579 

---

Follow-up work after this PR:

- Make another variant of this job that builds our instructlab container with cuda support and uses that to run the same workflow
- Consider how and where to run end-to-end tests for other environments, file tracking issues for those