### PR TITLE
feat: use labels to trigger backports

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -145,3 +145,11 @@ pull_request_rules:
     label:
       add:
         - backport
+
+- name: backport release-v0.14
+  actions:
+    backport:
+      branches:
+        - release-v0.14
+  conditions:
+    - label=backport-release-v0.14


### PR DESCRIPTION
When setting a label to a PR, if it matches 'backport-release-v014' Mergify will automatically create a backport PR in the configured stable branch.
I've found this approach easier than writing a comment to a PR, also we can visually see if a PR made it in a release branch by looking at the label.
The only condition is to create the label.

Signed-off-by: Sébastien Han <seb@redhat.com>