### PR TITLE
--hf-token flag is not used in .14 release

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -721,19 +721,19 @@ def download(ctx, repository, release, filename, model_dir, hf_token):
     try:
         if ctx.obj is not None:
             hf_logging.set_verbosity(ctx.obj.config.general.log_level.upper())
-        files = list_repo_files(repo_id=repository, token=os.getenv("HF_TOKEN"))
+        files = list_repo_files(repo_id=repository, token=hf_token)
         if any(".safetensors" in string for string in files):
             if not os.path.exists(os.path.join(model_dir, repository)):
                 os.makedirs(name=os.path.join(model_dir, repository), exist_ok=True)
             snapshot_download(
-                token=os.getenv("HF_TOKEN"),
+                token=hf_token,
                 repo_id=repository,
                 revision=release,
                 local_dir=os.path.join(model_dir, repository),
             )
         else:
             hf_hub_download(
-                token=os.getenv("HF_TOKEN"),
+                token=hf_token,
                 repo_id=repository,
                 revision=release,
                 filename=filename,


### PR DESCRIPTION
the code pulls from the env HF_TOKEN not from --hf_token


(cherry picked from commit 21b8eefbd03c4aca9af68e429a33561132ad636d)
