### PR TITLE
Fix broken md linting in schema submodule

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -13,7 +13,8 @@ globs:
   - "**/*.md"
 ignores:
   - ".tox/**"
-  - "venv/**"
   - ".venv/**"
   - "build/**"
+  - "src/instructlab/schema/**"
   - "tests/**"
+  - "venv/**"


### PR DESCRIPTION
**Description of your changes:**

Pulls the latest schema commit whereby the schema linting has been fixed. Also, disables linting of schema in this repo as it should be linted in its own repo.
