### PR TITLE
Disable push to Test PyPI on merge

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -44,10 +44,7 @@ jobs:
         name: Publish packages to test.pypi.org
         # environment: publish-test-pypi
         if: |
-            github.repository_owner == 'instructlab' && (
-                github.event.action == 'published' ||
-                (github.event_name == 'push' && github.ref == 'refs/heads/main')
-            )
+            github.repository_owner == 'instructlab' && github.event.action == 'published'
         runs-on: ubuntu-latest
         needs: build-package
 


### PR DESCRIPTION
# Changes

**Description of your changes:**

Test PyPI does not accept `dev` builds with local version. Disable push on PR merge for now.

> The use of local versions in <Version('0.14.1.dev11+g12e0386')> is not
> allowed. See https://packaging.python.org/specifications/core-metadata

