### PR TITLE
train rework, introduce --backend and --dtype flags

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,11 +29,11 @@ rouge-score>=0.1.2,<0.2.0
 sentencepiece>=0.2.0,<0.3.0
 tokenizers>=0.15.2,<0.16.0
 toml>=0.10.2,<0.11.0
-# Habana installer has 2.2.0a0+git8964477 with oneMKL
 torch>=2.2.0a0,<3.0.0 ; python_version == '3.10'
-torch>=2.2.1,<3.0.0 ; python_version != '3.10'
+torch>=2.3.0,<3.0.0 ; python_version != '3.10'
 tqdm>=4.66.2,<5.0.0
-transformers>=4.30.0,<=4.38.2
+transformers==4.38.1; sys_platform == 'darwin' and platform_machine == 'arm64'
+transformers>=4.37.0,<=4.38.2; sys_platform != 'darwin' and platform_machine != 'arm64'
 trl>=0.7.11,<0.8.0
 wandb>=0.16.4,<0.17.0
 langchain-text-splitters

--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -134,7 +134,7 @@ test_train() {
     task Train the model
 
     # TODO Only cuda for now
-    TRAIN_ARGS="--device=cuda --4-bit-quant"
+    TRAIN_ARGS="--device=cuda --4-bit-quant --dtype=fp16"
     if [ "$GRANITE" -eq 1 ]; then
         TRAIN_ARGS="--gguf-model-path models/granite-7b-lab-Q4_K_M.gguf ${TRAIN_ARGS}"
     fi


### PR DESCRIPTION
# Changes

added `--backend` flag for `ilab train` allowing users to switch their training backend between pytorch and mlx. 

changed what was `linux_train.py` to work for both macos and linux depending on some new flags like fp16, bfp16, etc. 

**Which issue is resolved by this Pull Request:**

resolves #1108 

**Description of your changes:**

ilab train on macos and linux are really different just for MLX support.

It turns out pytorch supports an mps device enabling hardware accleration on macos. This allows us to use 99% of the codepath for linux train with less storage and memory used. the mlx method requires adapters files, and a whole -fused dir that almost doubles the storage used in this whole process

This backend is also more maintainable as mlx is written in a way that lead us to need some heavy infrastructure to run it.

In testing, the pytorch train code takes roughly the same amount of time on comparable hardware and yields a better result with a model that appears to learn the new skill/knowledge in a better manner with less hallucinations. 

I will note, 18gb of ram is the minimum to run this backend. When you have 32/38 train takes less than a quarter of the amount of time that 18gb does, and produces better results. 

ilab train now defaults to --backend=pytorch but --backend=mlx is still available

added a few more enhancements:
- the --backend flag lets users choose pytorch or mlx
- I got rid of the multiple flags referencing "model" and just made a --model-repo flag since train should always pull the full safetensors from HF
- I got rid of a few bad flags people should probably never use like gguf-model-path gguf models for training yield horrible results most of the time
- --dtype takes fp16, bf16, ftp32, and auto. This sets the dtype to user in pytorch. bf16 and fp16 were hardcoded in the past.
