### PR TITLE
Fix PyPI release issues

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -43,7 +43,10 @@ jobs:
         name: Publish packages to test.pypi.org
         # environment: publish-test-pypi
         if: |
-            github.repository_owner == 'instructlab' && github.event.action == 'published'
+            github.repository_owner == 'instructlab' && (
+                github.event.action == 'published' ||
+                (github.event_name == 'push' && github.ref == 'refs/heads/main')
+            )
         permissions:
             contents: read
             # see https://docs.pypi.org/trusted-publishers/

--- a/docs/habana-gaudi.md
+++ b/docs/habana-gaudi.md
@@ -142,11 +142,11 @@ The [`SFTTrainer`](https://huggingface.co/docs/trl/sft_trainer) from `trl` does 
 
 ## Install and run InstructLab with Intel Gaudi
 
-Install `InstructLab` from checkout with additional dependency `habana`:
+Install `InstructLab` from checkout with additional dependencies:
 
 ```shell
 . $HABANALABS_VIRTUAL_DIR/bin/activate
-pip install './instructlab[habana]'
+pip install -r instructlab/requirements-hpu.txt ./instructlab
 ```
 
 > **TIP** If `llama-cpp-python` fails to build with error ``unsupported instruction `vpdpbusd'``, then install with `CFLAGS="-mno-avx" pip install ...`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,13 +41,14 @@ issues = "https://github.com/instructlab/instructlab/issues"
 
 [tool.setuptools_scm]
 version_file = "src/instructlab/_version.py"
+# do not include +gREV local version, required for Test PyPI upload
+local_scheme = "no-local-version"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
-optional-dependencies.hpu = { file = ["requirements-hpu.txt"]}
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -1,6 +1,4 @@
-# Optional dependencies for Intel Gaudi / Habana Labs HPU devices
-#
-# install with 'pip install instructlab[hpu]'
+# Dependencies for Intel Gaudi / Habana Labs HPU devices
 #
 
 # upstream version "optimum[habana]>=1.19.0,<2.0.0" does not work


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves #1054 

**Description of your changes:**

Disable setuptool-scm's local version tag. Test PyPI does not accept packages with a local version. By default setuptools-scm includes `+g{GITREVISION}` in the version.

Enable dev uploads to Test PyPI again.

Disable optional dependency `instructlab[hpu]`. Intel Gaudi support currently requires a fork of optimum-habana from git. PyPI does not accept packages with a direct dependency.

