### PR TITLE
Docs: Improve instructions for hardware acceleration

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -57,6 +57,7 @@ Miniforge
 Mixtral
 MLX
 mlx
+MPS
 NVidia
 Nvidia
 orchestrator
@@ -84,6 +85,7 @@ Salawu
 SDG
 sexualized
 SHA
+Shaders
 Shivchander
 Srivastava
 subdirectory

--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ The full process is described graphically in the [workflow diagram](./docs/workf
 
    > **NOTE**: ⏳ `pip install` may take some time, depending on your internet connection.
 
+   See [the GPU acceleration documentation](./docs/gpu-acceleration.md) how to
+   to enable hardware acceleration for inference and training on AMD ROCm,
+   NVidia CUDA, and Apple Metal Performance Shaders (MPS).
+
+   ```shell
+   rm -rf venv
+   python3 -m venv venv
+   source venv/bin/activate
+   (venv) $ pip cache remove llama_cpp_python
+   (venv) $ pip install git+https://github.com/instructlab/instructlab.git@stable -C cmake.args="-DLLAMA_CUBLAS=on"
+   ```
+
+   ```shell
+   rm -rf venv
+   python3 -m venv venv
+   source venv/bin/activate
+   (venv) $ pip cache remove llama_cpp_python
+   (venv) $ pip install git+https://github.com/instructlab/instructlab.git@stable -C cmake.args="-DLLAMA_METAL=on"
+   ```
+
 4. From your `venv` environment, verify `ilab` is installed correctly, by running the `ilab` command.
 
    ```shell

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ There are three options to train the model on your synthetic data-enhanced datas
 ilab train
 ```
 
-> **NOTE:** ⏳ This step can potentially take **several hours** to complete depending on your computing resources.
+> **NOTE:** ⏳ This step can potentially take **several hours** to complete depending on your computing resources. Please stop `ilab chat` and `ilab serve` first to free resources.
 
 `ilab train` outputs a brand-new model that can be served in the `models` directory called `ggml-model-f16.gguf`.
 
@@ -366,10 +366,6 @@ ilab train
  (venv) $ ls models
  ggml-merlinite-7b-lab-Q4_K_M.gguf  ggml-model-f16.gguf
 ```
-
-> **NOTE:** `ilab train` ships with experimental support for GPU acceleration with Nvidia CUDA
-or AMD ROCm. See [the GPU acceleration documentation](./docs/gpu-acceleration.md) for more
-details.
 
 #### Train the model locally on an M-series Mac
 
@@ -390,6 +386,14 @@ adapters-010.npz        adapters-050.npz        adapters-090.npz        config.j
 adapters-020.npz        adapters-060.npz        adapters-100.npz        model.safetensors       tokenizer_config.json
 adapters-030.npz        adapters-070.npz        adapters.npz            special_tokens_map.json
 adapters-040.npz        adapters-080.npz        added_tokens.json       tokenizer.jso
+```
+
+#### Training the model locally with GPU acceleration
+
+Training has experimental support for GPU acceleration with Nvidia CUDA or AMD ROCm. Please see [the GPU acceleration documentation](./docs/gpu-acceleration.md) for more details. At present, hardware acceleration requires a data center GPU or high-end consumer GPU with at least 18 GB free memory.
+
+```shell
+ilab train --device=cuda
 ```
 
 #### Training the model in the cloud

--- a/README.md
+++ b/README.md
@@ -95,32 +95,54 @@ The full process is described graphically in the [workflow diagram](./docs/workf
 
 3. Install and activate your `venv` environment by running the following command:
 
-   ```shell
-   python3 -m venv venv
-   source venv/bin/activate
-   pip install git+https://github.com/instructlab/instructlab.git@stable
-   ```
-
-   > **NOTE**: ⏳ `pip install` may take some time, depending on your internet connection.
+   > **NOTE**: ⏳ `pip install` may take some time, depending on your internet connection. In case installation fails with error ``unsupported instruction `vpdpbusd'``, append `-C cmake.args="-DLLAMA_NATIVE=off"` to `pip install` command.
 
    See [the GPU acceleration documentation](./docs/gpu-acceleration.md) for how to
    to enable hardware acceleration for inference and training on AMD ROCm,
-   Apple Metal Performance Shaders (MPS), and NVidia CUDA. You have to start
-   with a fresh virtual environment. The `--clear` option deletes the contents
-   of the environment directory.
+   Apple Metal Performance Shaders (MPS), and Nvidia CUDA.
+
+   #### To install with no GPU acceleration and PyTorch without CUDA bindings
 
    ```shell
-   python3 -m venv --clear venv
+   python3 -m venv --upgrade-deps venv
    source venv/bin/activate
    (venv) $ pip cache remove llama_cpp_python
-   (venv) $ pip install git+https://github.com/instructlab/instructlab.git@stable -C cmake.args="-DLLAMA_CUBLAS=on"
+   (venv) $ pip install git+https://github.com/instructlab/instructlab.git@stable --extra-index-url=https://download.pytorch.org/whl/cpu
    ```
 
+   #### To install with AMD ROCm
+
    ```shell
-   python3 -m venv --clear venv
+   python3 -m venv --upgrade-deps venv
+   source venv/bin/activate
+   (venv) $ pip cache remove llama_cpp_python
+   (venv) $ pip install git+https://github.com/instructlab/instructlab.git@stable \
+       --extra-index-url https://download.pytorch.org/whl/rocm6.0 \
+       -C cmake.args="-DLLAMA_HIPBLAS=on" \
+       -C cmake.args="-DAMDGPU_TARGETS=all" \
+       -C cmake.args="-DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang" \
+       -C cmake.args="-DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++" \
+       -C cmake.args="-DCMAKE_PREFIX_PATH=/opt/rocm"
+   ```
+
+   On Fedora 40+, use `-DCMAKE_C_COMPILER=clang-17` and `-DCMAKE_CXX_COMPILER=clang++-17`.
+
+   #### To install with Apple Metal on M1/M2/M3 Mac
+
+   ```shell
+   python3 -m venv --upgrade-deps venv
    source venv/bin/activate
    (venv) $ pip cache remove llama_cpp_python
    (venv) $ pip install git+https://github.com/instructlab/instructlab.git@stable -C cmake.args="-DLLAMA_METAL=on"
+   ```
+
+   #### To install with Nvidia CUDA
+
+   ```shell
+   python3 -m venv --upgrade-deps venv
+   source venv/bin/activate
+   (venv) $ pip cache remove llama_cpp_python
+   (venv) $ pip install git+https://github.com/instructlab/instructlab.git@stable -C cmake.args="-DLLAMA_CUBLAS=on"
    ```
 
 4. From your `venv` environment, verify `ilab` is installed correctly, by running the `ilab` command.

--- a/README.md
+++ b/README.md
@@ -105,19 +105,19 @@ The full process is described graphically in the [workflow diagram](./docs/workf
 
    See [the GPU acceleration documentation](./docs/gpu-acceleration.md) for how to
    to enable hardware acceleration for inference and training on AMD ROCm,
-   NVidia CUDA, and Apple Metal Performance Shaders (MPS).
+   Apple Metal Performance Shaders (MPS), and NVidia CUDA. You have to start
+   with a fresh virtual environment. The `--clear` option deletes the contents
+   of the environment directory.
 
    ```shell
-   rm -rf venv
-   python3 -m venv venv
+   python3 -m venv --clear venv
    source venv/bin/activate
    (venv) $ pip cache remove llama_cpp_python
    (venv) $ pip install git+https://github.com/instructlab/instructlab.git@stable -C cmake.args="-DLLAMA_CUBLAS=on"
    ```
 
    ```shell
-   rm -rf venv
-   python3 -m venv venv
+   python3 -m venv --clear venv
    source venv/bin/activate
    (venv) $ pip cache remove llama_cpp_python
    (venv) $ pip install git+https://github.com/instructlab/instructlab.git@stable -C cmake.args="-DLLAMA_METAL=on"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The full process is described graphically in the [workflow diagram](./docs/workf
 
    > **NOTE**: ⏳ `pip install` may take some time, depending on your internet connection.
 
-   See [the GPU acceleration documentation](./docs/gpu-acceleration.md) how to
+   See [the GPU acceleration documentation](./docs/gpu-acceleration.md) for how to
    to enable hardware acceleration for inference and training on AMD ROCm,
    NVidia CUDA, and Apple Metal Performance Shaders (MPS).
 

--- a/docs/containerization.md
+++ b/docs/containerization.md
@@ -8,30 +8,8 @@ experience.
 
 ## Steps to build an image then run a container
 
-**Containerfile:**
-
-```dockerfile
-FROM nvcr.io/nvidia/cuda:12.3.2-devel-ubi9
-RUN dnf install -y python3.11 git python3-pip make automake gcc gcc-c++
-WORKDIR /instructlab
-RUN python3.11 -m ensurepip
-RUN dnf install -y gcc
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo && dnf repolist && dnf config-manager --set-enabled cuda-rhel9-x86_64 && dnf config-manager --set-enabled cuda && dnf config-manager --set-enabled epel && dnf update -y
-RUN python3.11 -m pip install --force-reinstall nvidia-cuda-nvcc-cu12
-RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64" \
-    && export CUDA_HOME=/usr/local/cuda \
-    && export PATH="/usr/local/cuda/bin:$PATH" \
-    && export XLA_TARGET=cuda120 \
-    && export XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
-RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-cache-dir llama-cpp-python
-RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@stable
-CMD ["/bin/bash"]
-```
-
-Or image: TBD (am I allowed to have a public image with references to lab in it?)
-
-This `Containerfile` is based on Nvidia CUDA image, which lucky for us plugs
+The [`Containerfile`](../containers/cuda/Containerfile)
+is based on Nvidia CUDA image, which lucky for us plugs
 directly into Podman via their `nvidia-container-toolkit`! The `ubi9` base
 image does not have most packages installed. The bulk of the `Containerfile` is
 spent configuring your system so `ilab` can be installed and run properly.

--- a/docs/demo-slides.md
+++ b/docs/demo-slides.md
@@ -34,7 +34,7 @@ source venv/bin/activate.fish
 Install CLI
 
 ```fish
-pip install git+https://github.com/instructlab/cli.git@v0.13.0
+pip install git+https://github.com/instructlab/cli.git@stable
 ```
 
 <!-- pause -->

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -35,8 +35,8 @@ how to do that on Fedora with `dnf`:
 
   # Install lab (assumes a locally-cloned repo)
   # You can clone the repo if you haven't already done so (either one)
-  # gh repo clone instructlab/instructlab
-  # git clone https://github.com/instructlab/instructlab.git
+  # gh repo clone instructlab/instructlab -- --recurse-submodules
+  # git clone --recurse-submodules https://github.com/instructlab/instructlab.git
   pip install ./instructlab/
   ```
 

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -37,10 +37,33 @@ how to do that on Fedora with `dnf`:
   # You can clone the repo if you haven't already done so (either one)
   # gh repo clone instructlab/instructlab
   # git clone https://github.com/instructlab/instructlab.git
-  pip3 install ./instructlab/
+  pip install ./instructlab/
   ```
 
 With Python 3.11 installed, it's time to replace some packages!
+
+### llama-cpp-python backends
+
+Go to the project's GitHub to see
+the [supported backends](https://github.com/abetlen/llama-cpp-python?tab=readme-ov-file#supported-backends).
+
+Whichever backend you choose, you'll see a `pip install` command. First
+you have to purge pip's wheel cache to force a rebuild of llama-cpp-python:
+
+ ```shell
+ pip cache remove llama_cpp_python
+ ```
+
+You'll want to add a few options to ensure it gets installed over the
+existing package, has the desired backend, and the correct version.
+
+```shell
+pip install --force-reinstall llama_cpp_python==0.2.55 -C cmake.args="-DLLAMA_$BACKEND=on"
+```
+
+where `$BACKEND` is one of `HIPBLAS` (ROCm), `CUBLAS` (CUDA), `METAL`
+(Apple Silicon MPS), `CLBLAST` (OpenCL), or another backend listed in
+llama-cpp-python's documentation.
 
 ### Nvidia/CUDA
 
@@ -89,9 +112,9 @@ sudo dnf -y install cuda-toolkit-12-4 nvtop
 
 Go to the project's GitHub to see the
 [supported backends](https://github.com/abetlen/llama-cpp-python?tab=readme-ov-file#supported-backends).
-Find the `cuBLAS (CUDA)` backend. You'll see a `pip3 install` command.
+Find the `cuBLAS (CUDA)` backend. You'll see a `pip install` command.
 You'll want to add a few options to ensure it gets installed over the
-existing package: `--force-reinstall` and `--no-cache-dir`. Your final
+existing package: `--force-reinstall`. Your final
 command should look like this:
 
 ```shell
@@ -101,10 +124,11 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/ex
 export PATH=$PATH:$CUDA_HOME/bin
 
 # Recompile llama-cpp-python using CUDA
-CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip3 install --force-reinstall --no-cache-dir llama-cpp-python
+pip cache remove llama_cpp_python
+pip install --force-reinstall llama_cpp_python==0.2.55 -C cmake.args="-DLLAMA_CUBLAS=on"
 
 # Re-install InstructLab
-pip3 install instructlab/.
+pip install instructlab/.
 ```
 
 Proceed to the `Initialize` section of
@@ -136,7 +160,7 @@ and use the matrix installer tool to find the ROCm package. `Stable, Linux, Pip,
 Python, ROCm 5.7` in the matrix installer spits out the following command:
 
 ```shell
-pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.7
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.0
 ```
 
 You don't need `torchvision` or `torchaudio`, so get rid of those. You also want
@@ -146,21 +170,10 @@ that doesn't have GPU support, so you should add these options:
 Run it to install the new version of `torch`.
 
 ```shell
-pip3 install torch --force-reinstall --no-cache-dir --index-url https://download.pytorch.org/whl/rocm5.7
+pip install torch --force-reinstall --no-cache-dir --index-url https://download.pytorch.org/whl/rocm6.0
 ```
 
 With that done, it's time to move on to `llama-cpp-python`.
-
-Go to the project's GitHub to see
-the [supported backends](https://github.com/abetlen/llama-cpp-python?tab=readme-ov-file#supported-backends).
-There are several possible backends that may work on AMD; `CLBlast (OpenCL)`
-and `hipBLAS (ROCm)` have been tested to work. It may be worth installing others
-to see if they work for you, but your mileage may vary. Instructions for the
-tested backends are included below!
-
-Whichever backend you choose, you'll see a `pip3 install` command. You'll want
-to add a few options to ensure it gets installed over the existing package:
-`--force-reinstall` and `--no-cache-dir`.
 
 #### hipBLAS
 
@@ -198,7 +211,9 @@ In this case, `gfx1100` is the model we're looking for (our dedicated GPU) so
 we'll include that in our build command as follows:
 
 ```shell
-CMAKE_ARGS="-DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ -DCMAKE_PREFIX_PATH=/opt/rocm -DAMDGPU_TARGETS=gfx1100" FORCE_CMAKE=1 pip install llama-cpp-python --force-reinstall --no-cache-dir
+export PATH=/opt/rocm/llvm/bin:$PATH
+pip cache remove llama_cpp_python
+CMAKE_ARGS="-DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER='/opt/rocm/llvm/bin/clang' -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ -DCMAKE_PREFIX_PATH=/opt/rocm -DAMDGPU_TARGETS=gfx1100" FORCE_CMAKE=1 pip install --force-reinstall llama_cpp_python==0.2.55
 ```
 
 > **Note:** This is explicitly forcing the build to use the ROCm compilers and
@@ -208,7 +223,7 @@ CMAKE_ARGS="-DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang -DCMA
 > `CMAKE_ARGS="-DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER=/usr/bin/clang
 > -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DAMDGPU_TARGETS=gfx1100"` instead.
 
-Once that package is installed, recompile `ilab` with `pip3 install .`.  You also
+Once that package is installed, recompile `ilab` with `pip install .`.  You also
 need to tell `HIP` which GPU to use - you can find this out via `rocminfo`
 although it is typically GPU 0.  To set which device is visible to HIP, we'll
 set `export HIP_VISIBLE_DEVICES=0` for GPU 0.   You may also have to set
@@ -225,10 +240,11 @@ Now you can skip to the `Testing` section.
 Your final command should look like so (this uses `CLBlast`):
 
 ```shell
-CMAKE_ARGS="-DLLAMA_CLBLAST=on" pip3 install --force-reinstall --no-cache-dir llama-cpp-python
+pip cache remove llama_cpp_python
+pip install --force-reinstall llama_cpp_python==0.2.55 -C cmake.args="-DLLAMA_CLBLAST=on"
 ```
 
-Once that package is installed, recompile `ilab` with `pip3 install .` and skip
+Once that package is installed, recompile `ilab` with `pip install .` and skip
 to the `Testing` section.
 
 ### Metal/Apple Silicon
@@ -239,15 +255,16 @@ isn't the case, these steps might help to enable it.
 `torch` should already ship with Metal support, so you only have to
 replace `llama-cpp-python`. Go to the project's GitHub to see the
 [supported backends](https://github.com/abetlen/llama-cpp-python?tab=readme-ov-file#supported-backends).
-Find the `Metal` backend. You'll see a `pip3 install` command. You'll want to
+Find the `Metal` backend. You'll see a `pip install` command. You'll want to
 add a few options to ensure it gets installed over the existing package:
 `--force-reinstall` and `--no-cache-dir`. Your final command should look like so:
 
 ```shell
-CMAKE_ARGS="-DLLAMA_METAL=on" pip3 install --force-reinstall --no-cache-dir llama-cpp-python
+pip cache remove llama_cpp_python
+pip install --force-reinstall llama_cpp_python==0.2.55 -C cmake.args="-DLLAMA_METAL=on"
 ```
 
-Once that package is installed, recompile `ilab` with `pip3 install .` and skip
+Once that package is installed, recompile `ilab` with `pip install .` and skip
 to the `Testing` section.
 
 ### Testing


### PR DESCRIPTION
Our docs around GPU support have some rough edges. Users have been running into issues because they replaced their GPU accelerated llama-cpp-python with a slow CPU version. Pip also has some sharp edges concerning package name normalization.

- hard-code `llama_cpp_python` (sic!) version for now, so users will get the right version. I'll replace the docs with better ones after Summit.
- remove cached builds rather than disabling the cache, so pip can use its source cache to speed up builds.
- use pip's `--config-settings / -C` option to pass cmake arguments
- use ROCm 6.0

# Changes

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
