### PR TITLE
Use pytest instead of unittest.TestCase

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Standard
-import unittest
-
 # Third Party
 import pytest
 
@@ -10,44 +7,44 @@ import pytest
 from instructlab import config
 
 
-class TestConfig(unittest.TestCase):
+class TestConfig:
     @pytest.fixture(autouse=True)
     def _init_tmpdir(self, tmpdir):
         self.tmpdir = tmpdir
 
     def _assert_defaults(self, cfg):
-        self.assertIsNotNone(cfg.general)
-        self.assertEqual(cfg.general.log_level, "INFO")
+        assert cfg.general is not None
+        assert cfg.general.log_level == "INFO"
 
-        self.assertIsNotNone(cfg.chat)
-        self.assertEqual(cfg.chat.model, "merlinite-7b-lab-Q4_K_M")
-        self.assertFalse(cfg.chat.vi_mode)
-        self.assertTrue(cfg.chat.visible_overflow)
-        self.assertEqual(cfg.chat.context, "default")
-        self.assertIsNone(cfg.chat.session)
-        self.assertEqual(cfg.chat.logs_dir, "data/chatlogs")
-        self.assertFalse(cfg.chat.greedy_mode)
+        assert cfg.chat is not None
+        assert cfg.chat.model == "merlinite-7b-lab-Q4_K_M"
+        assert not cfg.chat.vi_mode
+        assert cfg.chat.visible_overflow
+        assert cfg.chat.context == "default"
+        assert cfg.chat.session is None
+        assert cfg.chat.logs_dir == "data/chatlogs"
+        assert not cfg.chat.greedy_mode
 
-        self.assertIsNotNone(cfg.generate)
-        self.assertEqual(cfg.generate.model, "merlinite-7b-lab-Q4_K_M")
-        self.assertEqual(cfg.generate.taxonomy_path, "taxonomy")
-        self.assertEqual(cfg.generate.taxonomy_base, "origin/main")
-        self.assertEqual(cfg.generate.num_cpus, 10)
-        self.assertEqual(cfg.generate.num_instructions, 100)
-        self.assertEqual(cfg.generate.chunk_word_count, 1000)
-        self.assertEqual(cfg.generate.output_dir, "generated")
-        self.assertEqual(cfg.generate.prompt_file, "prompt.txt")
-        self.assertEqual(cfg.generate.seed_file, "seed_tasks.json")
+        assert cfg.generate is not None
+        assert cfg.generate.model == "merlinite-7b-lab-Q4_K_M"
+        assert cfg.generate.taxonomy_path == "taxonomy"
+        assert cfg.generate.taxonomy_base == "origin/main"
+        assert cfg.generate.num_cpus == 10
+        assert cfg.generate.num_instructions == 100
+        assert cfg.generate.chunk_word_count == 1000
+        assert cfg.generate.output_dir == "generated"
+        assert cfg.generate.prompt_file == "prompt.txt"
+        assert cfg.generate.seed_file == "seed_tasks.json"
 
-        self.assertIsNotNone(cfg.serve)
-        self.assertEqual(cfg.serve.model_path, "models/merlinite-7b-lab-Q4_K_M.gguf")
-        self.assertEqual(cfg.serve.gpu_layers, -1)
-        self.assertEqual(cfg.serve.host_port, "127.0.0.1:8000")
-        self.assertEqual(cfg.serve.max_ctx_size, 4096)
+        assert cfg.serve is not None
+        assert cfg.serve.model_path == "models/merlinite-7b-lab-Q4_K_M.gguf"
+        assert cfg.serve.gpu_layers == -1
+        assert cfg.serve.host_port == "127.0.0.1:8000"
+        assert cfg.serve.max_ctx_size == 4096
 
     def test_default_config(self):
         cfg = config.get_default_config()
-        self.assertIsNotNone(cfg)
+        assert cfg is not None
         self._assert_defaults(cfg)
 
     def test_minimal_config(self):
@@ -65,7 +62,7 @@ serve:
 """
             )
         cfg = config.read_config(config_path)
-        self.assertIsNotNone(cfg)
+        assert cfg is not None
         self._assert_defaults(cfg)
 
     def test_full_config(self):
@@ -100,7 +97,7 @@ serve:
 """
             )
         cfg = config.read_config(config_path)
-        self.assertIsNotNone(cfg)
+        assert cfg is not None
         self._assert_defaults(cfg)
 
     def test_config_unexpected_fields(self):

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -2,7 +2,6 @@
 
 # Standard
 import re
