### PR TITLE
notebook: more clean results code and output

### DIFF
--- a/notebooks/Training_a_LoRA_With_Instruct_Lab.ipynb
+++ b/notebooks/Training_a_LoRA_With_Instruct_Lab.ipynb
@@ -724,20 +724,12 @@
    },
    "outputs": [],
    "source": [
-    "for (i, (d, assistant_old)) in enumerate(zip(test_dataset, assistant_old_lst)):\n",
-    "  assistant_new = model_generate(d[\"user\"]).split(response_template.strip())[-1].strip()\n",
-    "  assistant_expected = d[\"assistant\"]\n",
-    "\n",
-    "  print(f\"\\n===\\ntest {i}\\n===\\n\")\n",
-    "  print(\"\\n===\\nuser\\n===\\n\")\n",
-    "  print(d['user'])\n",
-    "  print(\"\\n===\\nassistant_old\\n===\\n\")\n",
-    "  print(assistant_old)\n",
-    "  print(\"\\n===\\nassistant_new\\n===\\n\")\n",
-    "  print(assistant_new)\n",
-    "  print(\"\\n===\\nassistant_expected\\n===\\n\")\n",
-    "  print(assistant_expected)\n",
-    "  print(\"\\n\\n\")"
+    "for (i, (d, pre)) in enumerate(zip(test_dataset, assistant_old_lst)):",
+    "  print(f"### {i+1}: {d['user']}")",
+    "  print(f"Pre-trainted:\n_{pre[:300]}..._\n")",
+    "  print(f"Provided:\n{d['assistant']}\n")",
+    "  print("Fine-tuned:")",
+    "  print(model_generate(d["user"]).split(response_template.strip())[-1].strip(),"\n")"
    ]
   },
   {


### PR DESCRIPTION
Improvements of notebook results:
1. Shorter, cleaner and more maintainable code and output.
2. Markdown format of output is suitable for copy-paste to PR.
3. Pre-trained text is truncated because usually it is hallucinated and not valuable. It is only used as baseline to see improvement of fine-tuned results.
4. Pre-trained text written in italic font to distinguish it visually from provided in qna.yaml and fine-tuned.