### PR TITLE
ci: fix typo in actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     branches:
       - "main"
-      - '.github/**'
+      - "release-**"
     paths:
       - '.github/**'
 


### PR DESCRIPTION
Was digging into why https://github.com/instructlab/instructlab/pull/1166 wasn't automerging and it seems this typo is to blame