### PR TITLE
fix: do not spellcheck on venv and taxonomy

### DIFF
--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -8,7 +8,7 @@ matrix:
     camel-case: true
     mode: markdown
   sources:
-  - "**/*.md|!REVIEWERS.md|!build/**|!.tox/**|!src/instructlab/schema/**"
+  - "**/*.md|!REVIEWERS.md|!build/**|!.tox/**|!src/instructlab/schema/**|!venv/**|!taxonomy/**"
   dictionary:
     wordlists:
     - .spellcheck-en-custom.txt


### PR DESCRIPTION
We don't want to run the spellcheck linter on 'venv' and 'taxonomy' directories.

Fixes: #1129
Signed-off-by: Sébastien Han <seb@redhat.com>

