### PR TITLE
e2e: Add timestamps to the test script

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -26,7 +26,7 @@ NC='\033[0m' # No Color
 SCRIPTDIR=$(dirname "$0")
 
 step() {
-    echo -e "$BOLD$@$NC"
+    echo -e "$BOLD$@ - $(date)$NC"
 }
 
 task() {


### PR DESCRIPTION
Every time we log a new step in the script, include a timestamp. This
should help with seeing how long each piece is taking within the
script.

This came up in discussion on #1111.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
