### PR TITLE
ci: add 'one-approval' label on PR that has one approval

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -169,3 +169,19 @@ pull_request_rules:
     label:
       remove:
         - ci-failure
+
+- name: Apply 'one-approval' label if one of the maintainer approved the PR
+  conditions:
+      - "#approved-reviews-by=1"
+  actions:
+    label:
+      add:
+        - one-approval
+
+- name: Remove 'one-approval' label if the approval was reset
+  conditions:
+      - "#approved-reviews-by!=1"
+  actions:
+    label:
+      remove:
+        - one-approval


### PR DESCRIPTION
If a PR has been approved already by one of the maintainers, the PR will be labeled with 'one-approval'. This is useful for maintainers to help them determine which PR is getting close to completion and thus prioritize the review.
With the help of filters, one can look for PRs that have one approval already.

Signed-off-by: Sébastien Han <seb@redhat.com>
