### PR TITLE
containers: cuda contianer needs libcudann8 and nvidia-driver-NVML

### DIFF
--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -7,6 +7,7 @@ RUN python3.11 -m ensurepip
 RUN dnf install -y gcc
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo && dnf repolist && dnf config-manager --set-enabled cuda-rhel9-x86_64 && dnf config-manager --set-enabled cuda && dnf config-manager --set-enabled epel && dnf update -y
+RUN dnf install -y libcudnn8 nvidia-driver-NVML
 RUN python3.11 -m pip install --force-reinstall nvidia-cuda-nvcc-cu12
 RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64" \
     && export CUDA_HOME=/usr/local/cuda \


### PR DESCRIPTION
The libcudann8 container needs to be installed in the container or
else we see errors like this one:
    
        File "/usr/local/lib64/python3.11/site-packages/torch/__init__.py", line 237, in <module>
            from torch._C import *  # noqa: F403
            ^^^^^^^^^^^^^^^^^^^^^^
        ImportError: libcudnn.so.8: cannot open shared object file: No such file or directory
    
And in order to find devices in torch:
    
        $ python3.11
        >>> import torch
        >>> torch.cuda.device_count()
        1
    
The above returns zero without nvidia-driver-NVML