### PR TITLE
tests: Isolate file system for all test cases, implicitly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,13 @@
 
 # Standard
 from unittest import mock
+import os
+import re
+import shutil
 import sys
 
 # Third Party
+from click.testing import CliRunner
 import pytest
 
 # Local
@@ -30,4 +34,33 @@ def mock_mlx_package():
         for name in ["mlx", "mlx.core", "mlx.nn", "mlx.optimizers", "mlx.utils"]
     }
     with mock.patch.dict(sys.modules, mlx_modules):
+        yield
+
+
+_SKIP_FILESYSTEM_ISOLATION_TESTS = [
+    # These cases expect notebooks present in current dir.
+    # We could probably copy them into isolated environment too...
+    r"^test_notebooks\[.*\]$",
+]
+
+_SKIP_TESTS_RE = [re.compile(pattern) for pattern in _SKIP_FILESYSTEM_ISOLATION_TESTS]
+
+
+def should_skip_filesystem_isolation(testname):
+    return any(re.match(p, testname) for p in _SKIP_TESTS_RE)
+
+
+def get_testdata_dir():
+    return os.path.join(os.getcwd(), "tests/testdata")
+
+
+@pytest.fixture(scope="function", autouse=True)
+def isolate_filesystem(request):
+    if should_skip_filesystem_isolation(request.node.name):
+        yield
+        return
+
+    test_data = get_testdata_dir()
+    with CliRunner().isolated_filesystem():
+        shutil.copytree(test_data, get_testdata_dir())
         yield

