### PR TITLE
fix: re-add 'spawn' method for the multiprocessing task on the temp server

### DIFF
--- a/src/instructlab/server.py
+++ b/src/instructlab/server.py
@@ -20,7 +20,7 @@ import uvicorn
 
 # Local
 from .client import ClientException, list_models
-from .config import get_api_base
+from .config import DEFAULT_MULTIPROCESSING_START_METHOD, get_api_base
 
 templates = [
     {
@@ -71,7 +71,7 @@ def ensure_server(
         return (None, None, None)
     except ClientException:
         tried_ports = set()
-        mpctx = multiprocessing.get_context(None)
+        mpctx = multiprocessing.get_context(DEFAULT_MULTIPROCESSING_START_METHOD)
         # use a queue to communicate between the main process and the server process
         queue = mpctx.Queue()
         port = random.randint(1024, 65535)


### PR DESCRIPTION
With the help of https://github.com/instructlab/instructlab/pull/1050 we
have a working implementation of multiprocessing. We can then add again
the 'spawn' method when running the temporary server.

Signed-off-by: Sébastien Han <seb@redhat.com>