### PR TITLE
github: Add a test-workflow-complete job

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -45,11 +45,7 @@ pull_request_rules:
     - or:
       - and:
         - check-success=lint
-        - check-success=3.9 on ubuntu-latest
-        - check-success=3.10 on ubuntu-latest
-        - check-success=3.11 on ubuntu-latest
-        - check-success=3.12 on ubuntu-latest
-        - check-success=3.11 on macos-latest
+        - check-success=test-workflow-complete
         - or:
           # see .github/workflows/lint.yml and test.yml
           - files~=.*\.py$

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,3 +87,10 @@ jobs:
       - name: Run unit tests with tox (macOS)
         if: startsWith(matrix.platform, 'macos')
         run: tox -e py-unit
+
+  test-workflow-complete:
+    needs: ["test"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test Workflow Complete
+        run: echo "Test Workflow Complete"


### PR DESCRIPTION
Instead of creating dependencies on specific test jobs, make a final job that depends on the others that can be referenced instead. This will simplify mergify configuration.