-import unittest
 
 # Third Party
 import click
@@ -13,7 +12,7 @@ from instructlab import lab
 from instructlab.utils import is_macos_with_m_chip
 
 
-class TestConfig(unittest.TestCase):
+class TestConfig:
     def test_cli_params_hyphenated(self):
         flag_pattern = re.compile("-{1,2}[0-9a-z-]+")
         invalid_flags = []
@@ -24,9 +23,7 @@ class TestConfig(unittest.TestCase):
                 for opt in param.opts:
                     if not flag_pattern.fullmatch(opt):
                         invalid_flags.append(f"{name} {opt}")
-        self.assertFalse(
-            invalid_flags, "<- these commands are using non-hyphenated params"
-        )
+        assert not invalid_flags, "<- these commands are using non-hyphenated params"
 
 
 def test_llamap_cpp_import():

--- a/tests/test_lab_diff.py
+++ b/tests/test_lab_diff.py
@@ -2,7 +2,6 @@
 
 # Standard
 from pathlib import Path
-import unittest
 
 # Third Party
 from click.testing import CliRunner
@@ -21,7 +20,7 @@ rules:
 """
 
 
-class TestLabDiff(unittest.TestCase):
+class TestLabDiff:
     """Test collection for `ilab diff` command."""
 
     @pytest.fixture(autouse=True)
@@ -44,9 +43,9 @@ class TestLabDiff(unittest.TestCase):
                     self.taxonomy.root,
                 ],
             )
-            self.assertIn(untracked_file, result.output)
-            self.assertNotIn(tracked_file, result.output)
-            self.assertEqual(result.exit_code, 0)
+            assert untracked_file in result.output
+            assert tracked_file not in result.output
+            assert result.exit_code == 0
 
     def test_diff_rm_tracked(self):
         tracked_file = "compositional_skills/tracked/qna.yaml"
@@ -63,8 +62,8 @@ class TestLabDiff(unittest.TestCase):
                     self.taxonomy.root,
                 ],
             )
-            self.assertNotIn(tracked_file, result.output)
-            self.assertEqual(result.exit_code, 0)
+            assert tracked_file not in result.output
+            assert result.exit_code == 0
 
     def test_diff_invalid_ext(self):
         untracked_file = "compositional_skills/writing/new/qna.YAML"
@@ -80,10 +79,10 @@ class TestLabDiff(unittest.TestCase):
                     self.taxonomy.root,
                 ],
             )
-            self.assertListEqual(self.taxonomy.untracked_files, [untracked_file])
+            assert self.taxonomy.untracked_files == [untracked_file]
             # Invalid extension is silently filtered out
-            self.assertNotIn(untracked_file, result.output)
-            self.assertEqual(result.exit_code, 0)
+            assert untracked_file not in result.output
+            assert result.exit_code == 0
 
     def test_diff_invalid_base(self):
         taxonomy_base = "invalid"
@@ -98,13 +97,12 @@ class TestLabDiff(unittest.TestCase):
                     self.taxonomy.root,
                 ],
             )
-            self.assertIsNone(result.exception)
-            self.assertIn(
+            assert result.exception is None
+            assert (
                 f'Couldn\'t find the taxonomy git ref "{taxonomy_base}" '
-                "from the current HEAD",
-                result.output,
+                "from the current HEAD" in result.output
             )
-            self.assertEqual(result.exit_code, 0)
+            assert result.exit_code == 0
 
     def test_diff_invalid_path(self):
         taxonomy_path = "/path/to/taxonomy"
@@ -119,9 +117,9 @@ class TestLabDiff(unittest.TestCase):
                     taxonomy_path,
                 ],
             )
-            self.assertIsNone(result.exception)
-            self.assertIn(f"{taxonomy_path}", result.output)
-            self.assertEqual(result.exit_code, 0)
+            assert result.exception is None
+            assert f"{taxonomy_path}" in result.output
+            assert result.exit_code == 0
 
     def test_diff_valid_yaml(self):
         with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
@@ -137,10 +135,8 @@ class TestLabDiff(unittest.TestCase):
                     self.taxonomy.root,
                 ],
             )
-            self.assertIn(
-                f"Taxonomy in /{self.taxonomy.root}/ is valid :)", result.output
-            )
-            self.assertEqual(result.exit_code, 0)
+            assert f"Taxonomy in /{self.taxonomy.root}/ is valid :)" in result.output
+            assert result.exit_code == 0
 
     def test_diff_valid_yaml_quiet(self):
         with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
@@ -157,8 +153,8 @@ class TestLabDiff(unittest.TestCase):
                     "--quiet",
                 ],
             )
-            self.assertEqual(result.output, "")
-            self.assertEqual(result.exit_code, 0)
+            assert result.output == ""
+            assert result.exit_code == 0
 
     def test_diff_invalid_yaml(self):
         with open("tests/testdata/invalid_yaml.yaml", "rb") as qnafile:
@@ -175,8 +171,8 @@ class TestLabDiff(unittest.TestCase):
                     self.taxonomy.root,
                 ],
             )
-            self.assertIn("Reading taxonomy failed", result.output)
-            self.assertEqual(result.exit_code, 1)
+            assert "Reading taxonomy failed" in result.output
+            assert result.exit_code == 1
 
     def test_diff_invalid_yaml_quiet(self):
         with open("tests/testdata/invalid_yaml.yaml", "rb") as qnafile:
@@ -194,8 +190,8 @@ class TestLabDiff(unittest.TestCase):
                     "--quiet",
                 ],
             )
-            self.assertIsNotNone(result.exception)
-            self.assertEqual(result.exit_code, 1)
+            assert result.exception is not None
+            assert result.exit_code == 1
 
     def test_diff_custom_yaml(self):
         with open("tests/testdata/invalid_yaml.yaml", "rb") as qnafile:
@@ -217,8 +213,8 @@ class TestLabDiff(unittest.TestCase):
                 ],
             )
             # custom yaml rules mean "invalid" yaml file should pass
-            self.assertEqual(result.output, "")
-            self.assertEqual(result.exit_code, 0)
+            assert result.output == ""
+            assert result.exit_code == 0
             Path.unlink(custom_rules_file)
 
     def test_diff_failing_schema_yaml(self):
@@ -235,5 +231,5 @@ class TestLabDiff(unittest.TestCase):
                     self.taxonomy.root,
                 ],
             )
-            self.assertIn("Reading taxonomy failed", result.output)
-            self.assertEqual(result.exit_code, 1)
+            assert "Reading taxonomy failed" in result.output
+            assert result.exit_code == 1

--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -2,7 +2,6 @@
 
 # Standard
 from unittest.mock import MagicMock, patch
-import unittest
 
 # Third Party
 from click.testing import CliRunner
@@ -12,7 +11,7 @@ from huggingface_hub.utils import HfHubHTTPError
 from instructlab import lab
 
 
-class TestLabDownload(unittest.TestCase):
+class TestLabDownload:
     # When using `from X import Y` you need to understand that Y becomes part
     # of your module, so you should use `my_module.Y`` to patch.
     # When using `import X`, you should use `X.Y` to patch.
@@ -22,9 +21,9 @@ class TestLabDownload(unittest.TestCase):
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(lab.download)
-            self.assertEqual(
-                result.exit_code, 0, "command finished with an unexpected exit code"
-            )
+            assert (
+                result.exit_code == 0
+            ), "command finished with an unexpected exit code"
             mock_hf_hub_download.assert_called_once()
 
     @patch(
@@ -35,7 +34,7 @@ class TestLabDownload(unittest.TestCase):
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(lab.download)
-            self.assertEqual(
-                result.exit_code, 1, "command finished with an unexpected exit code"
-            )
-            self.assertIn("Could not reach hugging face server", result.output)
+            assert (
+                result.exit_code == 1
+            ), "command finished with an unexpected exit code"
+            assert "Could not reach hugging face server" in result.output

--- a/tests/test_lab_generate.py
+++ b/tests/test_lab_generate.py
@@ -6,10 +6,10 @@ import fnmatch
 import logging
 import os
 import pathlib
-import unittest
 
 # Third Party
 from click.testing import CliRunner
+import pytest
 
 # First Party
 from instructlab import lab
@@ -21,7 +21,7 @@ from .taxonomy import MockTaxonomy
 from .testdata import testdata
 
 
-class TestLabGenerate(unittest.TestCase):
+class TestLabGenerate:
     """Test collection for `ilab generate` command."""
 
     @patch(
@@ -43,13 +43,13 @@ class TestLabGenerate(unittest.TestCase):
                     "localhost:8000",
                 ],
             )
-            self.assertEqual(
-                result.exit_code, 1, "command finished with an unexpected exit code"
-            )
+            assert (
+                result.exit_code == 1
+            ), "command finished with an unexpected exit code"
             generate_data_mock.assert_called_once()
-            self.assertIn(
-                "Generating dataset failed with the following error: Connection Error",
-                result.output,
+            assert (
+                "Generating dataset failed with the following error: Connection Error"
+                in result.output
             )
             mt.teardown()
 
@@ -63,13 +63,10 @@ class TestLabGenerate(unittest.TestCase):
                     "localhost:8000",
                 ],
             )
-            self.assertEqual(
-                result.exit_code, 1, "command finished with an unexpected exit code"
-            )
-            self.assertIn(
-                "Error: taxonomy (taxonomy) does not exist",
-                result.output,
-            )
+            assert (
+                result.exit_code == 1
+            ), "command finished with an unexpected exit code"
+            assert "Error: taxonomy (taxonomy) does not exist" in result.output
 
     def test_no_new_data(self):
         runner = CliRunner()
@@ -86,13 +83,10 @@ class TestLabGenerate(unittest.TestCase):
                     "localhost:8000",
                 ],
             )
-            self.assertEqual(
-                result.exit_code, 1, "command finished with an unexpected exit code"
-            )
-            self.assertIn(
-                "Nothing to generate. Exiting.",
-                result.output,
-            )
+            assert (
+                result.exit_code == 1
+            ), "command finished with an unexpected exit code"
+            assert "Nothing to generate. Exiting." in result.output
             mt.teardown()
 
     def test_new_data_invalid_answer(self):
@@ -114,13 +108,10 @@ class TestLabGenerate(unittest.TestCase):
                         "localhost:8000",
                     ],
                 )
-                self.assertEqual(
-                    result.exit_code, 1, "command finished with an unexpected exit code"
-                )
-                self.assertIn(
-                    "taxonomy files with errors",
-                    result.output,
-                )
+                assert (
+                    result.exit_code == 1
+                ), "command finished with an unexpected exit code"
+                assert "taxonomy files with errors" in result.output
                 mt.teardown()
 
     @patch(
@@ -129,14 +120,14 @@ class TestLabGenerate(unittest.TestCase):
             "There was a problem connecting to the OpenAI server."
         ),
     )
-    def test_OpenAI_server_error(self, get_instructions_from_model):
+    def test_open_ai_server_error(self, get_instructions_from_model):
         with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
             with CliRunner().isolated_filesystem():
                 mt = MockTaxonomy(pathlib.Path("taxonomy"))
                 mt.create_untracked(
                     "compositional_skills/tracked/qna.yaml", qnafile.read()
                 )
-                with self.assertRaises(GenerateException) as exc:
+                with pytest.raises(GenerateException) as exc:
                     generate_data(
                         logger=logging.getLogger("test_logger"),
                         api_base="localhost:8000",
@@ -155,9 +146,8 @@ class TestLabGenerate(unittest.TestCase):
                         server_ctx_size=4096,
                         tls_insecure=False,
                     )
-                self.assertIn(
-                    "There was a problem connecting to the OpenAI server",
-                    f"{exc.exception}",
+                assert "There was a problem connecting to the OpenAI server" in str(
+                    exc.value
                 )
                 get_instructions_from_model.assert_called_once()
                 mt.teardown()
@@ -198,8 +188,8 @@ class TestLabGenerate(unittest.TestCase):
                     "test_my-model*.jsonl",
                 ]
                 for f in os.listdir("generated"):
-                    self.assertTrue(
-                        any(fnmatch.fnmatch(f, pattern) for pattern in expected_files)
+                    assert any(
+                        fnmatch.fnmatch(f, pattern) for pattern in expected_files
                     )
                 mt.teardown()
 
@@ -244,7 +234,7 @@ class TestLabGenerate(unittest.TestCase):
                     "test_my-model*.jsonl",
                 ]
                 for f in os.listdir("generated"):
-                    self.assertTrue(
-                        any(fnmatch.fnmatch(f, pattern) for pattern in expected_files)
+                    assert any(
+                        fnmatch.fnmatch(f, pattern) for pattern in expected_files
                     )
                 mt.teardown()

--- a/tests/test_lab_init.py
+++ b/tests/test_lab_init.py
@@ -3,7 +3,6 @@
 # Standard
 from unittest.mock import MagicMock, patch
 import os
-import unittest
 
 # Third Party
 from click.testing import CliRunner
@@ -14,7 +13,7 @@ from instructlab import lab
 from instructlab.config import read_config
 
 
-class TestLabInit(unittest.TestCase):
+class TestLabInit:
     # When using `from X import Y` you need to understand that Y becomes part
     # of your module, so you should use `my_module.Y`` to patch.
     # When using `import X`, you should use `X.Y` to patch.
@@ -24,16 +23,16 @@ class TestLabInit(unittest.TestCase):
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(lab.init, args=["--non-interactive"])
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
+            assert result.exit_code == 0
+            assert "config.yaml" in os.listdir()
             mock_clone_from.assert_called_once()
 
     def test_init_interactive(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(lab.init, input="\nn")
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
+            assert result.exit_code == 0
+            assert "config.yaml" in os.listdir()
 
     @patch(
         "instructlab.lab.Repo.clone_from",
@@ -43,21 +42,21 @@ class TestLabInit(unittest.TestCase):
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(lab.init, input="\ny")
-            self.assertEqual(
-                result.exit_code, 1, "command finished with an unexpected exit code"
+            assert (
+                result.exit_code == 1
+            ), "command finished with an unexpected exit code"
+            assert (
+                "Failed to clone taxonomy repo: Authentication failed" in result.output
             )
-            self.assertIn(
-                "Failed to clone taxonomy repo: Authentication failed", result.output
-            )
-            self.assertIn("manually run", result.output)
+            assert "manually run" in result.output
 
     @patch("instructlab.lab.Repo.clone_from")
     def test_init_interactive_clone(self, mock_clone_from):
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(lab.init, input="\ny")
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
+            assert result.exit_code == 0
+            assert "config.yaml" in os.listdir()
             mock_clone_from.assert_called_once()
 
     def test_init_interactive_with_preexisting_nonempty_taxonomy(self):
@@ -65,30 +64,30 @@ class TestLabInit(unittest.TestCase):
         with runner.isolated_filesystem():
             os.makedirs("taxonomy/contents")
             result = runner.invoke(lab.init, input="\n")
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
-            self.assertIn("taxonomy", os.listdir())
+            assert result.exit_code == 0
+            assert "config.yaml" in os.listdir()
+            assert "taxonomy" in os.listdir()
 
     def test_init_interactive_with_preexisting_config(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
             # first run to prime the config.yaml in current directory
             result = runner.invoke(lab.init, input="non-default-taxonomy\nn")
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
+            assert result.exit_code == 0
+            assert "config.yaml" in os.listdir()
             config = read_config("config.yaml")
-            self.assertEqual(config.generate.taxonomy_path, "non-default-taxonomy")
+            assert config.generate.taxonomy_path == "non-default-taxonomy"
 
             # second invocation should ask if we want to overwrite - yes, and change taxonomy path
             result = runner.invoke(lab.init, input="y\ndifferent-taxonomy\nn")
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
+            assert result.exit_code == 0
+            assert "config.yaml" in os.listdir()
             config = read_config("config.yaml")
-            self.assertEqual(config.generate.taxonomy_path, "different-taxonomy")
+            assert config.generate.taxonomy_path == "different-taxonomy"
 
             # third invocation should again ask, but this time don't overwrite
             result = runner.invoke(lab.init, input="n")
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("config.yaml", os.listdir())
+            assert result.exit_code == 0
+            assert "config.yaml" in os.listdir()
             config = read_config("config.yaml")
-            self.assertEqual(config.generate.taxonomy_path, "different-taxonomy")
+            assert config.generate.taxonomy_path == "different-taxonomy"

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 import os
 import platform
 import sys
-import unittest
 
 # Third Party
 from click.testing import CliRunner
@@ -64,7 +63,7 @@ def is_arm_mac():
 
 
 @pytest.mark.usefixtures("mock_mlx_package")
-class TestLabTrain(unittest.TestCase):
+class TestLabTrain:
     """Test collection for `ilab train` command."""
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=True)
@@ -84,34 +83,31 @@ class TestLabTrain(unittest.TestCase):
         with runner.isolated_filesystem():
             setup_input_dir()
             result = runner.invoke(lab.train, ["--input-dir", INPUT_DIR])
-            self.assertEqual(result.exit_code, 0)
+            assert result.exit_code == 0
             load_mock.assert_not_called()
             load_and_train_mock.assert_called_once()
-            self.assertIsNotNone(load_and_train_mock.call_args[1]["model"])
-            self.assertTrue(load_and_train_mock.call_args[1]["train"])
-            self.assertEqual(
-                load_and_train_mock.call_args[1]["data"], "./taxonomy_data"
-            )
-            self.assertIsNotNone(load_and_train_mock.call_args[1]["adapter_file"])
-            self.assertEqual(load_and_train_mock.call_args[1]["iters"], 100)
-            self.assertEqual(load_and_train_mock.call_args[1]["save_every"], 10)
-            self.assertEqual(load_and_train_mock.call_args[1]["steps_per_eval"], 10)
-            self.assertEqual(len(load_and_train_mock.call_args[1]), 7)
+            assert load_and_train_mock.call_args[1]["model"] is not None
+            assert load_and_train_mock.call_args[1]["train"]
+            assert load_and_train_mock.call_args[1]["data"] == "./taxonomy_data"
+            assert load_and_train_mock.call_args[1]["adapter_file"] is not None
+            assert load_and_train_mock.call_args[1]["iters"] == 100
+            assert load_and_train_mock.call_args[1]["save_every"] == 10
+            assert load_and_train_mock.call_args[1]["steps_per_eval"] == 10
+            assert len(load_and_train_mock.call_args[1]) == 7
             convert_between_mlx_and_pytorch_mock.assert_called_once()
-            self.assertIsNotNone(
-                convert_between_mlx_and_pytorch_mock.call_args[1]["hf_path"]
+            assert (
+                convert_between_mlx_and_pytorch_mock.call_args[1]["hf_path"] is not None
             )
-            self.assertIsNotNone(
+            assert (
                 convert_between_mlx_and_pytorch_mock.call_args[1]["mlx_path"]
+                is not None
             )
-            self.assertTrue(
-                convert_between_mlx_and_pytorch_mock.call_args[1]["quantize"]
-            )
-            self.assertFalse(convert_between_mlx_and_pytorch_mock.call_args[1]["local"])
-            self.assertEqual(len(convert_between_mlx_and_pytorch_mock.call_args[1]), 4)
+            assert convert_between_mlx_and_pytorch_mock.call_args[1]["quantize"]
+            assert not convert_between_mlx_and_pytorch_mock.call_args[1]["local"]
+            assert len(convert_between_mlx_and_pytorch_mock.call_args[1]) == 4
             make_data_mock.assert_called_once()
-            self.assertEqual(make_data_mock.call_args[1]["data_dir"], "./taxonomy_data")
-            self.assertEqual(len(make_data_mock.call_args[1]), 1)
+            assert make_data_mock.call_args[1]["data_dir"] == "./taxonomy_data"
+            assert len(make_data_mock.call_args[1]) == 1
             is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=True)
@@ -133,12 +129,12 @@ class TestLabTrain(unittest.TestCase):
             result = runner.invoke(
                 lab.train, ["--input-dir", INPUT_DIR, "--skip-quantize"]
             )
-            self.assertEqual(result.exit_code, 0)
+            assert result.exit_code == 0
             load_mock.assert_not_called()
             load_and_train_mock.assert_called_once()
             convert_between_mlx_and_pytorch_mock.assert_called_once()
-            self.assertEqual(
-                convert_between_mlx_and_pytorch_mock.call_args[1]["quantize"], False
+            assert (
+                convert_between_mlx_and_pytorch_mock.call_args[1]["quantize"] is False
             )
             make_data_mock.assert_called_once()
             is_macos_with_m_chip_mock.assert_called_once()
@@ -147,21 +143,21 @@ class TestLabTrain(unittest.TestCase):
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(lab.train, ["--input-dir", "invalid"])
-            self.assertIsNotNone(result.exception)
-            self.assertIn("No such file or directory: 'invalid'", result.output)
-            self.assertEqual(result.exit_code, 1)
+            assert result.exception is not None
+            assert "No such file or directory: 'invalid'" in result.output
+            assert result.exit_code == 1
 
     def test_invalid_taxonomy(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
             os.mkdir(INPUT_DIR)  # Leave out the test and train files
             result = runner.invoke(lab.train, ["--input-dir", INPUT_DIR])
-            self.assertIsNotNone(result.exception)
-            self.assertIn(
-                f"{INPUT_DIR} does not contain training or test files, did you run `ilab generate`?",
-                result.output,
+            assert result.exception is not None
+            assert (
+                f"{INPUT_DIR} does not contain training or test files, did you run `ilab generate`?"
+                in result.output
             )
-            self.assertEqual(result.exit_code, 1)
+            assert result.exit_code == 1
 
     def test_invalid_data_dir(self):
         # The error comes from make_data itself so it's only really useful to test on a mac
@@ -172,12 +168,9 @@ class TestLabTrain(unittest.TestCase):
                 result = runner.invoke(
                     lab.train, ["--data-dir", "invalid", "--input-dir", INPUT_DIR]
                 )
-                self.assertIsNotNone(result.exception)
-                self.assertIn(
-                    "Could not read from data directory",
-                    result.output,
-                )
-                self.assertEqual(result.exit_code, 1)
+                assert result.exception is not None
+                assert "Could not read from data directory" in result.output
+                assert result.exit_code == 1
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=True)
     @patch(
@@ -194,12 +187,9 @@ class TestLabTrain(unittest.TestCase):
                 lab.train, ["--data-dir", "invalid", "--input-dir", INPUT_DIR]
             )
             make_data_mock.assert_called_once()
-            self.assertIsNotNone(result.exception)
-            self.assertIn(
-                "Could not read from data directory",
-                result.output,
-            )
-            self.assertEqual(result.exit_code, 1)
+            assert result.exception is not None
+            assert "Could not read from data directory" in result.output
+            assert result.exit_code == 1
             is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=True)
@@ -221,7 +211,7 @@ class TestLabTrain(unittest.TestCase):
             result = runner.invoke(
                 lab.train, ["--input-dir", INPUT_DIR, "--skip-preprocessing"]
             )
-            self.assertEqual(result.exit_code, 0)
+            assert result.exit_code == 0
             load_mock.assert_not_called()
             load_and_train_mock.assert_called_once()
             convert_between_mlx_and_pytorch_mock.assert_called_once()
@@ -260,15 +250,15 @@ class TestLabTrain(unittest.TestCase):
                     MODEL_DIR,
                 ],
             )
-            self.assertEqual(result.exit_code, 0)
+            assert result.exit_code == 0
             load_mock.assert_called_once()
             load_and_train_mock.assert_called_once()
             convert_between_mlx_and_pytorch_mock.assert_not_called()
             make_data_mock.assert_called_once()
             fetch_tokenizer_from_hub_mock.assert_called_once()
-            self.assertEqual(fetch_tokenizer_from_hub_mock.call_args[0][0], "tokenizer")
-            self.assertEqual(fetch_tokenizer_from_hub_mock.call_args[0][1], "tokenizer")
-            self.assertEqual(len(fetch_tokenizer_from_hub_mock.call_args[0]), 2)
+            assert fetch_tokenizer_from_hub_mock.call_args[0][0] == "tokenizer"
+            assert fetch_tokenizer_from_hub_mock.call_args[0][1] == "tokenizer"
+            assert len(fetch_tokenizer_from_hub_mock.call_args[0]) == 2
             is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=True)
@@ -304,7 +294,7 @@ class TestLabTrain(unittest.TestCase):
                     "--local",
                 ],
             )
-            self.assertEqual(result.exit_code, 0)
+            assert result.exit_code == 0
             load_mock.assert_called_once()
             load_and_train_mock.assert_called_once()
             convert_between_mlx_and_pytorch_mock.assert_not_called()
@@ -326,30 +316,30 @@ class TestLabTrain(unittest.TestCase):
             setup_input_dir()
             setup_linux_dir()
             result = runner.invoke(lab.train, ["--input-dir", INPUT_DIR])
-            self.assertEqual(result.exit_code, 0)
+            assert result.exit_code == 0
             convert_llama_to_gguf_mock.assert_called_once()
-            self.assertEqual(
-                convert_llama_to_gguf_mock.call_args[1]["model"],
-                "./training_results/final",
+            assert (
+                convert_llama_to_gguf_mock.call_args[1]["model"]
+                == "./training_results/final"
             )
-            self.assertEqual(convert_llama_to_gguf_mock.call_args[1]["pad_vocab"], True)
-            self.assertEqual(len(convert_llama_to_gguf_mock.call_args[1]), 2)
+            assert convert_llama_to_gguf_mock.call_args[1]["pad_vocab"] is True
+            assert len(convert_llama_to_gguf_mock.call_args[1]) == 2
             linux_train_mock.assert_called_once()
             print(linux_train_mock.call_args[1])
-            self.assertEqual(
-                linux_train_mock.call_args[1]["train_file"],
-                "test_generated/train_1.jsonl",
+            assert (
+                linux_train_mock.call_args[1]["train_file"]
+                == "test_generated/train_1.jsonl"
             )
-            self.assertEqual(
-                linux_train_mock.call_args[1]["test_file"],
-                "test_generated/test_1.jsonl",
+            assert (
+                linux_train_mock.call_args[1]["test_file"]
+                == "test_generated/test_1.jsonl"
             )
-            self.assertEqual(linux_train_mock.call_args[1]["num_epochs"], 1)
-            self.assertIsNotNone(linux_train_mock.call_args[1]["device"])
-            self.assertFalse(linux_train_mock.call_args[1]["four_bit_quant"])
-            self.assertEqual(len(linux_train_mock.call_args[1]), 7)
+            assert linux_train_mock.call_args[1]["num_epochs"] == 1
+            assert linux_train_mock.call_args[1]["device"] is not None
+            assert not linux_train_mock.call_args[1]["four_bit_quant"]
+            assert len(linux_train_mock.call_args[1]) == 7
             is_macos_with_m_chip_mock.assert_called_once()
-            self.assertFalse(os.path.isfile(LINUX_GGUF_FILE))
+            assert not os.path.isfile(LINUX_GGUF_FILE)
 
     @patch("instructlab.lab.utils.is_macos_with_m_chip", return_value=False)
     @patch("instructlab.train.linux_train.linux_train")
@@ -364,17 +354,17 @@ class TestLabTrain(unittest.TestCase):
             result = runner.invoke(
                 lab.train, ["--input-dir", INPUT_DIR, "--num-epochs", "2"]
             )
-            self.assertEqual(result.exit_code, 0)
+            assert result.exit_code == 0
             convert_llama_to_gguf_mock.assert_called_once()
             linux_train_mock.assert_called_once()
-            self.assertEqual(linux_train_mock.call_args[1]["num_epochs"], 2)
+            assert linux_train_mock.call_args[1]["num_epochs"] == 2
             is_macos_with_m_chip_mock.assert_called_once()
-            self.assertFalse(os.path.isfile(LINUX_GGUF_FILE))
+            assert not os.path.isfile(LINUX_GGUF_FILE)
 
             # Test with invalid num_epochs
             result = runner.invoke(
                 lab.train, ["--input-dir", INPUT_DIR, "--num-epochs", "two"]
             )
-            self.assertIsNotNone(result.exception)
-            self.assertEqual(result.exit_code, 2)
-            self.assertIn("'two' is not a valid integer", result.output)
+            assert result.exception is not None
+            assert result.exit_code == 2
+            assert "'two' is not a valid integer" in result.output

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,10 +3,10 @@
 # Standard
 from unittest.mock import Mock, patch
 import logging
-import unittest
 
 # Third Party
 import git
+import pytest
 import yaml
 
 # First Party
@@ -16,31 +16,31 @@ from instructlab import utils
 from .testdata import testdata
 
 
-class TestUtils(unittest.TestCase):
+class TestUtils:
     """Test collection in instructlab.utils."""
 
     def test_chunk_docs_wc_exeeds_ctx_window(self):
-        with self.assertRaises(ValueError) as exc:
+        with pytest.raises(ValueError) as exc:
             utils.chunk_document(
                 documents=testdata.documents,
                 chunk_word_count=1000,
                 server_ctx_size=1034,
             )
-        self.assertIn(
-            "Given word count (1000) per doc will exceed the server context window size (1034)",
-            f"{exc.exception}",
+        assert (
+            "Given word count (1000) per doc will exceed the server context window size (1034)"
+            in str(exc.value)
         )
 
     def test_chunk_docs_chunk_overlap_error(self):
-        with self.assertRaises(ValueError) as exc:
+        with pytest.raises(ValueError) as exc:
             utils.chunk_document(
                 documents=testdata.documents,
                 chunk_word_count=5,
                 server_ctx_size=1034,
             )
-        self.assertIn(
-            "Got a larger chunk overlap (100) than chunk size (24), should be smaller",
-            f"{exc.exception}",
+        assert (
+            "Got a larger chunk overlap (100) than chunk size (24), should be smaller"
+            in str(exc.value)
         )
 
     def test_chunk_docs_long_lines(self):
@@ -71,4 +71,4 @@ class TestUtils(unittest.TestCase):
                 logger=logging.getLogger("_test_"),
             )
             git_clone_checkout.assert_called_once()
-            self.assertEqual(len(documents), 2)
+            assert len(documents) == 2


### PR DESCRIPTION
# Changes

**Description of your changes:**

Tests now use modern pytest style instead of old `unittest.TestCase`. This has multiple benefits. Test code is easier to read. Pytest fixtures in functions now work. Test failures now show error context and local variables.

The code was automatically fixed by `pytestify==1.5.0`. ExceptionInfo was manually fixed to `str(exc.value)`.