### PR TITLE
POC: Implement model signing/verification with Sigstore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ click-didyoumean>=0.3.0
 datasets>=2.18.0
 gguf>=0.6.0
 GitPython>=3.1.42
+sigstore>=3.0.0
 # Linux: 4-bit quantization with BitsAndBytes is not ready to use, yet.
 # see https://github.com/instructlab/instructlab/issues/579
 # bitsandbytes; sys_platform=='linux' and platform_machine=='x86_64'

--- a/src/instructlab/model/model.py
+++ b/src/instructlab/model/model.py
@@ -9,8 +9,10 @@ from .chat import chat
 from .convert import convert
 from .download import download
 from .serve import serve
+from .sign import sign
 from .test import test
 from .train import train
+from .verify import verify
 
 
 @click.group(cls=DYMGroup)
@@ -31,3 +33,5 @@ model.add_command(convert)
 model.add_command(chat)
 model.add_command(test)
 model.add_command(download)
+model.add_command(sign)
+model.add_command(verify)

--- a/src/instructlab/model/sign.py
+++ b/src/instructlab/model/sign.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from pathlib import Path
+
+# Third Party
+import click
+
+# First Party
+from instructlab import configuration as config
+from instructlab import signing, utils
+
+
+@click.command()
+@click.option(
+    "--model-path",
+    type=click.Path(),
+    default=config.DEFAULT_MODEL_PATH,
+    show_default=True,
+    help="Path to the model to be signed.",
+)
+@click.option(
+    "--bundle-path",
+    type=click.Path(),
+    default=None,
+    show_default=True,
+    help="Path to save the Sigstore bundle file after signing.",
+)
+@click.option(
+    "--staging",
+    is_flag=True,
+    help="Use Sigstore's staging environment.",
+)
+@click.pass_context
+@utils.display_params
+def sign(ctx, model_path, bundle_path, staging):
+    """Signs a model with Sigstore"""
+
+    if bundle_path is None:
+        bundle_path = f"{model_path}.sigstore.json"
+
+    signing.sign_model(
+        model_path=Path(model_path), bundle_path=Path(bundle_path), staging=staging
+    )

--- a/src/instructlab/model/verify.py
+++ b/src/instructlab/model/verify.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from pathlib import Path
+
+# Third Party
+from sigstore.errors import VerificationError
+import click
+
+# First Party
+from instructlab import configuration as config
+from instructlab import signing, utils
+
+
+@click.command()
+@click.option(
+    "--model-path",
+    type=click.Path(),
+    default=config.DEFAULT_MODEL_PATH,
+    show_default=True,
+    help="Path to the model to be signed.",
+)
+@click.option(
+    "--bundle-path",
+    type=click.Path(),
+    default=None,
+    show_default=True,
+    help="Path to save the Sigstore bundle file after signing.",
+)
+@click.option(
+    "--identity",
+    help="Certificate identity to verify against."
+    "Typically an email provided by the OIDC identity provider."
+    "Example: a model signed using a Github account under hello@instructlab.ai would use hello@instructlab.ai.",
+)
+@click.option(
+    "--issuer",
+    help="Certificate identity's issuing authority.",
+    default="https://github.com/login/oauth",
+    show_default=True,
+)
+@click.option(
+    "--staging",
+    is_flag=True,
+    help="Use Sigstore's staging environment.",
+)
+@click.pass_context
+@utils.display_params
+def verify(ctx, model_path, bundle_path, identity, issuer, staging):
+    """Signs a model with Sigstore"""
+
+    if bundle_path is None:
+        bundle_path = f"{model_path}.sigstore.json"
+
+    try:
+        signing.verify_model(
+            model_path=Path(model_path),
+            bundle_path=Path(bundle_path),
+            identity=identity,
+            issuer=issuer,
+            staging=staging,
+        )
+        print(f"✅ {bundle_path} passed verification")
+    except VerificationError as e:
+        print(f"❌ {bundle_path} failed verification: {str(e)}")

--- a/src/instructlab/signing.py
+++ b/src/instructlab/signing.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from pathlib import Path
+import hashlib
+
+# Third Party
+from sigstore.hashes import Hashed
+from sigstore.models import Bundle
+from sigstore.oidc import Issuer
+from sigstore.sign import SigningContext
+from sigstore.verify import Verifier
+from sigstore.verify.policy import Identity
+from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
+
+
+def sign_model(model_path: Path, bundle_path: Path, staging: bool = False) -> None:
+    """Signs a model with Sigstore"""
+
+    # Sigstore setup
+    if staging:
+        issuer = Issuer.staging()
+        signing_ctx = SigningContext.staging()
+    else:
+        issuer = Issuer.production()
+        signing_ctx = SigningContext.production()
+    identity = issuer.identity_token()
+
+    # Hash the model file
+    model_hash = incremental_hash(model_path=model_path)
+
+    # Sign the model's hash and write Sigstore bundle to disk
+    with signing_ctx.signer(identity, cache=True) as signer:
+        result = signer.sign_artifact(model_hash)
+    with bundle_path.open("w", encoding="utf8") as bundle_file:
+        bundle_file.write(result.to_json())
+
+
+def verify_model(
+    model_path: Path,
+    bundle_path: Path,
+    identity: str,
+    issuer: str,
+    staging: bool = False,
+) -> None:
+    """Verifies a model and its bundle with Sigstore"""
+
+    # Sigstore setup
+    if staging:
+        verifier = Verifier.staging()
+    else:
+        verifier = Verifier.production()
+
+    # Hash the model file
+    model_hash = incremental_hash(model_path=model_path)
+
+    # Read the Sigstore bundle to verify with from disk
+    bundle = Bundle.from_json(bundle_path.read_bytes())
+
+    # Verify the model hash against the bundle
+    verifier.verify_artifact(
+        model_hash,
+        bundle,
+        Identity(
+            identity=identity,
+            issuer=issuer,
+        ),
+    )
+
+
+def incremental_hash(model_path: Path) -> Hashed:
+    """Incrementally hash a file and create a sigstore.hashes.Hashed object"""
+    h = hashlib.sha256()
+    with model_path.open("rb") as f:
+        while True:
+            buf = f.read(128 * 1024)
+            if not buf:
+                break
+            h.update(buf)
+    return Hashed(algorithm=HashAlgorithm.SHA2_256, digest=h.digest())


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves #821 

**Description of your changes:**

This adds a new `ilab` command that allows users to sign their completed `GGUF` models with Sigstore and later verify them.

Signing uses Sigstore's interactive OIDC flow, so a user will be prompted to log into the identity provider of their choice (Github, Google, or Microsoft):

```shell
> ilab sign --model-path models/merlinite-7b-lab-Q4_K_M.gguf
```

The command creates a `.sigstore.json` bundle file within the `models` directory that corresponds to the signed model. (In the above example, it would be `models/merlinite-7b-lab-Q4_K_M.gguf.sigstore.json`.)

Verification expects a bundle and identity provided via flags. This example assumes Google as the identity provider:

```shell
> ilab verify --model-path merlinite-7b-lab-Q4_K_M.gguf --identity user@gmail.com --issuer https://accounts.google.com
```

Marking as a proof-of-concept, since @cdoern mentioned that there's a big command hierarchy rework underway at https://github.com/instructlab/instructlab/pull/1157.