### PR TITLE
Refactor CliRunner tests

### DIFF
--- a/tests/test_lab_diff.py
+++ b/tests/test_lab_diff.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=duplicate-code
 
 # Standard
 from pathlib import Path
@@ -35,8 +36,10 @@ class TestLabDiff:
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(
-                lab.diff,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
                     "--taxonomy-path",
@@ -54,8 +57,10 @@ class TestLabDiff:
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(
-                lab.diff,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
                     "--taxonomy-path",
@@ -71,8 +76,10 @@ class TestLabDiff:
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(
-                lab.diff,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
                     "--taxonomy-path",
@@ -89,37 +96,39 @@ class TestLabDiff:
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(
-                lab.diff,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "diff",
                     "--taxonomy-base",
                     taxonomy_base,
                     "--taxonomy-path",
                     self.taxonomy.root,
                 ],
             )
-            assert result.exception is None
             assert (
                 f'Couldn\'t find the taxonomy git ref "{taxonomy_base}" '
                 "from the current HEAD" in result.output
             )
-            assert result.exit_code == 0
+            assert result.exit_code == 1
 
     def test_diff_invalid_path(self):
         taxonomy_path = "/path/to/taxonomy"
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(
-                lab.diff,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
                     "--taxonomy-path",
                     taxonomy_path,
                 ],
             )
-            assert result.exception is None
             assert f"{taxonomy_path}" in result.output
-            assert result.exit_code == 0
+            assert result.exit_code == 1
 
     def test_diff_valid_yaml(self):
         with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
@@ -127,8 +136,10 @@ class TestLabDiff:
             self.taxonomy.create_untracked(valid_yaml_file, qnafile.read())
             runner = CliRunner()
             result = runner.invoke(
-                lab.diff,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
                     "--taxonomy-path",
@@ -144,8 +155,10 @@ class TestLabDiff:
             self.taxonomy.create_untracked(valid_yaml_file, qnafile.read())
             runner = CliRunner()
             result = runner.invoke(
-                lab.diff,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
                     "--taxonomy-path",
@@ -163,8 +176,10 @@ class TestLabDiff:
             )
             runner = CliRunner()
             result = runner.invoke(
-                lab.diff,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
                     "--taxonomy-path",
@@ -181,8 +196,10 @@ class TestLabDiff:
             )
             runner = CliRunner()
             result = runner.invoke(
-                lab.diff,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
                     "--taxonomy-path",
@@ -201,8 +218,10 @@ class TestLabDiff:
             self.taxonomy.create_untracked(invalid_yaml_file, qnafile.read())
             runner = CliRunner()
             result = runner.invoke(
-                lab.diff,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
                     "--taxonomy-path",
@@ -223,8 +242,10 @@ class TestLabDiff:
             self.taxonomy.create_untracked(failing_yaml_file, qnafile.read())
             runner = CliRunner()
             result = runner.invoke(
-                lab.diff,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
                     "--taxonomy-path",

--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -20,7 +20,13 @@ class TestLabDownload:
     def test_download(self, mock_hf_hub_download):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(lab.download)
+            result = runner.invoke(
+                lab.cli,
+                [
+                    "--config=DEFAULT",
+                    "download",
+                ],
+            )
             assert (
                 result.exit_code == 0
             ), "command finished with an unexpected exit code"
@@ -33,7 +39,13 @@ class TestLabDownload:
     def test_download_error(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(lab.download)
+            result = runner.invoke(
+                lab.cli,
+                [
+                    "--config=DEFAULT",
+                    "download",
+                ],
+            )
             assert (
                 result.exit_code == 1
             ), "command finished with an unexpected exit code"

--- a/tests/test_lab_generate.py
+++ b/tests/test_lab_generate.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=duplicate-code
 
 # Standard
 from unittest.mock import patch
@@ -33,8 +34,10 @@ class TestLabGenerate:
         with runner.isolated_filesystem():
             mt = MockTaxonomy(pathlib.Path("taxonomy"))
             result = runner.invoke(
-                lab.generate,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "generate",
                     "--taxonomy-base",
                     "main",
                     "--taxonomy-path",
@@ -57,8 +60,10 @@ class TestLabGenerate:
         runner = CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(
-                lab.generate,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "generate",
                     "--endpoint-url",
                     "localhost:8000",
                 ],
@@ -73,8 +78,10 @@ class TestLabGenerate:
         with runner.isolated_filesystem():
             mt = MockTaxonomy(pathlib.Path("taxonomy"))
             result = runner.invoke(
-                lab.generate,
+                lab.cli,
                 [
+                    "--config=DEFAULT",
+                    "generate",
                     "--taxonomy-base",
                     "main",
                     "--taxonomy-path",
@@ -98,8 +105,10 @@ class TestLabGenerate:
                     "compositional_skills/tracked/qna.yaml", qnafile.read()
                 )
                 result = runner.invoke(
-                    lab.generate,
+                    lab.cli,
                     [
+                        "--config=DEFAULT",
+                        "generate",
                         "--taxonomy-base",
                         "main",
                         "--taxonomy-path",

--- a/tests/test_lab_init.py
+++ b/tests/test_lab_init.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=duplicate-code
 
 # Standard
 from unittest.mock import MagicMock, patch
@@ -22,7 +23,7 @@ class TestLabInit:
     def test_init_noninteractive(self, mock_clone_from):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(lab.init, args=["--non-interactive"])
+            result = runner.invoke(lab.cli, ["init", "--non-interactive"])
             assert result.exit_code == 0
             assert "config.yaml" in os.listdir()
             mock_clone_from.assert_called_once()
@@ -30,7 +31,7 @@ class TestLabInit:
     def test_init_interactive(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(lab.init, input="\nn")
+            result = runner.invoke(lab.cli, ["init"], input="\nn")
             assert result.exit_code == 0
             assert "config.yaml" in os.listdir()
 
@@ -41,7 +42,7 @@ class TestLabInit:
     def test_init_interactive_git_error(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(lab.init, input="\ny")
+            result = runner.invoke(lab.cli, ["init"], input="\ny")
             assert (
                 result.exit_code == 1
             ), "command finished with an unexpected exit code"
@@ -54,7 +55,7 @@ class TestLabInit:
     def test_init_interactive_clone(self, mock_clone_from):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(lab.init, input="\ny")
+            result = runner.invoke(lab.cli, ["init"], input="\ny")
             assert result.exit_code == 0
             assert "config.yaml" in os.listdir()
             mock_clone_from.assert_called_once()
@@ -63,7 +64,7 @@ class TestLabInit:
         runner = CliRunner()
         with runner.isolated_filesystem():
             os.makedirs("taxonomy/contents")
-            result = runner.invoke(lab.init, input="\n")
+            result = runner.invoke(lab.cli, ["init"], input="\n")
             assert result.exit_code == 0
             assert "config.yaml" in os.listdir()
             assert "taxonomy" in os.listdir()
@@ -72,21 +73,21 @@ class TestLabInit:
         runner = CliRunner()
         with runner.isolated_filesystem():
             # first run to prime the config.yaml in current directory
-            result = runner.invoke(lab.init, input="non-default-taxonomy\nn")
+            result = runner.invoke(lab.cli, ["init"], input="non-default-taxonomy\nn")
             assert result.exit_code == 0
             assert "config.yaml" in os.listdir()
             config = read_config("config.yaml")
             assert config.generate.taxonomy_path == "non-default-taxonomy"
 
             # second invocation should ask if we want to overwrite - yes, and change taxonomy path
-            result = runner.invoke(lab.init, input="y\ndifferent-taxonomy\nn")
+            result = runner.invoke(lab.cli, ["init"], input="y\ndifferent-taxonomy\nn")
             assert result.exit_code == 0
             assert "config.yaml" in os.listdir()
             config = read_config("config.yaml")
             assert config.generate.taxonomy_path == "different-taxonomy"
 
             # third invocation should again ask, but this time don't overwrite
-            result = runner.invoke(lab.init, input="n")
+            result = runner.invoke(lab.cli, ["init"], input="n")
             assert result.exit_code == 0
             assert "config.yaml" in os.listdir()
             config = read_config("config.yaml")

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -82,7 +82,9 @@ class TestLabTrain:
         runner = CliRunner()
         with runner.isolated_filesystem():
             setup_input_dir()
-            result = runner.invoke(lab.train, ["--input-dir", INPUT_DIR])
+            result = runner.invoke(
+                lab.cli, ["--config=DEFAULT", "train", "--input-dir", INPUT_DIR]
+            )
             assert result.exit_code == 0
             load_mock.assert_not_called()
             load_and_train_mock.assert_called_once()
@@ -127,7 +129,14 @@ class TestLabTrain:
         with runner.isolated_filesystem():
             setup_input_dir()
             result = runner.invoke(
-                lab.train, ["--input-dir", INPUT_DIR, "--skip-quantize"]
+                lab.cli,
+                [
+                    "--config=DEFAULT",
+                    "train",
+                    "--input-dir",
+                    INPUT_DIR,
+                    "--skip-quantize",
+                ],
             )
             assert result.exit_code == 0
             load_mock.assert_not_called()
@@ -142,7 +151,9 @@ class TestLabTrain:
     def test_input_error(self):
         runner = CliRunner()
         with runner.isolated_filesystem():
-            result = runner.invoke(lab.train, ["--input-dir", "invalid"])
+            result = runner.invoke(
+                lab.cli, ["--config=DEFAULT", "train", "--input-dir", "invalid"]
+            )
             assert result.exception is not None
             assert "No such file or directory: 'invalid'" in result.output
             assert result.exit_code == 1
@@ -151,7 +162,9 @@ class TestLabTrain:
         runner = CliRunner()
         with runner.isolated_filesystem():
             os.mkdir(INPUT_DIR)  # Leave out the test and train files
-            result = runner.invoke(lab.train, ["--input-dir", INPUT_DIR])
+            result = runner.invoke(
+                lab.cli, ["--config=DEFAULT", "train", "--input-dir", INPUT_DIR]
+            )
             assert result.exception is not None
             assert (
                 f"{INPUT_DIR} does not contain training or test files, did you run `ilab generate`?"
@@ -166,7 +179,15 @@ class TestLabTrain:
             with runner.isolated_filesystem():
                 os.mkdir(INPUT_DIR)  # Leave out the test and train files
                 result = runner.invoke(
-                    lab.train, ["--data-dir", "invalid", "--input-dir", INPUT_DIR]
+                    lab.cli,
+                    [
+                        "--config=DEFAULT",
+                        "train",
+                        "--data-dir",
+                        "invalid",
+                        "--input-dir",
+                        INPUT_DIR,
+                    ],
                 )
                 assert result.exception is not None
                 assert "Could not read from data directory" in result.output
@@ -184,7 +205,15 @@ class TestLabTrain:
         with runner.isolated_filesystem():
             os.mkdir(INPUT_DIR)  # Leave out the test and train files
             result = runner.invoke(
-                lab.train, ["--data-dir", "invalid", "--input-dir", INPUT_DIR]
+                lab.cli,
+                [
+                    "--config=DEFAULT",
+                    "train",
+                    "--data-dir",
+                    "invalid",
+                    "--input-dir",
+                    INPUT_DIR,
+                ],
             )
             make_data_mock.assert_called_once()
             assert result.exception is not None
@@ -209,7 +238,14 @@ class TestLabTrain:
         with runner.isolated_filesystem():
             setup_input_dir()
             result = runner.invoke(
-                lab.train, ["--input-dir", INPUT_DIR, "--skip-preprocessing"]
+                lab.cli,
+                [
+                    "--config=DEFAULT",
+                    "train",
+                    "--input-dir",
+                    INPUT_DIR,
+                    "--skip-preprocessing",
+                ],
             )
             assert result.exit_code == 0
             load_mock.assert_not_called()
@@ -315,7 +351,9 @@ class TestLabTrain:
         with runner.isolated_filesystem():
             setup_input_dir()
             setup_linux_dir()
-            result = runner.invoke(lab.train, ["--input-dir", INPUT_DIR])
+            result = runner.invoke(
+                lab.cli, ["--config=DEFAULT", "train", "--input-dir", INPUT_DIR]
+            )
             assert result.exit_code == 0
             convert_llama_to_gguf_mock.assert_called_once()
             assert (
@@ -352,7 +390,15 @@ class TestLabTrain:
             setup_input_dir()
             setup_linux_dir()
             result = runner.invoke(
-                lab.train, ["--input-dir", INPUT_DIR, "--num-epochs", "2"]
+                lab.cli,
+                [
+                    "--config=DEFAULT",
+                    "train",
+                    "--input-dir",
+                    INPUT_DIR,
+                    "--num-epochs",
+                    "2",
+                ],
             )
             assert result.exit_code == 0
             convert_llama_to_gguf_mock.assert_called_once()
@@ -363,7 +409,15 @@ class TestLabTrain:
 
             # Test with invalid num_epochs
             result = runner.invoke(
-                lab.train, ["--input-dir", INPUT_DIR, "--num-epochs", "two"]
+                lab.cli,
+                [
+                    "--config=DEFAULT",
+                    "train",
+                    "--input-dir",
+                    INPUT_DIR,
+                    "--num-epochs",
+                    "two",
+                ],
             )
             assert result.exception is not None
             assert result.exit_code == 2


### PR DESCRIPTION
# Changes

**Description of your changes:**

Functional tests now behave more like actual click CLI. Tests cases no longer run the subcommand function directly. Instead they invoke the cli main entry point and delegate the subcommands to click.

The config file is now parsed in the main cli entry point instead of the option's validation callback. The `ctx.obj` is created in the entry point, too. The change was necessary because click's CliRunner does neither update `sys.argv` or set `ctx.invoked_subcommand` for the callback. IMO it's also a nicer design.
