### PR TITLE
fix: update config file and chat ctx while serving model

### DIFF
--- a/src/instructlab/chat/chat.py
+++ b/src/instructlab/chat/chat.py
@@ -181,7 +181,7 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
             raise KeyboardInterrupt
         context = cs[1]
         if context not in CONTEXTS:
-            available_contexts = ", ".join(CONTEXTS.keys())
+            available_contexts = ", ".ƒdeoin(CONTEXTS.keys())
             self._sys_print(
                 Markdown(
                     f"**WARNING**: Context `{context}` not found. "
@@ -501,7 +501,7 @@ def chat_cli(
 
     # Initialize chat bot
     ccb = ConsoleChatBot(
-        config.model if model is None else model,
+        model if config.model is None else config.model,
         client=client,
         vi_mode=config.vi_mode,
         log_file=log_file,

--- a/src/instructlab/chat/chat.py
+++ b/src/instructlab/chat/chat.py
@@ -181,7 +181,7 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
             raise KeyboardInterrupt
         context = cs[1]
         if context not in CONTEXTS:
-            available_contexts = ", ".ƒdeoin(CONTEXTS.keys())
+            available_contexts = ", ".join(CONTEXTS.keys())
             self._sys_print(
                 Markdown(
                     f"**WARNING**: Context `{context}` not found. "

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import sys
 import typing
+from pathlib import Path
 
 # Third Party
 from click_didyoumean import DYMGroup
@@ -309,6 +310,12 @@ def serve(ctx, model_path, gpu_layers, num_threads, max_ctx_size, model_family):
     # pylint: disable=C0415
     # Local
     from .server import ServerException, server
+
+    served_model = model_path.split('/')[-1]
+    configPath = os.path.join(Path(__file__).resolve().parent.parent.parent.parent, "config.yaml")
+    configFile = config.read_config(config_file=configPath)
+    configFile.chat.model = served_model
+    config.write_config(cfg=configFile, config_file=configPath)
 
     ctx.obj.logger.info(
         f"Using model '{model_path}' with {gpu_layers} gpu-layers and {max_ctx_size} max context size."
@@ -637,6 +644,10 @@ def chat(
     # Local
     from .chat.chat import ChatException, chat_cli
     from .server import ensure_server
+
+    configPath = os.path.join(Path(__file__).resolve().parent.parent.parent.parent, "config.yaml")
+    configFile = config.read_config(config_file=configPath)
+    ctx.obj.config.chat.model = configFile.chat.model
 
     if endpoint_url:
         api_base = endpoint_url


### PR DESCRIPTION
# Changes
Updates logic in `serve` and `chat` to use the `config.yaml` to determine model name to be displayed in the chat window

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
use model path provided to serve, identify model name from given path, update `chat.model` field in `config.yaml`, read the `chat.model` field and populate the chat ctx before displaying the name during `ilab chat`