### PR TITLE
fix: add unit test for config log level

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,3 +158,19 @@ generate:
 """,
         ):
             config.read_config(config_path)
+
+    def test_validate_log_level_invalid(self):
+        cfg = config.get_default_config()
+        with pytest.raises(ValueError):
+            cfg.general.validate_log_level("INVALID")
+
+    def test_validate_log_level_valid(self):
+        cfg = config.get_default_config()
+        assert cfg.general.validate_log_level("DEBUG") == "DEBUG"
+        assert cfg.general.validate_log_level("INFO") == "INFO"
+        assert cfg.general.validate_log_level("WARNING") == "WARNING"
+        assert cfg.general.validate_log_level("WARN") == "WARN"
+        assert cfg.general.validate_log_level("FATAL") == "FATAL"
+        assert cfg.general.validate_log_level("CRITICAL") == "CRITICAL"
+        assert cfg.general.validate_log_level("ERROR") == "ERROR"
+        assert cfg.general.validate_log_level("NOTSET") == "NOTSET"


### PR DESCRIPTION
As requested in
https://github.com/instructlab/instructlab/pull/1092#pullrequestreview-2048991277 adding some unit tests to validate the "validate_log_level" function.

Signed-off-by: Sébastien Han <seb@redhat.com>

