### PR TITLE
Improve logging and diagnostic output

### DIFF
--- a/src/instructlab/__main__.py
+++ b/src/instructlab/__main__.py
@@ -3,4 +3,5 @@
 # First Party
 from instructlab import lab
 
-lab.cli(None, None)
+# pylint does not understand click's decorators
+lab.cli()  # pylint: disable=no-value-for-parameter

--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -16,12 +16,11 @@ import time
 # Third Party
 from jinja2 import Template
 from rouge_score import rouge_scorer
-import click
 import tqdm
 
 # Local
 from ..config import DEFAULT_MULTIPROCESSING_START_METHOD, get_model_family
-from ..utils import chunk_document, read_taxonomy
+from ..utils import chunk_document, error_exit, read_taxonomy
 from . import utils
 from .utils import GenerateException
 
@@ -408,11 +407,11 @@ def generate_data(
                 }
             )
         except TypeError as exc:
-            click.secho(
-                f"Error reading seed examples: {exc}. Please make sure your answers are verbose enough.",
-                fg="red",
+            error_exit(
+                "Error reading seed examples",
+                exc=exc,
+                hint="Please make sure your answers are verbose enough.",
             )
-            raise click.exceptions.Exit(1)
 
     name = Path(model_name).stem  # Just in case it is a file path
     date_suffix = datetime.now().replace(microsecond=0).isoformat().replace(":", "_")

--- a/src/instructlab/mlx_explore/utils.py
+++ b/src/instructlab/mlx_explore/utils.py
@@ -59,7 +59,7 @@ def make_shards(weights: dict, max_file_size_gibibyte: int = 15):
     return shards
 
 
-@macos_requirement(echo_func=click.secho, exit_exception=click.exceptions.Exit)
+@macos_requirement()
 def save_model(save_dir: str, weights):
     save_dir = Path(save_dir)
     save_dir.mkdir(parents=True, exist_ok=True)

--- a/src/instructlab/server.py
+++ b/src/instructlab/server.py
@@ -106,12 +106,12 @@ def ensure_server(
             f"Connection to {api_base} failed. Starting a temporary server at {temp_api_base}..."
         )
         # create a temporary, throw-away logger
-        logger = logging.getLogger(host_port)
-        logger.setLevel(logging.FATAL)
+        tmplogger = logging.getLogger(host_port)
+        tmplogger.setLevel(logging.FATAL)
         server_process = mpctx.Process(
             target=server,
             kwargs={
-                "logger": logger,
+                "logger": tmplogger,
                 "model_path": serve_config.model_path,
                 "gpu_layers": serve_config.gpu_layers,
                 "max_ctx_size": serve_config.max_ctx_size,
@@ -157,7 +157,7 @@ def server(
         model=model_path,
         n_ctx=max_ctx_size,
         n_gpu_layers=gpu_layers,
-        verbose=logger.level == logging.DEBUG,
+        verbose=logger.isEnabledFor(logging.DEBUG),
     )
     if threads is not None:
         settings.n_threads = threads


### PR DESCRIPTION
# Changes

**Description of your changes:**

`ilab` now has a global `--log-level` option to override the log level from the config. It can be used to enable debug logging on the fly.

Logging configuration has been improved and log output is now colorized with `click.style`. This makes it easier to distinguish debug lines (blue) from warnings (yellow) or errors (red).

All error exit paths in `instructlab.lab` use a common helper function that prints the end-user error message in red. In debug mode, it also logs the stack trace.

llama-cpp debug logging is enabled with Python debug logging.