### PR TITLE
Enforce maximum length in generate seed examples

### DIFF
--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -241,6 +241,20 @@ def num_chars_from_tokens(num_tokens) -> int:
     return int(num_tokens * 4)  # 1 token ~ 4 English character
 
 
+def num_tokens_from_chars(num_chars) -> int:
+    return int(num_chars / 4)  # 1 token ~ 4 English character
+
+
+def max_seed_example_tokens(server_ctx_size, prompt_num_chars) -> int:
+    # Ensure we have at least 1024 tokens available for a response.
+    max_seed_tokens = server_ctx_size - 1024
+    # Subtract the number of tokens in our prompt template
+    max_seed_tokens = max_seed_tokens - num_tokens_from_chars(prompt_num_chars)
+    # Divide number of characters by 2, since we insert 2 examples
+    max_seed_tokens = int(max_seed_tokens / 2)
+    return max_seed_tokens
+
+
 def chunk_document(documents: List, server_ctx_size, chunk_word_count) -> List[str]:
     """
     Iterates over the documents and splits them into chunks based on the word count provided by the user.

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -246,6 +246,33 @@ def num_tokens_from_chars(num_chars) -> int:
 
 
 def max_seed_example_tokens(server_ctx_size, prompt_num_chars) -> int:
+    """
+    Estimates the maximum number of tokens any seed example can have based
+    on the server context size and number of characters in the selected prompt.
+
+    A lot has to fit into the given server context size:
+      - The prompt itself, which can vary in size a bit based on model family and knowledge vs skill
+      - Two seed examples, which we append to the prompt template.
+      - A knowledge document chunk, if this is a knowledge example.
+      - The generated completion, which can vary substantially in length.
+
+    This is an attempt to roughly estimate the maximum size any seed example
+    (question + answer + context values from the yaml) should be to even have
+    a hope of not often exceeding the server's maximum context size.
+
+    NOTE: This does not take into account knowledge document chunks. It's meant
+    to calculate the maximum size that any seed example should be, whether knowledge
+    or skill. Knowledge seed examples will want to stay well below this limit.
+
+    NOTE: This is a very simplistic calculation, and examples with lots of numbers
+    or punctuation may have quite a different token count than the estimates here,
+    depending on the model (and thus tokenizer) in use. That's ok, as it's only
+    meant to be a rough estimate.
+
+    Args:
+        server_ctx_size (int): Size of the server context, in tokens.
+        prompt_num_chars (int): Number of characters in the prompt (not including the examples)
+    """
     # Ensure we have at least 1024 tokens available for a response.
     max_seed_tokens = server_ctx_size - 1024
     # Subtract the number of tokens in our prompt template

--- a/tests/testdata/skill_too_long_answer.yaml
+++ b/tests/testdata/skill_too_long_answer.yaml
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+
+created_by: test-bot
+version: 2
+seed_examples:
+- answer: |
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
+  question: |
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+    Is this for a test? Is this for a test? Is this for a test?
+- answer: Yes I am very sure.
+  question: Are you sure it's for a test?
+- answer: "answer3"
+  question: "question3"
+- answer: "answer4"
+  question: "question4"
+- answer: "answer5"
+  question: "question5"
+task_description: for testing

--- a/tests/testdata/skill_too_long_answer.yaml
+++ b/tests/testdata/skill_too_long_answer.yaml
@@ -29,33 +29,6 @@ seed_examples:
     Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
     Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
     Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
-    Yes, it is. Yes, it is. Yes, it is. Yes, it is. Yes, it is.
   question: |
     Is this for a test? Is this for a test? Is this for a test?
     Is this for a test? Is this for a test? Is this for a test?
@@ -82,37 +55,212 @@ seed_examples:
     Is this for a test? Is this for a test? Is this for a test?
     Is this for a test? Is this for a test? Is this for a test?
     Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-    Is this for a test? Is this for a test? Is this for a test?
-- answer: Yes I am very sure.
-  question: Are you sure it's for a test?
-- answer: "answer3"
-  question: "question3"
-- answer: "answer4"
-  question: "question4"
-- answer: "answer5"
-  question: "question5"
-task_description: for testing
+- answer: |
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+    Yes I am very sure. Yes I am very sure. Yes I am very sure.
+  question: |
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+    Are you sure it's for a test? Are you sure it's for a test?
+- answer: |
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+    Answer 3 goes here. Answer 3 goes here. Answer 3 goes here.
+  question: |
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+    Question 3 goes here. Question 3 goes here. Question 3 goes here.
+- answer: |
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+    Answer 4 goes here. Answer 4 goes here. Answer 4 goes here.
+  question: |
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+    Question 4 goes here. Question 4 goes here. Question 4 goes here.
+- answer: |
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+    Answer 5 goes here. Answer 5 goes here. Answer 5 goes here.
+  question: |
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+    Question 5 goes here. Question 5 goes here. Question 5 goes here.
+task_description: long yaml for testing context windows


### PR DESCRIPTION
This calculates a maximum number of characters per seed instruction example based on the configured server context size as passed to `ilab generate`. Before starting the generation, we verify that none of the examples we're going to use exceed this limit. If they do, we fail generation with a helpful error message.

When adding generated responses to our list of seed examples, we do a similar check of the response length. If the response is too long, we skip adding that particular response to our list of seed examples so that we don't end up adding really long machine-generated responses to our seed examples and blowing our context size that way.

Helps #1024 but doesn't entirely fix all sources of exceeding our context.
