### PR TITLE
Clean exit from the chat.py

### DIFF
--- a/src/instructlab/chat/chat.py
+++ b/src/instructlab/chat/chat.py
@@ -141,7 +141,7 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
         )
 
     def _handle_quit(self, content):
-        raise EOFError
+        sys.exit(0)
 
     def _handle_help(self, content):
         self._sys_print(Markdown(HELP_MD))


### PR DESCRIPTION
Seeing:
```
>>> /q
[S][default]

Aborted!
```
This is ugly, due to the `raise`. This change fixes the exit to a 0 exit, removing the aborted warning.
