### PR TITLE
Don't fail if multiprocessing is already set to spawn; fix issues from lack of cleanup

### DIFF
--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -559,6 +559,8 @@ def generate_data(
                 json.dump(entry, outfile, ensure_ascii=False)
                 outfile.write("\n")
 
+    progress_bar.close()
+
     if total_discarded or total_rouged:
         logger.info(
             f"{len(machine_instruction_data)} instructions generated, {total_discarded} discarded due to format (see {output_file_discarded}), {total_rouged} discarded due to rouge score"

--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -499,11 +499,12 @@ def generate_data(
             new_instruction_tokens = scorer._tokenizer.tokenize(
                 instruction_data_entry["instruction"]
             )
-            with mpctx.Pool(num_cpus) as p:
-                rouge_scores = p.map(
+            with mpctx.Pool(num_cpus) as pool:
+                rouge_scores = pool.map(
                     partial(rouge_scorer._score_lcs, new_instruction_tokens),
                     all_instruction_tokens,
                 )
+            pool.join()
             instruction_data_entry["taxonomy_path"] = selected_taxonomy
             rouge_scores = [score.fmeasure for score in rouge_scores]
             # Comment out extra info not currently being used:

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -26,15 +26,11 @@ import yaml
 # NOTE: Subcommands are using local imports to speed up startup time.
 from . import config, utils
 
-# 'fork' incompatible with some hardware accelerators
-try:
-    multiprocessing.set_start_method(config.DEFAULT_MULTIPROCESSING_START_METHOD)
-except RuntimeError as _mp_set_e:
-    if multiprocessing.get_start_method() == "fork":
-        raise ValueError(
-            "multiprocessing start method already set to 'fork'."
-        ) from _mp_set_e
-
+# 'fork' is unsafe and incompatible with some hardware accelerators.
+# Python 3.14 will switch to 'spawn' on all platforms.
+multiprocessing.set_start_method(
+    config.DEFAULT_MULTIPROCESSING_START_METHOD, force=True
+)
 
 # Set logging level of OpenAI client and httpx library to ERROR to suppress INFO messages
 logging.getLogger("openai").setLevel(logging.ERROR)

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -29,9 +29,11 @@ from . import config, utils
 # 'fork' incompatible with some hardware accelerators
 try:
     multiprocessing.set_start_method(config.DEFAULT_MULTIPROCESSING_START_METHOD)
-except RuntimeError as e:
+except RuntimeError as _mp_set_e:
     if multiprocessing.get_start_method() == "fork":
-        raise ValueError(f"multiprocessing start method already set to 'fork'.") from e
+        raise ValueError(
+            "multiprocessing start method already set to 'fork'."
+        ) from _mp_set_e
 
 
 # Set logging level of OpenAI client and httpx library to ERROR to suppress INFO messages

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -7,6 +7,7 @@ from glob import glob
 from os.path import basename, dirname, exists, splitext
 import json
 import logging
+import multiprocessing
 import os
 import shutil
 import sys
@@ -24,6 +25,14 @@ import yaml
 # Local
 # NOTE: Subcommands are using local imports to speed up startup time.
 from . import config, utils
+
+# 'fork' incompatible with some hardware accelerators
+try:
+    multiprocessing.set_start_method(config.DEFAULT_MULTIPROCESSING_START_METHOD)
+except RuntimeError as e:
+    if multiprocessing.get_start_method() == "fork":
+        raise ValueError(f"multiprocessing start method already set to 'fork'.") from e
+
 
 # Set logging level of OpenAI client and httpx library to ERROR to suppress INFO messages
 logging.getLogger("openai").setLevel(logging.ERROR)

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -492,7 +492,7 @@ def generate(
         api_base = endpoint_url
     else:
         try:
-            server_process, api_base = ensure_server(
+            server_process, api_base, server_queue = ensure_server(
                 ctx.obj.logger,
                 ctx.obj.config.serve,
                 tls_insecure,
@@ -542,6 +542,8 @@ def generate(
         if server_process:
             server_process.terminate()
             server_process.join(timeout=30)
+            server_queue.close()
+            server_queue.join_thread()
 
 
 @cli.command()
@@ -650,7 +652,7 @@ def chat(
         server_process = None
     else:
         try:
-            server_process, api_base = ensure_server(
+            server_process, api_base, server_queue = ensure_server(
                 ctx.obj.logger,
                 ctx.obj.config.serve,
                 tls_insecure,
@@ -689,6 +691,8 @@ def chat(
         if server_process:
             server_process.terminate()
             server_process.join(timeout=30)
+            server_queue.close()
+            server_queue.join_thread()
 
 
 @cli.command()

--- a/src/instructlab/server.py
+++ b/src/instructlab/server.py
@@ -9,7 +9,6 @@ import os
 import random
 import signal
 import socket
-import sys
 
 # Third Party
 from llama_cpp import llama_chat_format
@@ -72,8 +71,7 @@ def ensure_server(
         return (None, None, None)
     except ClientException:
         tried_ports = set()
-        # TODO: use fork, "spawn" fails with semaphore FileNotFound on Linux.
-        mpctx = multiprocessing.get_context("fork" if sys.platform == "linux" else None)
+        mpctx = multiprocessing.get_context(None)
         # use a queue to communicate between the main process and the server process
         queue = mpctx.Queue()
         port = random.randint(1024, 65535)

--- a/src/instructlab/server.py
+++ b/src/instructlab/server.py
@@ -21,7 +21,7 @@ import uvicorn
 
 # Local
 from .client import ClientException, list_models
-from .config import get_api_base, DEFAULT_MULTIPROCESSING_START_METHOD
+from .config import get_api_base
 
 templates = [
     {

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -20,21 +20,9 @@ import torch
 
 # Local
 from ..chat.chat import CONTEXTS
-from ..config import DEFAULT_MULTIPROCESSING_START_METHOD
 
 # TODO CPU: Look into using these extensions
 # import intel_extension_for_pytorch as ipex
-
-# 'fork' incompatible with some hardware accelerators
-try:
-    torch.multiprocessing.set_start_method(DEFAULT_MULTIPROCESSING_START_METHOD)
-except RuntimeError as e:
-    start_method = torch.multiprocessing.get_start_method()
-    if start_method != DEFAULT_MULTIPROCESSING_START_METHOD:
-        raise ValueError(
-            f"multiprocessing start method already set to {start_method}."
-        ) from e
-    del start_method
 
 
 class StoppingCriteriaSub(StoppingCriteria):

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -26,7 +26,15 @@ from ..config import DEFAULT_MULTIPROCESSING_START_METHOD
 # import intel_extension_for_pytorch as ipex
 
 # 'fork' incompatible with some hardware accelerators
-torch.multiprocessing.set_start_method(DEFAULT_MULTIPROCESSING_START_METHOD)
+try:
+    torch.multiprocessing.set_start_method(DEFAULT_MULTIPROCESSING_START_METHOD)
+except RuntimeError as e:
+    start_method = torch.multiprocessing.get_start_method()
+    if start_method != DEFAULT_MULTIPROCESSING_START_METHOD:
+        raise ValueError(
+            f"multiprocessing start method already set to {start_method}."
+        ) from e
+    del start_method
 
 
 class StoppingCriteriaSub(StoppingCriteria):


### PR DESCRIPTION
# Changes

**Description of your changes:**

Python multiprocessing does not allow th change the default start method when another code path has already configured a default start method. Even `get_start_method` or `get_context` sets a default context.

I was running into this exception when doing training with some hardware accelerator frameworks like Habana.

```python
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.10/multiprocessing/context.py", line 247, in set_start_method
    raise RuntimeError('context has already been set')
RuntimeError: context has already been set
```

---

After fixing the issue above, we were still seeing multiprocessing-related bugs exposed via CI. We went through and made several other changes ensuring that resources were cleaned up appropriately. Those fixes are included, as well.