### PR TITLE
feat: ability to log server to file

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -43,7 +43,7 @@ cleanup() {
     # revert model name change from test_model_print()
     sed -i.bak "s/baz/merlinite-7b-lab-Q4_K_M/g" config.yaml
     mv models/foo.gguf models/merlinite-7b-lab-Q4_K_M.gguf || true
-    rm -f config.yaml.bak
+    rm -f config.yaml.bak serve.log
     set -e
 }
 
@@ -309,10 +309,20 @@ test_temp_server_ignore_internal_messages(){
 
 test_server_welcome_message(){
     # test that the server welcome message is displayed
-    ilab serve &
+    ilab serve --log-file serve.log &
     PID_SERVE=$!
 
     wait_for_server
+
+    if ! timeout 10 bash -c '
+        until test -s serve.log; do
+        echo "waiting for server log file to be created"
+        sleep 1
+    done
+    '; then
+        echo "server log file was not created"
+        exit 1
+    fi
 }
 
 wait_for_server(){

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -327,15 +327,22 @@ utils.make_lab_diff_aliases(cli, diff)
     type=str,
     help="Force model family to specify which chat template to serve with",
 )
+@click.option(
+    "--log-file",
+    type=click.Path(),
+    help="Log file path to write server logs to.",
+)
 @click.pass_context
-def serve(ctx, model_path, gpu_layers, num_threads, max_ctx_size, model_family):
+def serve(
+    ctx, model_path, gpu_layers, num_threads, max_ctx_size, model_family, log_file
+):
     """Start a local server"""
     # pylint: disable=C0415
     # Local
     from .server import ServerException, server
 
     # Redirect server stdout and stderr to the logger
-    log.stdout_stderr_to_logger(ctx.obj.logger)
+    log.stdout_stderr_to_logger(ctx.obj.logger, log_file)
 
     ctx.obj.logger.info(
         f"Using model '{model_path}' with {gpu_layers} gpu-layers and {max_ctx_size} max context size."

--- a/src/instructlab/log.py
+++ b/src/instructlab/log.py
@@ -37,6 +37,16 @@ class LoggerWriter:
         return False
 
 
-def stdout_stderr_to_logger(logger):
+def stdout_stderr_to_logger(logger, log_file):
+    if log_file:
+        # Use the existing log file if it exists and append to it
+        mode = "a"
+        # Create file handler
+        file_handler = logging.FileHandler(log_file, mode, encoding="utf-8")
+        logger.addHandler(file_handler)
+        # Create formatter and set it for both handlers
+        formatter = CustomFormatter(FORMAT)
+        file_handler.setFormatter(formatter)
+
     sys.stdout = LoggerWriter(logger.info)
     sys.stderr = LoggerWriter(logger.error)


### PR DESCRIPTION
Using --log-file, we can now write the server logs to a file. It's
going to be useful once we introduce support for systemd unit as well as
launchd. Also, having a log file is crucial step toward production
deployments and system integration.
Note that while --log-file is used, `ilab serve` will continue to log on
the foreground so if running inside a container you can get the
container log stream as well as a file.

Signed-off-by: Sébastien Han <seb@redhat.com>