### PR TITLE
README.md: Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
    source venv/bin/activate
    ```
 
-5. You may optionally enabled tab completion for the `ilab` command.
+5. You may optionally enable tab completion for the `ilab` command.
 
    #### Bash (version 4.4 or newer)
 


### PR DESCRIPTION
s/enabled/enable/.

This was a typo in the tab completion docs I just wrote that I noticed
after it merged. Apologies!

Signed-off-by: Russell Bryant <rbryant@redhat.com>
