### PR TITLE
mergify: Fix config for changes to github workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,7 @@ CI/CD:
   - changed-file:
       - any-glob-to-any-file:
           - .github/labeler.yml
+          - .github/mergify.yml
           - .github/workflows/**/*
           - scripts/ruff.sh
           - .pre-commit-config.yaml

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -31,7 +31,6 @@ pull_request_rules:
           - files~=tox.ini$
           - files~=scripts/.*\.sh$
       - and:
-        - -files~=.github/.*$
         - -files~=.*\.py$
         - -files~=pyproject.toml$
         - -files~=requirements.*\.txt$


### PR DESCRIPTION

commit 50b1799d725aaca21d651572512f34fa4fd31cf3
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Apr 26 12:39:38 2024 -0400

    mergify: Don't require lint & test on github config changes
    
    The previous config was excpecting the lint and test jobs to run and
    pass on PRs taht only changed files under `.github/`, but those PRs
    won't run those jobs.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
