### PR TITLE
e2e: Disable pip cache

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,10 +51,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: pip
-          cache-dependency-path: |
-            **/pyproject.toml
-            **/requirements*.txt
 
       - name: Cache huggingface
         uses: actions/cache@v4


### PR DESCRIPTION
The caching from this job seems to be causing a problem with the rest
of the test jobs that do not install with cuda support. This is
causing CI failures where you see packages fail to load because NVIDIA
dependencies are not on the system.

The quick fix for the moment is to stop caching from this job. We'll
have to come back around and do a more focused cache specifically for
this.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
