### PR TITLE
containers/cuda: Allow specifying git branch to build from

### DIFF
--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -14,7 +14,9 @@ RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cu
     && export PATH="/usr/local/cuda/bin:$PATH" \
     && export XLA_TARGET=cuda120 \
     && export XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
-RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" CFLAGS="-mno-avx" python3.11 -m pip install -r https://raw.githubusercontent.com/instructlab/instructlab/stable/requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
-RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@stable
-CMD ["/bin/bash"]
 
+ARG GIT_TAG=stable
+RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" CFLAGS="-mno-avx" python3.11 -m pip install -r https://raw.githubusercontent.com/instructlab/instructlab/${GIT_TAG}/requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
+RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@${GIT_TAG}
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
This PR adds a new arg to the cuda Containerfile to specify which
instructlab git branch to build from. The default stays the same,
using `stable`.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
