### PR TITLE
Add `ilab sysinfo` command

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -54,6 +54,9 @@ rm -f config.yaml
 # print version
 ilab --version
 
+# print system information
+ilab sysinfo
+
 # pipe 3 carriage returns to ilab init to get past the prompts
 echo -e "\n\n\n" | ilab init
 

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -25,6 +25,7 @@ import yaml
 # Local
 # NOTE: Subcommands are using local imports to speed up startup time.
 from . import config, utils
+from .sysinfo import get_sysinfo
 
 # 'fork' is unsafe and incompatible with some hardware accelerators.
 # Python 3.14 will switch to 'spawn' on all platforms.
@@ -69,10 +70,13 @@ def cli(ctx, config_file):
 
     If this is your first time running InstructLab, it's best to start with `ilab init` to create the environment.
     """
-    # ilab init or "--help" have no config file
+    # ilab init or "--help" have no config file. ilab sysinfo does not need one.
     # CliRunner does fill ctx.invoke_subcommand in option callbacks. We have
     # to validate config_file here.
-    if ctx.invoked_subcommand != "init" and "--help" not in sys.argv[1:]:
+    if (
+        ctx.invoked_subcommand not in {"init", "sysinfo"}
+        and "--help" not in sys.argv[1:]
+    ):
         if config_file == "DEFAULT":
             config_obj = config.get_default_config()
         elif not os.path.isfile(config_file):
@@ -1344,3 +1348,10 @@ def convert(ctx, model_dir, adapter_file, skip_de_quantize, skip_quantize, model
 
     ctx.obj.logger.info(f"deleting {model_dir_fused_pt}/{model_name}.gguf...")
     os.remove(os.path.join(model_dir_fused_pt, f"{model_name}.gguf"))
+
+
+@cli.command
+def sysinfo():
+    """Print system information"""
+    for key, value in get_sysinfo().items():
+        print(f"{key}: {value}")

--- a/src/instructlab/sysinfo.py
+++ b/src/instructlab/sysinfo.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# Standard
+import importlib.metadata
+import os
+import platform
+import sys
+import typing
+
+
+def _platform_info() -> typing.Dict[str, typing.Any]:
+    """Platform and machine information"""
+    info = {
+        "sys.version": sys.version,
+        "sys.platform": sys.platform,
+        "os.name": os.name,
+        "platform.release": platform.release(),
+        "platform.machine": platform.machine(),
+    }
+    if sys.version_info >= (3, 10) and sys.platform == "linux":
+        os_release = platform.freedesktop_os_release()
+        for key in ["ID", "VERSION_ID", "PRETTY_NAME"]:
+            value = os_release.get(key)
+            if value:
+                info[f"os-release.{key}"] = value
+    return info
+
+
+def _torch_info() -> typing.Dict[str, typing.Any]:
+    """Torch capabilities and devices"""
+    # pylint: disable=import-outside-toplevel
+    # Third Party
+    import torch
+
+    return {
+        "torch.version": torch.__version__,
+        "torch.backends.cpu.capability": torch.backends.cpu.get_cpu_capability(),
+        "torch.version.cuda": torch.version.cuda,
+        "torch.version.hip": torch.version.hip,
+        "torch.cuda.available": torch.cuda.is_available(),
+        "torch.backends.cuda.is_built": torch.backends.cuda.is_built(),
+        "torch.backends.mps.is_built": torch.backends.mps.is_built(),
+        "torch.backends.mps.is_available": torch.backends.mps.is_available(),
+    }
+
+
+def _torch_cuda_info() -> typing.Dict[str, typing.Any]:
+    """Torch Nvidia CUDA / AMD ROCm devices"""
+    # pylint: disable=import-outside-toplevel
+    # Third Party
+    import torch
+
+    if not torch.cuda.is_available():
+        return {}
+
+    info = {
+        "torch.cuda.bf16": torch.cuda.is_bf16_supported(),
+        "torch.cuda.current": torch.cuda.current_device(),
+    }
+
+    for idx in range(torch.cuda.device_count()):
+        device = torch.device("cuda", idx)
+        free, total = torch.cuda.mem_get_info(device)
+        capmax, capmin = torch.cuda.get_device_capability(device)
+        info[f"torch.cuda.{idx}.name"] = torch.cuda.get_device_name(device)
+        info[f"torch.cuda.{idx}.free"] = f"{(free / 1024**3):.1f}"
+        info[f"torch.cuda.{idx}.total"] = f"{(total / 1024**3):.1f}"
+        info[f"torch.cuda.{idx}.capability"] = f"{capmax}.{capmin}"
+
+    return info
+
+
+def _llama_cpp_info() -> typing.Dict[str, typing.Any]:
+    """llama-cpp-python capabilities"""
+    # pylint: disable=import-outside-toplevel
+    # Third Party
+    import llama_cpp
+
+    return {
+        "llama_cpp_python.version": importlib.metadata.version("llama_cpp_python"),
+        "llama_cpp_python.supports_gpu_offload": llama_cpp.llama_supports_gpu_offload(),
+    }
+
+
+def get_sysinfo() -> typing.Dict[str, typing.Any]:
+    """Get system information"""
+    info = {
+        "instructlab.version": importlib.metadata.version("instructlab"),
+    }
+    info.update(_platform_info())
+    info.update(_torch_info())
+    info.update(_torch_cuda_info())
+    info.update(_llama_cpp_info())
+    return info
+
+
+def main():
+    for key, value in get_sysinfo().items():
+        print(f"{key}: {value}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Changes

**Description of your changes:**

The new `ilab sysinfo` command prints various system information related to the operating system, PyTorch, accelerators and llama-cpp. The output is useful for debugging issues.

```shell
$ ilab sysinfo
instructlab.version: 0.14.1.dev152+g3e610c1.d20240508
sys.version: 3.11.7 (main, Jan 22 2024, 00:00:00) [GCC 11.4.1 20231218 (Red Hat 11.4.1-3)]
sys.platform: linux
os.name: posix
platform.system: Linux
platform.release: 5.14.0-362.8.1.el9_3.x86_64
platform.machine: x86_64
os-release.ID: rhel
os-release.VERSION_ID: 9.4
os-release.PRETTY_NAME: Red Hat Enterprise Linux 9.4 (Plow)
torch.version: 2.3.0+cu121
torch.backends.cpu.capability: AVX512
torch.version.cuda: 12.1
torch.version.hip: None
torch.cuda.available: True
torch.backends.cuda.is_built: True
torch.backends.mps.is_built: False
torch.backends.mps.is_available: False
torch.cuda.bf16: True
torch.cuda.current: 0
torch.cuda.0.name: NVIDIA A100 80GB PCIe
torch.cuda.0.free: 78.7
torch.cuda.0.total: 79.1
torch.cuda.0.capability: 8.0
llama_cpp_python.version: 0.2.55
llama_cpp_python.supports_gpu_offload: True
```
