### PR TITLE
Change mergify automation to require 2 approving reviews for auto-merge

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,8 +1,8 @@
 pull_request_rules:
 - name: auto-merge
-  description: automatic merge for main with > 1 approved reviews, all requested reviews have given feedback, not held, and CI is successful
+  description: automatic merge for main with >= 2 approved reviews, all requested reviews have given feedback, not held, and CI is successful
   conditions:
-    - "#approved-reviews-by>=1"
+    - "#approved-reviews-by>=2"
     - "#review-requested=0"
     - "#changes-requested-reviews-by=0"
     - or:


### PR DESCRIPTION
As previously discussed, now that Summit is over we want to require 2 reviews for merging PRs instead of 1

Once this is in I will change the GitHub repo settings as well