### PR TITLE
linux-train: Skip convert to gguf when --4-bit-quant is used

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1002,6 +1002,13 @@ def train(
             shutil.copy(file, final_results_dir)
             print("Copied ", file, "to ", final_results_dir)
 
+        if four_bit_quant:
+            print(
+                "SKIPPING CONVERSION to gguf. This is unsupported with --4-bit-quant. "
+                + "See https://github.com/instructlab/instructlab/issues/579."
+            )
+            return
+
         convert_llama_to_gguf(model=final_results_dir, pad_vocab=True)
 
         gguf_models_dir = "./models"


### PR DESCRIPTION
This is known to be broken, per issue #579. Instead of failing,
exit cleanly before we know it will fail, but print a message
noting what was skipped, along with a link to the issue.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
