### PR TITLE
generate: warn when llama_cpp has not hardware acceleration

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -484,6 +484,18 @@ def generate(
     if endpoint_url:
         api_base = endpoint_url
     else:
+        # Third Party
+        import llama_cpp
+
+        if not llama_cpp.llama_supports_gpu_offload():
+            # TODO: check for working offloading. The function only checks
+            # for compile time defines like `GGML_USE_CUDA`.
+            click.secho(
+                "llama_cpp_python is built without hardware acceleration. "
+                "ilab generate will be very slow.",
+                fg="red",
+            )
+
         try:
             server_process, api_base = ensure_server(
                 ctx.obj.logger,


### PR DESCRIPTION
# Changes

**Description of your changes:**

`ilab generate` without hardware acceleration is very slow. Notify the user when llama_cpp is not compiled with GPU or other accelerators. `llama_supports_gpu_offload` does not check whether a device is available or GPU offloading actually works.