### PR TITLE
Fix llama_cpp cuda usage in Containerfile

### DIFF
--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -14,7 +14,7 @@ RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cu
     && export PATH="/usr/local/cuda/bin:$PATH" \
     && export XLA_TARGET=cuda120 \
     && export XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
-RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-cache-dir llama-cpp-python
+RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install -r https://raw.githubusercontent.com/instructlab/instructlab/stable/requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
 RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@stable
 CMD ["/bin/bash"]
 


### PR DESCRIPTION
# Problem

The current cuda builds of instructlab are unaccelerated for serve/generate

# Changes

Sync requirements.txt of  llama_cpp_python with instructlab

The step which pip installs llama_cpp_python is overwritten by the instructlab install since the instructlab has a pinned version that is lesser than the preceding llama_cpp_python. Since the instructlab install does not specify the cuda CMAKE args it gets rebuilt without cuda support. By aligning requirements we ensure that  llama_cpp_python will not be rebuilt.

Before this change:

```
>>> llama_cpp.llama_supports_gpu_offload()      
False
```

After:

```      
>>> llama_cpp.llama_supports_gpu_offload()      
True
```
