### PR TITLE
mergify: Rename backport label to release-branch

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -137,14 +137,14 @@ pull_request_rules:
       remove:
         - needs-rebase
 
-- name: backport-label
-  description: Automatically apply the backport label to release branch PRs
+- name: release-branch-label
+  description: Automatically apply the release-branch label to release branch PRs
   conditions:
     - base~=release-.*
   actions:
     label:
       add:
-        - backport
+        - release-branch
 
 - name: backport release-v0.14
   actions:


### PR DESCRIPTION
In #1074, we added a new way to trigger backports using backport
labels. To help avoid confusion, rename this label to reflect which
PRs are against release branches.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