--- a/tests/test_lab_diff.py
+++ b/tests/test_lab_diff.py
@@ -33,102 +33,91 @@ class TestLabDiff(unittest.TestCase):
         tracked_file = "compositional_skills/tracked/qna.yaml"
         self.taxonomy.create_untracked(untracked_file)
         self.taxonomy.add_tracked(tracked_file)
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.diff,
-                [
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                ],
-            )
-            self.assertIn(untracked_file, result.output)
-            self.assertNotIn(tracked_file, result.output)
-            self.assertEqual(result.exit_code, 0)
+        result = CliRunner().invoke(
+            lab.diff,
+            [
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        self.assertIn(untracked_file, result.output)
+        self.assertNotIn(tracked_file, result.output)
+        self.assertEqual(result.exit_code, 0)
 
     def test_diff_rm_tracked(self):
         tracked_file = "compositional_skills/tracked/qna.yaml"
         self.taxonomy.add_tracked(tracked_file)
         self.taxonomy.remove_file(tracked_file)
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.diff,
-                [
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                ],
-            )
-            self.assertNotIn(tracked_file, result.output)
-            self.assertEqual(result.exit_code, 0)
+        result = CliRunner().invoke(
+            lab.diff,
+            [
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        self.assertNotIn(tracked_file, result.output)
+        self.assertEqual(result.exit_code, 0)
 
     def test_diff_invalid_ext(self):
         untracked_file = "compositional_skills/writing/new/qna.YAML"
         self.taxonomy.create_untracked(untracked_file)
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.diff,
-                [
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                ],
-            )
-            self.assertListEqual(self.taxonomy.untracked_files, [untracked_file])
-            # Invalid extension is silently filtered out
-            self.assertNotIn(untracked_file, result.output)
-            self.assertEqual(result.exit_code, 0)
+        result = CliRunner().invoke(
+            lab.diff,
+            [
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        self.assertListEqual(self.taxonomy.untracked_files, [untracked_file])
+        # Invalid extension is silently filtered out
+        self.assertNotIn(untracked_file, result.output)
+        self.assertEqual(result.exit_code, 0)
 
     def test_diff_invalid_base(self):
         taxonomy_base = "invalid"
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.diff,
-                [
-                    "--taxonomy-base",
-                    taxonomy_base,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                ],
-            )
-            self.assertIsNone(result.exception)
-            self.assertIn(
-                f'Couldn\'t find the taxonomy git ref "{taxonomy_base}" '
-                "from the current HEAD",
-                result.output,
-            )
-            self.assertEqual(result.exit_code, 0)
+        result = CliRunner().invoke(
+            lab.diff,
+            [
+                "--taxonomy-base",
+                taxonomy_base,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        self.assertIsNone(result.exception)
+        self.assertIn(
+            f'Couldn\'t find the taxonomy git ref "{taxonomy_base}" '
+            "from the current HEAD",
+            result.output,
+        )
+        self.assertEqual(result.exit_code, 0)
 
     def test_diff_invalid_path(self):
         taxonomy_path = "/path/to/taxonomy"
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.diff,
-                [
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    taxonomy_path,
-                ],
-            )
-            self.assertIsNone(result.exception)
-            self.assertIn(f"{taxonomy_path}", result.output)
-            self.assertEqual(result.exit_code, 0)
+        result = CliRunner().invoke(
+            lab.diff,
+            [
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                taxonomy_path,
+            ],
+        )
+        self.assertIsNone(result.exception)
+        self.assertIn(f"{taxonomy_path}", result.output)
+        self.assertEqual(result.exit_code, 0)
 
     def test_diff_valid_yaml(self):
         with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
             valid_yaml_file = "compositional_skills/qna_valid.yaml"
             self.taxonomy.create_untracked(valid_yaml_file, qnafile.read())
-            runner = CliRunner()
-            result = runner.invoke(
+            result = CliRunner().invoke(
                 lab.diff,
                 [
                     "--taxonomy-base",
@@ -146,8 +135,7 @@ class TestLabDiff(unittest.TestCase):
         with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
             valid_yaml_file = "compositional_skills/qna_valid.yaml"
             self.taxonomy.create_untracked(valid_yaml_file, qnafile.read())
-            runner = CliRunner()
-            result = runner.invoke(
+            result = CliRunner().invoke(
                 lab.diff,
                 [
                     "--taxonomy-base",
@@ -165,8 +153,7 @@ class TestLabDiff(unittest.TestCase):
             self.taxonomy.create_untracked(
                 "compositional_skills/qna_invalid.yaml", qnafile.read()
             )
-            runner = CliRunner()
-            result = runner.invoke(
+            result = CliRunner().invoke(
                 lab.diff,
                 [
                     "--taxonomy-base",
@@ -183,8 +170,7 @@ class TestLabDiff(unittest.TestCase):
             self.taxonomy.create_untracked(
                 "compositional_skills/qna_invalid.yaml", qnafile.read()
             )
-            runner = CliRunner()
-            result = runner.invoke(
+            result = CliRunner().invoke(
                 lab.diff,
                 [
                     "--taxonomy-base",
@@ -203,8 +189,7 @@ class TestLabDiff(unittest.TestCase):
             custom_rules_file.write_bytes(TEST_CUSTOM_YAML_RULES)
             invalid_yaml_file = "compositional_skills/qna_invalid.yaml"
             self.taxonomy.create_untracked(invalid_yaml_file, qnafile.read())
-            runner = CliRunner()
-            result = runner.invoke(
+            result = CliRunner().invoke(
                 lab.diff,
                 [
                     "--taxonomy-base",
@@ -225,8 +210,7 @@ class TestLabDiff(unittest.TestCase):
         with open("tests/testdata/skill_incomplete.yaml", "rb") as qnafile:
             failing_yaml_file = "compositional_skills/failing/qna.yaml"
             self.taxonomy.create_untracked(failing_yaml_file, qnafile.read())
-            runner = CliRunner()
-            result = runner.invoke(
+            result = CliRunner().invoke(
                 lab.diff,
                 [
                     "--taxonomy-base",

--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -19,23 +19,19 @@ class TestLabDownload(unittest.TestCase):
     # https://docs.python.org/3/library/unittest.mock.html#where-to-patch?
     @patch("instructlab.lab.hf_hub_download")
     def test_download(self, mock_hf_hub_download):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(lab.download)
-            self.assertEqual(
-                result.exit_code, 0, "command finished with an unexpected exit code"
-            )
-            mock_hf_hub_download.assert_called_once()
+        result = CliRunner().invoke(lab.download)
+        self.assertEqual(
+            result.exit_code, 0, "command finished with an unexpected exit code"
+        )
+        mock_hf_hub_download.assert_called_once()
 
     @patch(
         "instructlab.lab.hf_hub_download",
         MagicMock(side_effect=HfHubHTTPError("Could not reach hugging face server")),
     )
     def test_download_error(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(lab.download)
-            self.assertEqual(
-                result.exit_code, 1, "command finished with an unexpected exit code"
-            )
-            self.assertIn("Could not reach hugging face server", result.output)
+        result = CliRunner().invoke(lab.download)
+        self.assertEqual(
+            result.exit_code, 1, "command finished with an unexpected exit code"
+        )
+        self.assertIn("Could not reach hugging face server", result.output)

--- a/tests/test_lab_generate.py
+++ b/tests/test_lab_generate.py
@@ -29,53 +29,71 @@ class TestLabGenerate(unittest.TestCase):
         side_effect=GenerateException("Connection Error"),
     )
     def test_generate_exception_error(self, generate_data_mock):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            mt = MockTaxonomy(pathlib.Path("taxonomy"))
-            result = runner.invoke(
-                lab.generate,
-                [
-                    "--taxonomy-base",
-                    "main",
-                    "--taxonomy-path",
-                    mt.root,
-                    "--endpoint-url",
-                    "localhost:8000",
-                ],
-            )
-            self.assertEqual(
-                result.exit_code, 1, "command finished with an unexpected exit code"
-            )
-            generate_data_mock.assert_called_once()
-            self.assertIn(
-                "Generating dataset failed with the following error: Connection Error",
-                result.output,
-            )
-            mt.teardown()
+        mt = MockTaxonomy(pathlib.Path("taxonomy"))
+        result = CliRunner().invoke(
+            lab.generate,
+            [
+                "--taxonomy-base",
+                "main",
+                "--taxonomy-path",
+                mt.root,
+                "--endpoint-url",
+                "localhost:8000",
+            ],
+        )
+        self.assertEqual(
+            result.exit_code, 1, "command finished with an unexpected exit code"
+        )
+        generate_data_mock.assert_called_once()
+        self.assertIn(
+            "Generating dataset failed with the following error: Connection Error",
+            result.output,
+        )
+        mt.teardown()
 
     def test_taxonomy_not_found(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.generate,
-                [
-                    "--endpoint-url",
-                    "localhost:8000",
-                ],
-            )
-            self.assertEqual(
-                result.exit_code, 1, "command finished with an unexpected exit code"
-            )
-            self.assertIn(
-                "Error: taxonomy (taxonomy) does not exist",
-                result.output,
-            )
+        result = CliRunner().invoke(
+            lab.generate,
+            [
+                "--endpoint-url",
+                "localhost:8000",
+            ],
+        )
+        self.assertEqual(
+            result.exit_code, 1, "command finished with an unexpected exit code"
+        )
+        self.assertIn(
+            "Error: taxonomy (taxonomy) does not exist",
+            result.output,
+        )
 
     def test_no_new_data(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
+        mt = MockTaxonomy(pathlib.Path("taxonomy"))
+        result = CliRunner().invoke(
+            lab.generate,
+            [
+                "--taxonomy-base",
+                "main",
+                "--taxonomy-path",
+                mt.root,
+                "--endpoint-url",
+                "localhost:8000",
+            ],
+        )
+        self.assertEqual(
+            result.exit_code, 1, "command finished with an unexpected exit code"
+        )
+        self.assertIn(
+            "Nothing to generate. Exiting.",
+            result.output,
+        )
+        mt.teardown()
+
+    def test_new_data_invalid_answer(self):
+        with open("tests/testdata/skill_invalid_answer.yaml", "rb") as qnafile:
             mt = MockTaxonomy(pathlib.Path("taxonomy"))
-            result = runner.invoke(
+            mt.create_untracked("compositional_skills/tracked/qna.yaml", qnafile.read())
+            result = CliRunner().invoke(
                 lab.generate,
                 [
                     "--taxonomy-base",
@@ -90,38 +108,10 @@ class TestLabGenerate(unittest.TestCase):
                 result.exit_code, 1, "command finished with an unexpected exit code"
             )
             self.assertIn(
-                "Nothing to generate. Exiting.",
+                "taxonomy files with errors",
                 result.output,
             )
             mt.teardown()
-
-    def test_new_data_invalid_answer(self):
-        runner = CliRunner()
-        with open("tests/testdata/skill_invalid_answer.yaml", "rb") as qnafile:
-            with runner.isolated_filesystem():
-                mt = MockTaxonomy(pathlib.Path("taxonomy"))
-                mt.create_untracked(
-                    "compositional_skills/tracked/qna.yaml", qnafile.read()
-                )
-                result = runner.invoke(
-                    lab.generate,
-                    [
-                        "--taxonomy-base",
-                        "main",
-                        "--taxonomy-path",
-                        mt.root,
-                        "--endpoint-url",
-                        "localhost:8000",
-                    ],
-                )
-                self.assertEqual(
-                    result.exit_code, 1, "command finished with an unexpected exit code"
-                )
-                self.assertIn(
-                    "taxonomy files with errors",
-                    result.output,
-                )
-                mt.teardown()
 
     @patch(
         "instructlab.generator.generate_data.get_instructions_from_model",
@@ -131,56 +121,17 @@ class TestLabGenerate(unittest.TestCase):
     )
     def test_OpenAI_server_error(self, get_instructions_from_model):
         with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
-            with CliRunner().isolated_filesystem():
-                mt = MockTaxonomy(pathlib.Path("taxonomy"))
-                mt.create_untracked(
-                    "compositional_skills/tracked/qna.yaml", qnafile.read()
-                )
-                with self.assertRaises(GenerateException) as exc:
-                    generate_data(
-                        logger=logging.getLogger("test_logger"),
-                        api_base="localhost:8000",
-                        api_key="",
-                        model_family="merlinite",
-                        model_name="test-model",
-                        num_cpus=10,
-                        num_instructions_to_generate=100,
-                        taxonomy=mt.root,
-                        taxonomy_base="main",
-                        output_dir="generated",
-                        prompt_file_path="prompt.txt",
-                        rouge_threshold=0.9,
-                        console_output=True,
-                        chunk_word_count=1000,
-                        server_ctx_size=4096,
-                        tls_insecure=False,
-                    )
-                self.assertIn(
-                    "There was a problem connecting to the OpenAI server",
-                    f"{exc.exception}",
-                )
-                get_instructions_from_model.assert_called_once()
-                mt.teardown()
-
-    @patch(
-        "instructlab.generator.generate_data.get_instructions_from_model",
-        return_value=(testdata.generate_data_return_value, 0),
-    )
-    def test_generate_no_error(self, get_instructions_from_model):
-        with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
-            with CliRunner().isolated_filesystem():
-                mt = MockTaxonomy(pathlib.Path("taxonomy"))
-                mt.create_untracked(
-                    "compositional_skills/tracked/qna.yaml", qnafile.read()
-                )
+            mt = MockTaxonomy(pathlib.Path("taxonomy"))
+            mt.create_untracked("compositional_skills/tracked/qna.yaml", qnafile.read())
+            with self.assertRaises(GenerateException) as exc:
                 generate_data(
                     logger=logging.getLogger("test_logger"),
                     api_base="localhost:8000",
                     api_key="",
-                    model_name="my-model",
                     model_family="merlinite",
+                    model_name="test-model",
                     num_cpus=10,
-                    num_instructions_to_generate=1,
+                    num_instructions_to_generate=100,
                     taxonomy=mt.root,
                     taxonomy_base="main",
                     output_dir="generated",
@@ -191,17 +142,50 @@ class TestLabGenerate(unittest.TestCase):
                     server_ctx_size=4096,
                     tls_insecure=False,
                 )
-                get_instructions_from_model.assert_called_once()
-                expected_files = [
-                    "generated_my-model*.json",
-                    "train_my-model*.jsonl",
-                    "test_my-model*.jsonl",
-                ]
-                for f in os.listdir("generated"):
-                    self.assertTrue(
-                        any(fnmatch.fnmatch(f, pattern) for pattern in expected_files)
-                    )
-                mt.teardown()
+            self.assertIn(
+                "There was a problem connecting to the OpenAI server",
+                f"{exc.exception}",
+            )
+            get_instructions_from_model.assert_called_once()
+            mt.teardown()
+
+    @patch(
+        "instructlab.generator.generate_data.get_instructions_from_model",
+        return_value=(testdata.generate_data_return_value, 0),
+    )
+    def test_generate_no_error(self, get_instructions_from_model):
+        with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
+            mt = MockTaxonomy(pathlib.Path("taxonomy"))
+            mt.create_untracked("compositional_skills/tracked/qna.yaml", qnafile.read())
+            generate_data(
+                logger=logging.getLogger("test_logger"),
+                api_base="localhost:8000",
+                api_key="",
+                model_name="my-model",
+                model_family="merlinite",
+                num_cpus=10,
+                num_instructions_to_generate=1,
+                taxonomy=mt.root,
+                taxonomy_base="main",
+                output_dir="generated",
+                prompt_file_path="prompt.txt",
+                rouge_threshold=0.9,
+                console_output=True,
+                chunk_word_count=1000,
+                server_ctx_size=4096,
+                tls_insecure=False,
+            )
+            get_instructions_from_model.assert_called_once()
+            expected_files = [
+                "generated_my-model*.json",
+                "train_my-model*.jsonl",
+                "test_my-model*.jsonl",
+            ]
+            for f in os.listdir("generated"):
+                self.assertTrue(
+                    any(fnmatch.fnmatch(f, pattern) for pattern in expected_files)
+                )
+            mt.teardown()
 
     @patch(
         "instructlab.generator.generate_data.get_instructions_from_model",
@@ -213,38 +197,37 @@ class TestLabGenerate(unittest.TestCase):
     )
     def test_knowledge_docs_no_error(self, read_taxonomy, get_instructions_from_model):
         with open("tests/testdata/knowledge_valid.yaml", "rb") as qnafile:
-            with CliRunner().isolated_filesystem():
-                mt = MockTaxonomy(pathlib.Path("taxonomy"))
-                mt.create_untracked(
-                    "knowledge/technical-manual/test/qna.yaml", qnafile.read()
+            mt = MockTaxonomy(pathlib.Path("taxonomy"))
+            mt.create_untracked(
+                "knowledge/technical-manual/test/qna.yaml", qnafile.read()
+            )
+            generate_data(
+                logger=logging.getLogger("test_logger"),
+                api_base="localhost:8000",
+                api_key="",
+                model_name="my-model",
+                model_family="merlinite",
+                num_cpus=10,
+                num_instructions_to_generate=1,
+                taxonomy=mt.root,
+                taxonomy_base="main",
+                output_dir="generated",
+                prompt_file_path="prompt.txt",
+                rouge_threshold=0.9,
+                console_output=True,
+                chunk_word_count=1000,
+                server_ctx_size=4096,
+                tls_insecure=False,
+            )
+            get_instructions_from_model.assert_called_once()
+            read_taxonomy.assert_called_once()
+            expected_files = [
+                "generated_my-model*.json",
+                "train_my-model*.jsonl",
+                "test_my-model*.jsonl",
+            ]
+            for f in os.listdir("generated"):
+                self.assertTrue(
+                    any(fnmatch.fnmatch(f, pattern) for pattern in expected_files)
                 )
-                generate_data(
-                    logger=logging.getLogger("test_logger"),
-                    api_base="localhost:8000",
-                    api_key="",
-                    model_name="my-model",
-                    model_family="merlinite",
-                    num_cpus=10,
-                    num_instructions_to_generate=1,
-                    taxonomy=mt.root,
-                    taxonomy_base="main",
-                    output_dir="generated",
-                    prompt_file_path="prompt.txt",
-                    rouge_threshold=0.9,
-                    console_output=True,
-                    chunk_word_count=1000,
-                    server_ctx_size=4096,
-                    tls_insecure=False,
-                )
-                get_instructions_from_model.assert_called_once()
-                read_taxonomy.assert_called_once()
-                expected_files = [
-                    "generated_my-model*.json",
-                    "train_my-model*.jsonl",
-                    "test_my-model*.jsonl",
-                ]
-                for f in os.listdir("generated"):
-                    self.assertTrue(
-                        any(fnmatch.fnmatch(f, pattern) for pattern in expected_files)
-                    )
-                mt.teardown()
+            mt.teardown()

--- a/tests/test_lab_init.py
+++ b/tests/test_lab_init.py
@@ -21,74 +21,63 @@ class TestLabInit(unittest.TestCase):
     # https://docs.python.org/3/library/unittest.mock.html#where-to-patch?
     @patch("instructlab.lab.Repo.clone_from")
     def test_init_noninteractive(self, mock_clone_from):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(lab.init, args=["--non-interactive"])
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
-            mock_clone_from.assert_called_once()
+        result = CliRunner().invoke(lab.init, args=["--non-interactive"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("config.yaml", os.listdir())
+        mock_clone_from.assert_called_once()
 
     def test_init_interactive(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(lab.init, input="\nn")
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
+        result = CliRunner().invoke(lab.init, input="\nn")
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("config.yaml", os.listdir())
 
     @patch(
         "instructlab.lab.Repo.clone_from",
         MagicMock(side_effect=GitError("Authentication failed")),
     )
     def test_init_interactive_git_error(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(lab.init, input="\ny")
-            self.assertEqual(
-                result.exit_code, 1, "command finished with an unexpected exit code"
-            )
-            self.assertIn(
-                "Failed to clone taxonomy repo: Authentication failed", result.output
-            )
-            self.assertIn("manually run", result.output)
+        result = CliRunner().invoke(lab.init, input="\ny")
+        self.assertEqual(
+            result.exit_code, 1, "command finished with an unexpected exit code"
+        )
+        self.assertIn(
+            "Failed to clone taxonomy repo: Authentication failed", result.output
+        )
+        self.assertIn("manually run", result.output)
 
     @patch("instructlab.lab.Repo.clone_from")
     def test_init_interactive_clone(self, mock_clone_from):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(lab.init, input="\ny")
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
-            mock_clone_from.assert_called_once()
+        result = CliRunner().invoke(lab.init, input="\ny")
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("config.yaml", os.listdir())
+        mock_clone_from.assert_called_once()
 
     def test_init_interactive_with_preexisting_nonempty_taxonomy(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            os.makedirs("taxonomy/contents")
-            result = runner.invoke(lab.init, input="\n")
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
-            self.assertIn("taxonomy", os.listdir())
+        os.makedirs("taxonomy/contents")
+        result = CliRunner().invoke(lab.init, input="\n")
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("config.yaml", os.listdir())
+        self.assertIn("taxonomy", os.listdir())
 
     def test_init_interactive_with_preexisting_config(self):
         runner = CliRunner()
-        with runner.isolated_filesystem():
-            # first run to prime the config.yaml in current directory
-            result = runner.invoke(lab.init, input="non-default-taxonomy\nn")
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
-            config = read_config("config.yaml")
-            self.assertEqual(config.generate.taxonomy_path, "non-default-taxonomy")
+        # first run to prime the config.yaml in current directory
+        result = runner.invoke(lab.init, input="non-default-taxonomy\nn")
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("config.yaml", os.listdir())
+        config = read_config("config.yaml")
+        self.assertEqual(config.generate.taxonomy_path, "non-default-taxonomy")
 
-            # second invocation should ask if we want to overwrite - yes, and change taxonomy path
-            result = runner.invoke(lab.init, input="y\ndifferent-taxonomy\nn")
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
-            config = read_config("config.yaml")
-            self.assertEqual(config.generate.taxonomy_path, "different-taxonomy")
+        # second invocation should ask if we want to overwrite - yes, and change taxonomy path
+        result = runner.invoke(lab.init, input="y\ndifferent-taxonomy\nn")
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("config.yaml", os.listdir())
+        config = read_config("config.yaml")
+        self.assertEqual(config.generate.taxonomy_path, "different-taxonomy")
 
-            # third invocation should again ask, but this time don't overwrite
-            result = runner.invoke(lab.init, input="n")
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
-            config = read_config("config.yaml")
-            self.assertEqual(config.generate.taxonomy_path, "different-taxonomy")
+        # third invocation should again ask, but this time don't overwrite
+        result = runner.invoke(lab.init, input="n")
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("config.yaml", os.listdir())
+        config = read_config("config.yaml")
+        self.assertEqual(config.generate.taxonomy_path, "different-taxonomy")

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -80,39 +80,33 @@ class TestLabTrain(unittest.TestCase):
         load_mock,
         is_macos_with_m_chip_mock,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            result = runner.invoke(lab.train, ["--input-dir", INPUT_DIR])
-            self.assertEqual(result.exit_code, 0)
-            load_mock.assert_not_called()
-            load_and_train_mock.assert_called_once()
-            self.assertIsNotNone(load_and_train_mock.call_args[1]["model"])
-            self.assertTrue(load_and_train_mock.call_args[1]["train"])
-            self.assertEqual(
-                load_and_train_mock.call_args[1]["data"], "./taxonomy_data"
-            )
-            self.assertIsNotNone(load_and_train_mock.call_args[1]["adapter_file"])
-            self.assertEqual(load_and_train_mock.call_args[1]["iters"], 100)
-            self.assertEqual(load_and_train_mock.call_args[1]["save_every"], 10)
-            self.assertEqual(load_and_train_mock.call_args[1]["steps_per_eval"], 10)
-            self.assertEqual(len(load_and_train_mock.call_args[1]), 7)
-            convert_between_mlx_and_pytorch_mock.assert_called_once()
-            self.assertIsNotNone(
-                convert_between_mlx_and_pytorch_mock.call_args[1]["hf_path"]
-            )
-            self.assertIsNotNone(
-                convert_between_mlx_and_pytorch_mock.call_args[1]["mlx_path"]
-            )
-            self.assertTrue(
-                convert_between_mlx_and_pytorch_mock.call_args[1]["quantize"]
-            )
-            self.assertFalse(convert_between_mlx_and_pytorch_mock.call_args[1]["local"])
-            self.assertEqual(len(convert_between_mlx_and_pytorch_mock.call_args[1]), 4)
-            make_data_mock.assert_called_once()
-            self.assertEqual(make_data_mock.call_args[1]["data_dir"], "./taxonomy_data")
-            self.assertEqual(len(make_data_mock.call_args[1]), 1)
-            is_macos_with_m_chip_mock.assert_called_once()
+        setup_input_dir()
+        result = CliRunner().invoke(lab.train, ["--input-dir", INPUT_DIR])
+        self.assertEqual(result.exit_code, 0)
+        load_mock.assert_not_called()
+        load_and_train_mock.assert_called_once()
+        self.assertIsNotNone(load_and_train_mock.call_args[1]["model"])
+        self.assertTrue(load_and_train_mock.call_args[1]["train"])
+        self.assertEqual(load_and_train_mock.call_args[1]["data"], "./taxonomy_data")
+        self.assertIsNotNone(load_and_train_mock.call_args[1]["adapter_file"])
+        self.assertEqual(load_and_train_mock.call_args[1]["iters"], 100)
+        self.assertEqual(load_and_train_mock.call_args[1]["save_every"], 10)
+        self.assertEqual(load_and_train_mock.call_args[1]["steps_per_eval"], 10)
+        self.assertEqual(len(load_and_train_mock.call_args[1]), 7)
+        convert_between_mlx_and_pytorch_mock.assert_called_once()
+        self.assertIsNotNone(
+            convert_between_mlx_and_pytorch_mock.call_args[1]["hf_path"]
+        )
+        self.assertIsNotNone(
+            convert_between_mlx_and_pytorch_mock.call_args[1]["mlx_path"]
+        )
+        self.assertTrue(convert_between_mlx_and_pytorch_mock.call_args[1]["quantize"])
+        self.assertFalse(convert_between_mlx_and_pytorch_mock.call_args[1]["local"])
+        self.assertEqual(len(convert_between_mlx_and_pytorch_mock.call_args[1]), 4)
+        make_data_mock.assert_called_once()
+        self.assertEqual(make_data_mock.call_args[1]["data_dir"], "./taxonomy_data")
+        self.assertEqual(len(make_data_mock.call_args[1]), 1)
+        is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=True)
     @patch("instructlab.mlx_explore.gguf_convert_to_mlx.load")
@@ -127,57 +121,49 @@ class TestLabTrain(unittest.TestCase):
         load_mock,
         is_macos_with_m_chip_mock,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            result = runner.invoke(
-                lab.train, ["--input-dir", INPUT_DIR, "--skip-quantize"]
-            )
-            self.assertEqual(result.exit_code, 0)
-            load_mock.assert_not_called()
-            load_and_train_mock.assert_called_once()
-            convert_between_mlx_and_pytorch_mock.assert_called_once()
-            self.assertEqual(
-                convert_between_mlx_and_pytorch_mock.call_args[1]["quantize"], False
-            )
-            make_data_mock.assert_called_once()
-            is_macos_with_m_chip_mock.assert_called_once()
+        setup_input_dir()
+        result = CliRunner().invoke(
+            lab.train, ["--input-dir", INPUT_DIR, "--skip-quantize"]
+        )
+        self.assertEqual(result.exit_code, 0)
+        load_mock.assert_not_called()
+        load_and_train_mock.assert_called_once()
+        convert_between_mlx_and_pytorch_mock.assert_called_once()
+        self.assertEqual(
+            convert_between_mlx_and_pytorch_mock.call_args[1]["quantize"], False
+        )
+        make_data_mock.assert_called_once()
+        is_macos_with_m_chip_mock.assert_called_once()
 
     def test_input_error(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(lab.train, ["--input-dir", "invalid"])
-            self.assertIsNotNone(result.exception)
-            self.assertIn("No such file or directory: 'invalid'", result.output)
-            self.assertEqual(result.exit_code, 1)
+        result = CliRunner().invoke(lab.train, ["--input-dir", "invalid"])
+        self.assertIsNotNone(result.exception)
+        self.assertIn("No such file or directory: 'invalid'", result.output)
+        self.assertEqual(result.exit_code, 1)
 
     def test_invalid_taxonomy(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            os.mkdir(INPUT_DIR)  # Leave out the test and train files
-            result = runner.invoke(lab.train, ["--input-dir", INPUT_DIR])
-            self.assertIsNotNone(result.exception)
-            self.assertIn(
-                f"{INPUT_DIR} does not contain training or test files, did you run `ilab generate`?",
-                result.output,
-            )
-            self.assertEqual(result.exit_code, 1)
+        os.mkdir(INPUT_DIR)  # Leave out the test and train files
+        result = CliRunner().invoke(lab.train, ["--input-dir", INPUT_DIR])
+        self.assertIsNotNone(result.exception)
+        self.assertIn(
+            f"{INPUT_DIR} does not contain training or test files, did you run `ilab generate`?",
+            result.output,
+        )
+        self.assertEqual(result.exit_code, 1)
 
     def test_invalid_data_dir(self):
         # The error comes from make_data itself so it's only really useful to test on a mac
         if is_arm_mac():
-            runner = CliRunner()
-            with runner.isolated_filesystem():
-                os.mkdir(INPUT_DIR)  # Leave out the test and train files
-                result = runner.invoke(
-                    lab.train, ["--data-dir", "invalid", "--input-dir", INPUT_DIR]
-                )
-                self.assertIsNotNone(result.exception)
-                self.assertIn(
-                    "Could not read from data directory",
-                    result.output,
-                )
-                self.assertEqual(result.exit_code, 1)
+            os.mkdir(INPUT_DIR)  # Leave out the test and train files
+            result = CliRunner().invoke(
+                lab.train, ["--data-dir", "invalid", "--input-dir", INPUT_DIR]
+            )
+            self.assertIsNotNone(result.exception)
+            self.assertIn(
+                "Could not read from data directory",
+                result.output,
+            )
+            self.assertEqual(result.exit_code, 1)
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=True)
     @patch(
@@ -187,20 +173,18 @@ class TestLabTrain(unittest.TestCase):
     def test_invalid_data_dir_synthetic(
         self, make_data_mock, is_macos_with_m_chip_mock
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            os.mkdir(INPUT_DIR)  # Leave out the test and train files
-            result = runner.invoke(
-                lab.train, ["--data-dir", "invalid", "--input-dir", INPUT_DIR]
-            )
-            make_data_mock.assert_called_once()
-            self.assertIsNotNone(result.exception)
-            self.assertIn(
-                "Could not read from data directory",
-                result.output,
-            )
-            self.assertEqual(result.exit_code, 1)
-            is_macos_with_m_chip_mock.assert_called_once()
+        os.mkdir(INPUT_DIR)  # Leave out the test and train files
+        result = CliRunner().invoke(
+            lab.train, ["--data-dir", "invalid", "--input-dir", INPUT_DIR]
+        )
+        make_data_mock.assert_called_once()
+        self.assertIsNotNone(result.exception)
+        self.assertIn(
+            "Could not read from data directory",
+            result.output,
+        )
+        self.assertEqual(result.exit_code, 1)
+        is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=True)
     @patch("instructlab.mlx_explore.gguf_convert_to_mlx.load")
@@ -215,18 +199,16 @@ class TestLabTrain(unittest.TestCase):
         load_mock,
         is_macos_with_m_chip_mock,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            result = runner.invoke(
-                lab.train, ["--input-dir", INPUT_DIR, "--skip-preprocessing"]
-            )
-            self.assertEqual(result.exit_code, 0)
-            load_mock.assert_not_called()
-            load_and_train_mock.assert_called_once()
-            convert_between_mlx_and_pytorch_mock.assert_called_once()
-            make_data_mock.assert_not_called()
-            is_macos_with_m_chip_mock.assert_called_once()
+        setup_input_dir()
+        result = CliRunner().invoke(
+            lab.train, ["--input-dir", INPUT_DIR, "--skip-preprocessing"]
+        )
+        self.assertEqual(result.exit_code, 0)
+        load_mock.assert_not_called()
+        load_and_train_mock.assert_called_once()
+        convert_between_mlx_and_pytorch_mock.assert_called_once()
+        make_data_mock.assert_not_called()
+        is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=True)
     @patch("instructlab.mlx_explore.utils.fetch_tokenizer_from_hub")
@@ -243,33 +225,31 @@ class TestLabTrain(unittest.TestCase):
         fetch_tokenizer_from_hub_mock,
         is_macos_with_m_chip_mock,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            setup_load()
-            result = runner.invoke(
-                lab.train,
-                [
-                    "--input-dir",
-                    INPUT_DIR,
-                    "--tokenizer-dir",
-                    "tokenizer",
-                    "--gguf-model-path",
-                    "gguf_model",
-                    "--model-dir",
-                    MODEL_DIR,
-                ],
-            )
-            self.assertEqual(result.exit_code, 0)
-            load_mock.assert_called_once()
-            load_and_train_mock.assert_called_once()
-            convert_between_mlx_and_pytorch_mock.assert_not_called()
-            make_data_mock.assert_called_once()
-            fetch_tokenizer_from_hub_mock.assert_called_once()
-            self.assertEqual(fetch_tokenizer_from_hub_mock.call_args[0][0], "tokenizer")
-            self.assertEqual(fetch_tokenizer_from_hub_mock.call_args[0][1], "tokenizer")
-            self.assertEqual(len(fetch_tokenizer_from_hub_mock.call_args[0]), 2)
-            is_macos_with_m_chip_mock.assert_called_once()
+        setup_input_dir()
+        setup_load()
+        result = CliRunner().invoke(
+            lab.train,
+            [
+                "--input-dir",
+                INPUT_DIR,
+                "--tokenizer-dir",
+                "tokenizer",
+                "--gguf-model-path",
+                "gguf_model",
+                "--model-dir",
+                MODEL_DIR,
+            ],
+        )
+        self.assertEqual(result.exit_code, 0)
+        load_mock.assert_called_once()
+        load_and_train_mock.assert_called_once()
+        convert_between_mlx_and_pytorch_mock.assert_not_called()
+        make_data_mock.assert_called_once()
+        fetch_tokenizer_from_hub_mock.assert_called_once()
+        self.assertEqual(fetch_tokenizer_from_hub_mock.call_args[0][0], "tokenizer")
+        self.assertEqual(fetch_tokenizer_from_hub_mock.call_args[0][1], "tokenizer")
+        self.assertEqual(len(fetch_tokenizer_from_hub_mock.call_args[0]), 2)
+        is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=True)
     @patch("instructlab.mlx_explore.utils.fetch_tokenizer_from_hub")
@@ -286,31 +266,29 @@ class TestLabTrain(unittest.TestCase):
         fetch_tokenizer_from_hub_mock,
         is_macos_with_m_chip_mock,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            setup_load()
-            result = runner.invoke(
-                lab.train,
-                [
-                    "--input-dir",
-                    INPUT_DIR,
-                    "--tokenizer-dir",
-                    "tokenizer",
-                    "--gguf-model-path",
-                    "gguf_model",
-                    "--model-dir",
-                    MODEL_DIR,
-                    "--local",
-                ],
-            )
-            self.assertEqual(result.exit_code, 0)
-            load_mock.assert_called_once()
-            load_and_train_mock.assert_called_once()
-            convert_between_mlx_and_pytorch_mock.assert_not_called()
-            make_data_mock.assert_called_once()
-            fetch_tokenizer_from_hub_mock.assert_not_called()
-            is_macos_with_m_chip_mock.assert_called_once()
+        setup_input_dir()
+        setup_load()
+        result = CliRunner().invoke(
+            lab.train,
+            [
+                "--input-dir",
+                INPUT_DIR,
+                "--tokenizer-dir",
+                "tokenizer",
+                "--gguf-model-path",
+                "gguf_model",
+                "--model-dir",
+                MODEL_DIR,
+                "--local",
+            ],
+        )
+        self.assertEqual(result.exit_code, 0)
+        load_mock.assert_called_once()
+        load_and_train_mock.assert_called_once()
+        convert_between_mlx_and_pytorch_mock.assert_not_called()
+        make_data_mock.assert_called_once()
+        fetch_tokenizer_from_hub_mock.assert_not_called()
+        is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=False)
     @patch.object(linux_train, "linux_train")
@@ -321,35 +299,33 @@ class TestLabTrain(unittest.TestCase):
         linux_train_mock,
         is_macos_with_m_chip_mock,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            setup_linux_dir()
-            result = runner.invoke(lab.train, ["--input-dir", INPUT_DIR])
-            self.assertEqual(result.exit_code, 0)
-            convert_llama_to_gguf_mock.assert_called_once()
-            self.assertEqual(
-                convert_llama_to_gguf_mock.call_args[1]["model"],
-                "./training_results/final",
-            )
-            self.assertEqual(convert_llama_to_gguf_mock.call_args[1]["pad_vocab"], True)
-            self.assertEqual(len(convert_llama_to_gguf_mock.call_args[1]), 2)
-            linux_train_mock.assert_called_once()
-            print(linux_train_mock.call_args[1])
-            self.assertEqual(
-                linux_train_mock.call_args[1]["train_file"],
-                "test_generated/train_1.jsonl",
-            )
-            self.assertEqual(
-                linux_train_mock.call_args[1]["test_file"],
-                "test_generated/test_1.jsonl",
-            )
-            self.assertEqual(linux_train_mock.call_args[1]["num_epochs"], 1)
-            self.assertIsNotNone(linux_train_mock.call_args[1]["device"])
-            self.assertFalse(linux_train_mock.call_args[1]["four_bit_quant"])
-            self.assertEqual(len(linux_train_mock.call_args[1]), 7)
-            is_macos_with_m_chip_mock.assert_called_once()
-            self.assertFalse(os.path.isfile(LINUX_GGUF_FILE))
+        setup_input_dir()
+        setup_linux_dir()
+        result = CliRunner().invoke(lab.train, ["--input-dir", INPUT_DIR])
+        self.assertEqual(result.exit_code, 0)
+        convert_llama_to_gguf_mock.assert_called_once()
+        self.assertEqual(
+            convert_llama_to_gguf_mock.call_args[1]["model"],
+            "./training_results/final",
+        )
+        self.assertEqual(convert_llama_to_gguf_mock.call_args[1]["pad_vocab"], True)
+        self.assertEqual(len(convert_llama_to_gguf_mock.call_args[1]), 2)
+        linux_train_mock.assert_called_once()
+        print(linux_train_mock.call_args[1])
+        self.assertEqual(
+            linux_train_mock.call_args[1]["train_file"],
+            "test_generated/train_1.jsonl",
+        )
+        self.assertEqual(
+            linux_train_mock.call_args[1]["test_file"],
+            "test_generated/test_1.jsonl",
+        )
+        self.assertEqual(linux_train_mock.call_args[1]["num_epochs"], 1)
+        self.assertIsNotNone(linux_train_mock.call_args[1]["device"])
+        self.assertFalse(linux_train_mock.call_args[1]["four_bit_quant"])
+        self.assertEqual(len(linux_train_mock.call_args[1]), 7)
+        is_macos_with_m_chip_mock.assert_called_once()
+        self.assertFalse(os.path.isfile(LINUX_GGUF_FILE))
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=False)
     @patch("instructlab.train.linux_train.linux_train")
@@ -358,23 +334,22 @@ class TestLabTrain(unittest.TestCase):
         self, convert_llama_to_gguf_mock, linux_train_mock, is_macos_with_m_chip_mock
     ):
         runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            setup_linux_dir()
-            result = runner.invoke(
-                lab.train, ["--input-dir", INPUT_DIR, "--num-epochs", "2"]
-            )
-            self.assertEqual(result.exit_code, 0)
-            convert_llama_to_gguf_mock.assert_called_once()
-            linux_train_mock.assert_called_once()
-            self.assertEqual(linux_train_mock.call_args[1]["num_epochs"], 2)
-            is_macos_with_m_chip_mock.assert_called_once()
-            self.assertFalse(os.path.isfile(LINUX_GGUF_FILE))
+        setup_input_dir()
+        setup_linux_dir()
+        result = runner.invoke(
+            lab.train, ["--input-dir", INPUT_DIR, "--num-epochs", "2"]
+        )
+        self.assertEqual(result.exit_code, 0)
+        convert_llama_to_gguf_mock.assert_called_once()
+        linux_train_mock.assert_called_once()
+        self.assertEqual(linux_train_mock.call_args[1]["num_epochs"], 2)
+        is_macos_with_m_chip_mock.assert_called_once()
+        self.assertFalse(os.path.isfile(LINUX_GGUF_FILE))
 
-            # Test with invalid num_epochs
-            result = runner.invoke(
-                lab.train, ["--input-dir", INPUT_DIR, "--num-epochs", "two"]
-            )
-            self.assertIsNotNone(result.exception)
-            self.assertEqual(result.exit_code, 2)
-            self.assertIn("'two' is not a valid integer", result.output)
+        # Test with invalid num_epochs
+        result = runner.invoke(
+            lab.train, ["--input-dir", INPUT_DIR, "--num-epochs", "two"]
+        )
+        self.assertIsNotNone(result.exception)
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("'two' is not a valid integer", result.output)


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves #963

**Description of your changes:**

Instead of applying the isolation decorator to each test case - and risking to miss it for some test cases - automatically isolate the file system using `autouse=True` fixture in global `conftest`.
