### PR TITLE
Add option to include max_tokens for the ilab chat

### DIFF
--- a/src/instructlab/chat/chat.py
+++ b/src/instructlab/chat/chat.py
@@ -71,6 +71,7 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
         loaded={},
         log_file=None,
         greedy_mode=False,
+        max_tokens=None,
     ):
         self.client = client
         self.model = model
@@ -79,6 +80,7 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
         self.loaded = loaded
         self.log_file = log_file
         self.greedy_mode = greedy_mode
+        self.max_tokens = max_tokens
 
         self.console = Console()
 
@@ -355,6 +357,9 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
             # https://platform.openai.com/docs/api-reference/chat/create#chat-create-temperature
             create_params["temperature"] = 0
 
+        if self.max_tokens:
+            create_params["max_tokens"] = self.max_tokens
+
         # Get and parse response
         try:
             while True:
@@ -453,6 +458,7 @@ def chat_cli(
     session,
     qq,
     greedy_mode,
+    max_tokens,
     tls_insecure,
     tls_client_cert: Optional[str] = None,
     tls_client_key: Optional[str] = None,
@@ -511,6 +517,7 @@ def chat_cli(
         greedy_mode=(
             greedy_mode if greedy_mode else config.greedy_mode
         ),  # The CLI flag can only be used to enable
+        max_tokens=(max_tokens if max_tokens else config.max_tokens),
     )
 
     if not qq and session is None:

--- a/src/instructlab/config.py
+++ b/src/instructlab/config.py
@@ -58,6 +58,7 @@ class _chat(BaseModel):
     session: Optional[str] = None
     logs_dir: Optional[str] = "data/chatlogs"
     greedy_mode: Optional[bool] = False
+    max_tokens: Optional[int] = None
 
 
 class _generate(BaseModel):

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -554,6 +554,11 @@ def generate(
     help="Use model greedy decoding. Useful for debugging and reproducing errors.",
 )
 @click.option(
+    "--max-tokens",
+    type=click.INT,
+    help="Set a maxinum number of tokens.",
+)
+@click.option(
     "--endpoint-url",
     type=click.STRING,
     help="Custom URL endpoint for OpenAI-compatible API. Defaults to the `ilab serve` endpoint.",
@@ -598,6 +603,7 @@ def chat(
     session,
     quick_question,
     greedy_mode,
+    max_tokens,
     endpoint_url,
     api_key,
     tls_insecure,
@@ -642,6 +648,7 @@ def chat(
             session=session,
             qq=quick_question,
             greedy_mode=greedy_mode,
+            max_tokens=max_tokens,
             tls_insecure=tls_insecure,
             tls_client_cert=tls_client_cert,
             tls_client_key=tls_client_key,

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -556,7 +556,7 @@ def generate(
 @click.option(
     "--max-tokens",
     type=click.INT,
-    help="Set a maxinum number of tokens.",
+    help="Set a maximum number of tokens to request from the model endpoint.",
 )
 @click.option(
     "--endpoint-url",


### PR DESCRIPTION
This patch add the option to pass max_token OpenAI API parameter to ilab chat to limit the number of tokens to be generated. This can be useful in low performance devices or with large models