### PR TITLE
fix: Add hf-token default to fix checking error

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -711,6 +711,7 @@ def chat(
 )
 @click.option(
     "--hf-token",
+    default="",
     envvar="HF_TOKEN",
     help="User access token for connecting to the Hugging Face Hub.",
 )


### PR DESCRIPTION
**Description of your changes:**

The code check in https://github.com/instructlab/instructlab/blob/main/src/instructlab/lab.py#L721 will not be satisfied even if you pass non "instructlab" repository unless you pass the flag ` --hf-token ""` also. This is because the default is not set. This sets the default.

Test before and after with the following command: `ilab download --repository XXX/granite-7b-lab-GGUF --filename  granite-7b-lab-Q4_K_M.gguf`
