### PR TITLE
validation: Confirm yaml file contents are an object

### DIFF
--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -432,6 +432,12 @@ def read_taxonomy_file(
             logger.warn(f"Skipping {file_path} because it is empty!")
             warnings += 1
             return None, warnings, errors
+        if not isinstance(contents, Mapping):
+            logger.error(
+                f"{file_path} is not valid. The top-level element is not an object with key-value pairs."
+            )
+            errors += 1
+            return None, warnings, errors
 
         # do general YAML linting if specified
         version = get_version(contents)


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves #1170 

**Description of your changes:**

The top-level element of a yaml document can be an object (key-value pairs) or a list. We now test and provide an error message if the top-level element is not an object.
