### PR TITLE
Enable building the container on AArch64 also

### DIFF
--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM nvcr.io/nvidia/cuda:12.3.2-devel-ubi9
-RUN dnf install -y python3.11 git python3-pip make automake gcc gcc-c++
+RUN dnf install -y python3.11-devel git python3-pip make automake gcc gcc-c++
 WORKDIR /instructlab
 RUN python3.11 -m ensurepip
 RUN dnf install -y gcc
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo && dnf repolist && dnf config-manager --set-enabled cuda-rhel9-x86_64 && dnf config-manager --set-enabled cuda && dnf config-manager --set-enabled epel && dnf update -y
+RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/$(uname -m)/cuda-rhel9.repo && dnf repolist && dnf config-manager --set-enabled cuda-rhel9-$(uname -m) && dnf config-manager --set-enabled cuda && dnf config-manager --set-enabled epel && dnf update -y
 RUN dnf install -y libcudnn8 nvidia-driver-NVML nvidia-driver-cuda-libs
 RUN python3.11 -m pip install --force-reinstall nvidia-cuda-nvcc-cu12
 RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64" \


### PR DESCRIPTION
remove the hardcoded x86_64 and use "uname -m" instead. On AArch64 python3.11-devel is neede to enable building

# Changes

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
