### PR TITLE
Do test builds of the cuda image in CI

### DIFF
--- a/.github/workflows/image-cuda.yml
+++ b/.github/workflows/image-cuda.yml
@@ -1,0 +1,109 @@
+name: Test build cuda container image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'containers/cuda/Containerfile'
+      - '.github/workflows/image-cuda.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'containers/cuda/Containerfile'
+      - '.github/workflows/image-cuda.yml'
+
+# Note that the current containerfile builds against a git ref.
+# It is not built against the current source tree. So, we test
+# build the image against `stable` and `main` if the file changes.
+jobs:
+  build_cuda_image_stable:
+    name: Build CUDA image for stable
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          df -h
+          sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
+          sudo rm -rf \
+            /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+            /usr/lib/jvm || true
+          sudo apt install aptitude -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
+          sudo apt-get autoremove -y >/dev/null 2>&1
+          sudo apt-get autoclean -y >/dev/null 2>&1
+          df -h
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for gotbot image
+        id: gobot_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}/instructlab-cuda
+
+      - name: Build and push gobot image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            GIT_TAG=stable
+          push: false
+          tags: ${{ steps.gobot_meta.outputs.tags }}
+          labels: ${{ steps.gobot_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: containers/cuda/Containerfile
+
+  build_cuda_image_main:
+    name: Build CUDA image for main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          df -h
+          sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
+          sudo rm -rf \
+            /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+            /usr/lib/jvm || true
+          sudo apt install aptitude -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
+          sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
+          sudo apt-get autoremove -y >/dev/null 2>&1
+          sudo apt-get autoclean -y >/dev/null 2>&1
+          df -h
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for gotbot image
+        id: gobot_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}/instructlab-cuda
+
+      - name: Build and push gobot image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            GIT_TAG=main
+          push: false
+          tags: ${{ steps.gobot_meta.outputs.tags }}
+          labels: ${{ steps.gobot_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: containers/cuda/Containerfile

--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -14,7 +14,9 @@ RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cu
     && export PATH="/usr/local/cuda/bin:$PATH" \
     && export XLA_TARGET=cuda120 \
     && export XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
-RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" CFLAGS="-mno-avx" python3.11 -m pip install -r https://raw.githubusercontent.com/instructlab/instructlab/stable/requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
-RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@stable
-CMD ["/bin/bash"]
 
+ARG GIT_TAG=stable
+RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" CFLAGS="-mno-avx" python3.11 -m pip install -r https://raw.githubusercontent.com/instructlab/instructlab/${GIT_TAG}/requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
+RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@${GIT_TAG}
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
- **containers/cuda: Allow specifying git branch to build from**
- **ci: Add a job that does test builds of the cuda image**


commit 971994d1df8a12e47cc00d3b94c11e8c0961054f
Author: Russell Bryant <rbryant@redhat.com>
Date:   Sat Apr 27 21:07:59 2024 -0400

    containers/cuda: Allow specifying git branch to build from
    
    This PR adds a new arg to the cuda Containerfile to specify which
    instructlab git branch to build from. The default stays the same,
    using `stable`.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit d6134622e3a64e215e45a39afd23c48723d31d70
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu May 2 16:53:20 2024 -0400

    ci: Add a job that does test builds of the cuda image
    
    If the file `containers/cuda/Containerfile` changes, do a test build
    of it against `main` and `stable`. I don't have it doing test builds
    for all changes, because this isn't written to test building an image
    with the code in the current source tree.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

---

Includes #1066 