### PR TITLE
Automatically apply a backport label to release branch PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -137,3 +137,11 @@ pull_request_rules:
       remove:
         - needs-rebase
 
+- name: backport-label
+  description: Automatically apply the backport label to release branch PRs
+  conditions:
+    - base~=release-.*
+  actions:
+    label:
+      add:
+        - backport

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,26 +1,4 @@
 pull_request_rules:
-- name: ping author on conflicts and add 'needs-rebase' label
-  conditions:
-      - conflict
-      - -closed
-  actions:
-    label:
-      add:
-        - needs-rebase
-    comment:
-      message: |
-       This pull request has merge conflicts that must be resolved before it can be
-       merged. @{{author}} please rebase it. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
-
-- name: remove 'needs-rebase' label when conflict is resolved
-  conditions:
-      - -conflict
-      - -closed
-  actions:
-    label:
-      remove:
-        - needs-rebase
-
 - name: auto-merge
   description: automatic merge for main with > 1 approved reviews, all requested reviews have given feedback, not held, and CI is successful
   conditions:
@@ -136,3 +114,26 @@ pull_request_rules:
     label:
       add:
         - testing
+
+- name: ping author on conflicts and add 'needs-rebase' label
+  conditions:
+      - conflict
+      - -closed
+  actions:
+    label:
+      add:
+        - needs-rebase
+    comment:
+      message: |
+       This pull request has merge conflicts that must be resolved before it can be
+       merged. @{{author}} please rebase it. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
+
+- name: remove 'needs-rebase' label when conflict is resolved
+  conditions:
+      - -conflict
+      - -closed
+  actions:
+    label:
+      remove:
+        - needs-rebase
+


### PR DESCRIPTION
- **mergify: Keep auto merge rule at the top**
- **mergify: Automatically apply backport label**


commit af7562a584fec812998df5474a2a3176960e0c3f
Author: Russell Bryant <rbryant@redhat.com>
Date:   Tue Apr 30 14:17:04 2024 -0400

    mergify: Keep auto merge rule at the top
    
    This lets us keep all the labeling related rules together.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 3d4a2511d6bcf5cb80ffd23a9dc2df88c770d1e4
Author: Russell Bryant <rbryant@redhat.com>
Date:   Tue Apr 30 14:18:46 2024 -0400

    mergify: Automatically apply backport label
    
    Apply the backport label to all PRs posted against release branches.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
