### PR TITLE
mergify: Automate a label for CI failures

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -153,3 +153,19 @@ pull_request_rules:
         - release-v0.14
   conditions:
     - label=backport-release-v0.14
+
+- name: Apply ci-failure label if any CI checks have failed
+  conditions:
+      - "#check-failure>0"
+  actions:
+    label:
+      add:
+        - ci-failure
+
+- name: Remove ci-failure label if no failures are present
+  conditions:
+      - "#check-failure=0"
+  actions:
+    label:
+      remove:
+        - ci-failure


### PR DESCRIPTION
When I pull up the PR queue to do some reviews, having data to filter on helps me prioritize which PRs to look at first. Sometimes I want to filter out any PRs where CI isn't passing to help narrow down the list to the ones most likely to be ready for approval.

This PR makes mergify automate adding and removing the `ci-failures` label based on if there are any checks currently failing.