### PR TITLE
fix: handle incorrect log level

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@
 pre-commit>=3.0.4,<4.0
 pydeps>=1.12.12,<2
 pylint>=2.16.2,<4.0
+pylint-pydantic
 pytest
 pytest-asyncio
 pytest-cov

--- a/src/instructlab/config.py
+++ b/src/instructlab/config.py
@@ -4,7 +4,14 @@
 from typing import Optional
 
 # Third Party
-from pydantic import BaseModel, ConfigDict, PositiveInt, StrictStr, ValidationError
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    PositiveInt,
+    StrictStr,
+    ValidationError,
+    field_validator,
+)
 import httpx
 import yaml
 
@@ -40,6 +47,26 @@ class _general(BaseModel):
 
     # optional fields
     log_level: Optional[StrictStr] = "INFO"
+
+    @field_validator("log_level")
+    def validate_log_level(cls, v):
+        # TODO: remove 'valid_levels' once we switch to support Python 3.11+ and call
+        # "logging.getLevelNamesMapping()" instead
+        valid_levels = [
+            "DEBUG",
+            "INFO",
+            "WARNING",
+            "WARN",
+            "FATAL",
+            "CRITICAL",
+            "ERROR",
+            "NOTSET",
+        ]
+        if v.upper() not in valid_levels:
+            raise ValueError(
+                f"'{v}' is not a valid log level name. valid levels: {valid_levels}"
+            )
+        return v.upper()
 
 
 class _chat(BaseModel):

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ skip_install = true
 skipsdist = true
 deps = -r requirements-dev.txt
 commands =
-    {envpython} -m pylint src/instructlab/ tests/
+    {envpython} -m pylint --load-plugins pylint_pydantic src/instructlab/ tests/
 
 [testenv:fastlint]
 description = fast lint with pylint (without 3rd party modules)
@@ -40,8 +40,9 @@ skip_install = true
 skipsdist = true
 deps =
     pylint
+    pylint-pydantic
 commands =
-    {envpython} -m pylint {posargs:--disable=import-error src/instructlab/ tests/}
+    {envpython} -m pylint --load-plugins pylint_pydantic {posargs:--disable=import-error src/instructlab/ tests/}
 
 [testenv:ruff]
 description = reformat and fix code with Ruff (and isort)


### PR DESCRIPTION
If the specified log level in the config file is incorrect we return an
error and print the allowed levels.
Sadly, only Python 3.11+ supports logging.getLevelNamesMapping that
could be used to get the exhaustive list of supported level names. So we
maintain our own for the time being.

Fixes: https://github.com/instructlab/instructlab/issues/1091
Co-authored-by: Ihar Hrachyshka <ihrachys@redhat.com>
Signed-off-by: Sébastien Han <seb@redhat.com>