### PR TITLE
fix: update make help text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ verify: check-tox ## Run tox -e fmt,lint,spellcheck against code
 	tox p -e ruff,fastlint,spellcheck
 
 .PHONY: spellcheck-sort
-spellcheck-sort: .spellcheck-en-custom.txt
+spellcheck-sort: .spellcheck-en-custom.txt ## Sort spellcheck directory
 	sort -d -o $< $<
 
 .PHONY: man
@@ -153,25 +153,6 @@ man: check-tox
 
 .PHONY: docs
 docs: man ## Run tox -e docs against code
-
-##@ Validation
-.PHONY: check-tox
-check-tox:
-	@command -v tox &> /dev/null || (echo "'tox' is not installed" && exit 1)
-
-.PHONY: check-toolbox
-check-toolbox:
-	@command -v toolbox &> /dev/null || (echo "'toolbox' is not installed" && exit 1)
-
-.PHONY: check-engine
-check-engine:
-	@command -v $(CENGINE) &> /dev/null || (echo "'$(CENGINE)' container engine is not installed, you can override it with the 'CENGINE' variable" && exit 1)
-
-.PHONY: check-rocm
-check-rocm:
-	@command -v rocm &> /dev/null || (echo "'rocm' is not installed" && exit 1)
-
-##@ Linting
 
 #
 # If you want to see the full commands, run:
@@ -191,3 +172,21 @@ endif
 md-lint: check-engine ## Lint markdown files
 	$(ECHO_PREFIX) printf "  %-12s ./...\n" "[MD LINT]"
 	$(CMD_PREFIX) $(CENGINE) run --rm -v $(CURDIR):/workdir --security-opt label=disable docker.io/davidanson/markdownlint-cli2:v0.12.1 > /dev/null
+
+##@ Validation
+
+.PHONY: check-tox
+check-tox: ## ensure tox is installed
+	@command -v tox &> /dev/null || (echo "'tox' is not installed" && exit 1)
+
+.PHONY: check-toolbox
+check-toolbox: ## ensure toolbox is installed
+	@command -v toolbox &> /dev/null || (echo "'toolbox' is not installed" && exit 1)
+
+.PHONY: check-engine
+check-engine: ## ensure the container engine is installed
+	@command -v $(CENGINE) &> /dev/null || (echo "'$(CENGINE)' container engine is not installed, you can override it with the 'CENGINE' variable" && exit 1)
+
+.PHONY: check-rocm
+check-rocm: ## ensure rocm is installed
+	@command -v rocm &> /dev/null || (echo "'rocm' is not installed" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -173,20 +173,18 @@ md-lint: check-engine ## Lint markdown files
 	$(ECHO_PREFIX) printf "  %-12s ./...\n" "[MD LINT]"
 	$(CMD_PREFIX) $(CENGINE) run --rm -v $(CURDIR):/workdir --security-opt label=disable docker.io/davidanson/markdownlint-cli2:v0.12.1 > /dev/null
 
-##@ Validation
-
 .PHONY: check-tox
-check-tox: ## ensure tox is installed
+check-tox:
 	@command -v tox &> /dev/null || (echo "'tox' is not installed" && exit 1)
 
 .PHONY: check-toolbox
-check-toolbox: ## ensure toolbox is installed
+check-toolbox:
 	@command -v toolbox &> /dev/null || (echo "'toolbox' is not installed" && exit 1)
 
 .PHONY: check-engine
-check-engine: ## ensure the container engine is installed
+check-engine:
 	@command -v $(CENGINE) &> /dev/null || (echo "'$(CENGINE)' container engine is not installed, you can override it with the 'CENGINE' variable" && exit 1)
 
 .PHONY: check-rocm
-check-rocm: ## ensure rocm is installed
+check-rocm:
 	@command -v rocm &> /dev/null || (echo "'rocm' is not installed" && exit 1)


### PR DESCRIPTION
Example of before/after below

```bash
[nathan@nathan-redhat instructlab (make-help)]$ make help

Usage:
  make <target>

General
  help             Display this help.

Build
  images           Get the current controller, set the path, and build the Containerfile image. (auto-detect the compatible controller)
  cuda             Build container for NVidia CUDA
  hpu              Build container for Intel Gaudi HPU
  rocm             Build container for AMD ROCm (auto-detect the ROCm GPU arch)
  rocm-gfx1100     Build container for AMD ROCm RDNA3 (Radeon RX 7000 series)
  rocm-gfx1030     Build container for AMD ROCm RDNA2 (Radeon RX 6000 series)
  rocm-gfx90a      Build container for AMD ROCm gfx90a (untested)
  rocm-gfx908      Build container for AMD ROCm gfx908 (untested)
  rocm-gfx906      Build container for AMD ROCm gfx906 (untested)
  rocm-gfx900      Build container for AMD ROCm gfx900 (untested)
  toolbox-rocm     Create AMD ROCm toolbox from container
  toolbox-rm       Stop and remove toolbox container

Development
  tests            Run tox -e unit against code
  verify           Run tox -e fmt,lint,spellcheck against code
  docs             Run tox -e docs against code

Linting
  md-lint          Lint markdown files
[nathan@nathan-redhat instructlab (make-help)]$ make help

Usage:
  make <target>

General
  help             Display this help.

Build
  images           Get the current controller, set the path, and build the Containerfile image. (auto-detect the compatible controller)
  cuda             Build container for NVidia CUDA
  hpu              Build container for Intel Gaudi HPU
  rocm             Build container for AMD ROCm (auto-detect the ROCm GPU arch)
  rocm-gfx1100     Build container for AMD ROCm RDNA3 (Radeon RX 7000 series)
  rocm-gfx1030     Build container for AMD ROCm RDNA2 (Radeon RX 6000 series)
  rocm-gfx90a      Build container for AMD ROCm gfx90a (untested)
  rocm-gfx908      Build container for AMD ROCm gfx908 (untested)
  rocm-gfx906      Build container for AMD ROCm gfx906 (untested)
  rocm-gfx900      Build container for AMD ROCm gfx900 (untested)
  toolbox-rocm     Create AMD ROCm toolbox from container
  toolbox-rm       Stop and remove toolbox container

Development
  tests            Run tox -e unit against code
  verify           Run tox -e fmt,lint,spellcheck against code
  spellcheck-sort  Sort spellcheck directory
  docs             Run tox -e docs against code
  md-lint          Lint markdown files
```