### PR TITLE
Do not cache llama-cpp-python builds

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,11 +50,15 @@ jobs:
       - name: Setup Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: 3.11
           cache: pip
           cache-dependency-path: |
             **/pyproject.toml
             **/requirements*.txt
+
+      - name: Remove llama-cpp-python from cache
+        run: |
+          pip cache remove llama_cpp_python
 
       - name: Cache huggingface
         uses: actions/cache@v4
@@ -79,3 +83,8 @@ jobs:
         run: |
           . venv/bin/activate
           ./scripts/basic-workflow-tests.sh -cm
+
+      - name: Remove llama-cpp-python from cache
+        if: always()
+        run: |
+          pip cache remove llama_cpp_python

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,34 +40,23 @@ jobs:
           fetch-depth: 0
           submodules: true
 
-      - name: Set up Python
+      - name: Setup Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: 3.11
+          cache: pip
+          cache-dependency-path: |
+            **/pyproject.toml
+            **/requirements*.txt
 
-      # tox creates (and reuses) a separate Python (virtual) environment for each context (fmt, lint)
-      # tox requires (and will install, if not exists) all the packages listed in requirements.txt
-      # so we want to cache the entire Python environment, not just the pip cache as tox will not reuse that
-      # but caching tox environments is fickle and can cause weird errors
-      # tox does provide a legacy option to reuse the Python system wide site packages
-      # since GH action runners are one-and-done we can install all requirements into the system packages
-      # and cache and reuse all of the installed Python system packages
-      # tox can then reuse the system site packages with setting `-x testenv:lint.system_site_packages=True`
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        id: cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
-          restore-keys:
-            ${{ env.pythonLocation }}-
+      - name: Remove llama-cpp-python from cache
+        run: |
+          pip cache remove llama_cpp_python
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-          python -m pip install -r requirements-dev.txt
+          python -m pip install tox
 
       - name: Run Ruff check
         run: |
@@ -77,6 +66,9 @@ jobs:
         if: success() || failure()
         run: |
           echo "::add-matcher::.github/workflows/matchers/pylint.json"
-          tox \
-            -x testenv:lint.system_site_packages=True \
-            -e lint
+          tox -e lint
+
+      - name: Remove llama-cpp-python from cache
+        if: always()
+        run: |
+          pip cache remove llama_cpp_python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,10 @@ jobs:
             **/pyproject.toml
             **/requirements*.txt
 
+      - name: Remove llama-cpp-python from cache
+        run: |
+          pip cache remove llama_cpp_python
+
       - name: Cache huggingface
         uses: actions/cache@v4
         with:
@@ -88,6 +92,11 @@ jobs:
 
       - name: Run unit and functional tests with tox
         run: tox
+
+      - name: Remove llama-cpp-python from cache
+        if: always()
+        run: |
+          pip cache remove llama_cpp_python
 
   test-workflow-complete:
     needs: ["test"]
@@ -106,6 +115,19 @@ jobs:
           fetch-depth: 0
           submodules: true
 
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: pip
+          cache-dependency-path: |
+            **/pyproject.toml
+            **/requirements*.txt
+
+      - name: Remove llama-cpp-python from cache
+        run: |
+          pip cache remove llama_cpp_python
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -119,3 +141,8 @@ jobs:
         with:
           files: 'man/*.1'
           fail: true
+
+      - name: Remove llama-cpp-python from cache
+        if: always()
+        run: |
+          pip cache remove llama_cpp_python

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ GitPython>=3.1.42,<4.0.0
 # Linux: 4-bit quantization with BitsAndBytes is not ready to use, yet.
 # see https://github.com/instructlab/instructlab/issues/579
 # bitsandbytes; sys_platform=='linux' and platform_machine=='x86_64'
-httpx
+httpx>=0.25.0,<1.0.0
 jsonschema>=4.21.1,<5.0.0
 # pin version, lift restriction after testing >=0.2.58
 # see https://github.com/abetlen/llama-cpp-python/issues/1286
@@ -18,9 +18,9 @@ numpy>=1.26.4,<2.0.0
 openai>=1.13.3,<2.0.0
 peft>=0.9.0,<0.10.0
 prompt-toolkit>=3.0.38,<4.0.0
-pydantic
-pydantic_yaml
-PyYAML>=6.0.1,<7.0.0
+pydantic>=2.6.0,<3.0.0
+pydantic_yaml>=1.2.0,<2.0.0
+PyYAML>=6.0.0,<7.0.0
 rich>=13.3.1,<14.0.0
 rouge-score>=0.1.2,<0.2.0
 sentencepiece>=0.2.0,<0.3.0

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -29,6 +29,14 @@ class TestConfig(unittest.TestCase):
         )
 
 
+def test_llamap_cpp_import():
+    # pylint: disable=import-outside-toplevel
+    # Third Party
+    import llama_cpp
+
+    llama_cpp.llama_backend_init()
+
+
 def test_import_mlx():
     # smoke test to verify that mlx is always available on Apple Silicon
     # but never on Linux and Intel macOS.


### PR DESCRIPTION
# Changes

**Description of your changes:**

Prevent any job from caching a llama-cpp-python wheel. It looks like a cached CUBLAS build from `e2e` test can leak into other tests that do not have the CUDA system libraries installed.

pip does not have an option to force a rebuild of a single package that has been locally cached. `--no-binary` applies to downloads but not to binary wheels in local cache. Purge `llama_cpp_python` wheels from cache after setup-python has populated pip's cache. Also remove the wheel before a job finishes.

Also refactor lint job to use the same caching and add constraints to a couple of packages to trigger the bug.


