### PR TITLE
feat: redirect llama_cpp server stderr/stdout to a logger

### DIFF
--- a/src/instructlab/log.py
+++ b/src/instructlab/log.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+import logging
+import os
+import sys
+
+FORMAT = "%(levelname)s %(asctime)s %(filename)s:%(lineno)d %(message)s"
+
+
+class CustomFormatter(logging.Formatter):
+    def format(self, record):
+        if record.filename == os.path.basename(__file__):
+            # Replace our current file name with 'llama_cpp' since the message is coming from stdout or
+            # stderr. Printing this file name is not useful in this case, we need to print where the line is coming from.
+            record.filename = "llama_cpp"
+            record.lineno = 0  # Remove line number, no point of showing it
+        return super().format(record)
+
+
+class LoggerWriter:
+    def __init__(self, level):
+        self.level = level
+        self.buffer = ""
+
+    def write(self, message):
+        self.buffer += message
+        if message == "\n":  # Flush the buffer when an empty line is encountered
+            self.flush()
+
+    def flush(self):
+        if self.buffer:
+            self.level(self.buffer.strip())
+            self.buffer = ""
+
+    def isatty(self):
+        return False
+
+
+def stdout_stderr_to_logger(logger):
+    sys.stdout = LoggerWriter(logger.info)
+    sys.stderr = LoggerWriter(logger.error)

--- a/src/instructlab/server.py
+++ b/src/instructlab/server.py
@@ -223,6 +223,7 @@ def server(
     # In this case, we want to redirect stdout to null to avoid cluttering the chat with messages
     # returned by the server.
     if is_temp_server_running():
+        # TODO: redirect temp server logs to a file instead of hidding the logs completely
         # Redirect stdout and stderr to null
         with (
             open(os.devnull, "w", encoding="utf-8") as f,

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Mapping, Optional, Union
 import copy
 import glob
 import json
-import logging
 import os
 import platform
 import re
@@ -35,11 +34,6 @@ rules:
 """
 
 DEFAULT_CHUNK_OVERLAP = 100
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(levelname)s %(asctime)s %(filename)s:%(lineno)d %(message)s",
-)
 
 
 class TaxonomyReadingException(Exception):


### PR DESCRIPTION
Our logger now includes the llamap_cpp logs instead of printing to stderr and stdout, making the logs hard to read and parse. It looks like llma_cpp print debug messages to stderr instead of stdout so the startup logs look a little bit confusing when setting our log level to DEBUG.

Signed-off-by: Sébastien Han <seb@redhat.com>

