### PR TITLE
fix: cleaner message when generate dir is empty

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -924,6 +924,13 @@ def train(
             # generated input files reverse sorted by name (contains timestamp)
             train_files = sorted(glob(input_dir + "/train_*"), reverse=True)
             test_files = sorted(glob(input_dir + "/test_*"), reverse=True)
+
+            if not train_files or not test_files:
+                click.secho(
+                    f"{input_dir} does not contain training or test files, did you run `ilab generate`?",
+                    fg="red",
+                )
+                raise click.exceptions.Exit(1)
             if len(train_files) > 1 or len(test_files) > 1:
                 # pylint: disable=f-string-without-interpolation
                 click.secho(
@@ -942,12 +949,6 @@ def train(
         except OSError as exc:
             click.secho(
                 f"Could not create data dir: {exc}",
-                fg="red",
-            )
-            raise click.exceptions.Exit(1)
-        except IndexError as exc:
-            click.secho(
-                f"Could not copy into data directory: {exc}",
                 fg="red",
             )
             raise click.exceptions.Exit(1)

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -158,7 +158,7 @@ class TestLabTrain(unittest.TestCase):
             result = runner.invoke(lab.train, ["--input-dir", INPUT_DIR])
             self.assertIsNotNone(result.exception)
             self.assertIn(
-                "Could not copy into data directory: list index out of range",
+                f"{INPUT_DIR} does not contain training or test files, did you run `ilab generate`?",
                 result.output,
             )
             self.assertEqual(result.exit_code, 1)


### PR DESCRIPTION
Instead of returning the out of range error let's make it more human-readable.

Fixes: https://github.com/instructlab/instructlab/issues/1084
Signed-off-by: Sébastien Han <seb@redhat.com>

