### PR TITLE
feat: add a welcome message to our server root

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -293,6 +293,22 @@ test_temp_server_ignore_internal_messages(){
     '
 }
 
+test_server_welcome_message(){
+    # test that the server welcome message is displayed
+    ilab serve &
+    PID_SERVE=$!
+
+    if ! timeout 30 bash -c '
+        until curl 127.0.0.1:8000|grep "{\"message\":\"Hello from InstructLab! Visit us at https://instructlab.ai\"}"; do
+            echo "waiting for server to start"
+            sleep 1
+        done
+    '; then
+        echo "server did not start"
+        exit 1
+    fi
+}
+
 ########
 # MAIN #
 ########
@@ -313,5 +329,7 @@ cleanup
 test_no_chat_logs
 cleanup
 test_temp_server_ignore_internal_messages
+cleanup
+test_server_welcome_message
 
 exit 0

--- a/src/instructlab/server.py
+++ b/src/instructlab/server.py
@@ -163,6 +163,12 @@ def server(
         settings.n_threads = threads
     try:
         app = create_app(settings=settings)
+
+        @app.get("/")
+        def read_root():
+            return {
+                "message": "Hello from InstructLab! Visit us at https://instructlab.ai"
+            }
     except ValueError as exc:
         if queue:
             queue.put(exc)


### PR DESCRIPTION
Our server can now be identified easily by fetching the root of the API:

```
curl 127.0.0.1:8000/                                                                   ✹
{"message":"Hello from InstructLab! Visit us at https://instructlab.ai"}%
```

Fixes: https://github.com/instructlab/instructlab/issues/1094
Signed-off-by: Sébastien Han <seb@redhat.com>
