### PR TITLE
Add Sphinx documentation, MyST, and RTD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Test Workflow Complete
         run: echo "Test Workflow Complete"
 
-  man:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - name: "Harden Runner"
@@ -146,8 +146,7 @@ jobs:
           pip cache remove llama_cpp_python
 
       - name: Run tox docs target (expect failure since tox is not present)
-        run: |
-          make man
+        run: make docs
         continue-on-error: true
 
       - name: Run tox docs target
@@ -169,8 +168,7 @@ jobs:
           python -m pip install tox
 
       - name: Run tox docs target
-        run: |
-          make man
+        run: make docs
 
       - name: Check that man pages were generated
         uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,33 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    pre_install:
+      # install torch without CUDA bindings to speed up builds
+      - pip install --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+
+submodules:
+  include: all

--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -48,6 +48,7 @@ gpu
 habana
 Habana
 hipBLAS
+Heimes
 HPU
 ibmcloud
 ilab

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,9 @@ man: docs
 
 .PHONY: sphinx-apidoc
 sphinx-apidoc: check-tox
-	tox -e docs exec -- sphinx-apidoc --no-toc -o docs/api src/instructlab src/instructlab/llamacpp/llamacpp_convert_to_gguf.py
+	rm -f docs/api/instructlab.*.rst
+	tox -e docs exec -- sphinx-apidoc --no-toc -o docs/api src/instructlab \
+	    src/instructlab/llamacpp/llamacpp_convert_to_gguf.py
 
 #
 # If you want to see the full commands, run:

--- a/Makefile
+++ b/Makefile
@@ -155,12 +155,16 @@ spellcheck: .spellcheck.yml ## Spellcheck markdown files
 spellcheck-sort: .spellcheck-en-custom.txt ## Sort spellcheck directory
 	sort -d -o $< $<
 
-.PHONY: man
-man: check-tox
+.PHONY: docs
+docs: check-tox  ## Generate Sphinx docs and man pages
 	tox -e docs
 
-.PHONY: docs
-docs: man ## Run tox -e docs against code
+.PHONY: man
+man: docs
+
+.PHONY: sphinx-apidoc
+sphinx-apidoc: check-tox
+	tox -e docs exec -- sphinx-apidoc --no-toc -o docs/api src/instructlab src/instructlab/llamacpp/llamacpp_convert_to_gguf.py
 
 #
 # If you want to see the full commands, run:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?= -j auto
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/amd-rocm.md
+++ b/docs/amd-rocm.md
@@ -1,3 +1,7 @@
+---
+author: Christian Heimes
+---
+
 # InstructLab toolbox container for AMD ROCm GPUs
 
 The ROCm container file is designed for AMD GPUs with RDNA3 architecture (`gfx1100`). The container can be build for RDNA2 (`gfx1030`) and older GPUs, too. Please refer to [AMD's system requirements](https://rocm.docs.amd.com/projects/install-on-linux/en/develop/reference/system-requirements.html) for a list of officially supported cards. ROCm is known to work on more consumer GPUs.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,7 @@
+InstructLab Python API
+======================
+
+.. toctree::
+   :maxdepth: 3
+
+   instructlab

--- a/docs/api/instructlab.chat.rst
+++ b/docs/api/instructlab.chat.rst
@@ -1,0 +1,21 @@
+instructlab.chat package
+========================
+
+Submodules
+----------
+
+instructlab.chat.chat module
+----------------------------
+
+.. automodule:: instructlab.chat.chat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: instructlab.chat
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/instructlab.generator.rst
+++ b/docs/api/instructlab.generator.rst
@@ -1,0 +1,29 @@
+instructlab.generator package
+=============================
+
+Submodules
+----------
+
+instructlab.generator.generate\_data module
+-------------------------------------------
+
+.. automodule:: instructlab.generator.generate_data
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.generator.utils module
+----------------------------------
+
+.. automodule:: instructlab.generator.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: instructlab.generator
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/instructlab.llamacpp.rst
+++ b/docs/api/instructlab.llamacpp.rst
@@ -1,0 +1,10 @@
+instructlab.llamacpp package
+============================
+
+Module contents
+---------------
+
+.. automodule:: instructlab.llamacpp
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/instructlab.mlx_explore.rst
+++ b/docs/api/instructlab.mlx_explore.rst
@@ -1,0 +1,29 @@
+instructlab.mlx\_explore package
+================================
+
+Submodules
+----------
+
+instructlab.mlx\_explore.gguf\_convert\_to\_mlx module
+------------------------------------------------------
+
+.. automodule:: instructlab.mlx_explore.gguf_convert_to_mlx
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.mlx\_explore.utils module
+-------------------------------------
+
+.. automodule:: instructlab.mlx_explore.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: instructlab.mlx_explore
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/instructlab.rst
+++ b/docs/api/instructlab.rst
@@ -7,6 +7,7 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
+   instructlab.chat
    instructlab.generator
    instructlab.llamacpp
    instructlab.mlx_explore
@@ -51,6 +52,14 @@ instructlab.server module
 -------------------------
 
 .. automodule:: instructlab.server
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.sysinfo module
+--------------------------
+
+.. automodule:: instructlab.sysinfo
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/instructlab.rst
+++ b/docs/api/instructlab.rst
@@ -1,0 +1,72 @@
+instructlab package
+===================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   instructlab.generator
+   instructlab.llamacpp
+   instructlab.mlx_explore
+   instructlab.train
+
+Submodules
+----------
+
+instructlab.client module
+-------------------------
+
+.. automodule:: instructlab.client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.common module
+-------------------------
+
+.. automodule:: instructlab.common
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.config module
+-------------------------
+
+.. automodule:: instructlab.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.lab module
+----------------------
+
+.. automodule:: instructlab.lab
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.server module
+-------------------------
+
+.. automodule:: instructlab.server
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.utils module
+------------------------
+
+.. automodule:: instructlab.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: instructlab
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/instructlab.train.lora_mlx.models.rst
+++ b/docs/api/instructlab.train.lora_mlx.models.rst
@@ -1,0 +1,61 @@
+instructlab.train.lora\_mlx.models package
+==========================================
+
+Submodules
+----------
+
+instructlab.train.lora\_mlx.models.base module
+----------------------------------------------
+
+.. automodule:: instructlab.train.lora_mlx.models.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.train.lora\_mlx.models.llama module
+-----------------------------------------------
+
+.. automodule:: instructlab.train.lora_mlx.models.llama
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.train.lora\_mlx.models.lora module
+----------------------------------------------
+
+.. automodule:: instructlab.train.lora_mlx.models.lora
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.train.lora\_mlx.models.mixtral module
+-------------------------------------------------
+
+.. automodule:: instructlab.train.lora_mlx.models.mixtral
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.train.lora\_mlx.models.models module
+------------------------------------------------
+
+.. automodule:: instructlab.train.lora_mlx.models.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.train.lora\_mlx.models.phi2 module
+----------------------------------------------
+
+.. automodule:: instructlab.train.lora_mlx.models.phi2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: instructlab.train.lora_mlx.models
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/instructlab.train.lora_mlx.rst
+++ b/docs/api/instructlab.train.lora_mlx.rst
@@ -1,0 +1,69 @@
+instructlab.train.lora\_mlx package
+===================================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   instructlab.train.lora_mlx.models
+
+Submodules
+----------
+
+instructlab.train.lora\_mlx.convert module
+------------------------------------------
+
+.. automodule:: instructlab.train.lora_mlx.convert
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.train.lora\_mlx.fuse module
+---------------------------------------
+
+.. automodule:: instructlab.train.lora_mlx.fuse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.train.lora\_mlx.lora module
+---------------------------------------
+
+.. automodule:: instructlab.train.lora_mlx.lora
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.train.lora\_mlx.make\_data module
+---------------------------------------------
+
+.. automodule:: instructlab.train.lora_mlx.make_data
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.train.lora\_mlx.prepare\_model module
+-------------------------------------------------
+
+.. automodule:: instructlab.train.lora_mlx.prepare_model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+instructlab.train.lora\_mlx.utils module
+----------------------------------------
+
+.. automodule:: instructlab.train.lora_mlx.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: instructlab.train.lora_mlx
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/instructlab.train.rst
+++ b/docs/api/instructlab.train.rst
@@ -1,0 +1,29 @@
+instructlab.train package
+=========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   instructlab.train.lora_mlx
+
+Submodules
+----------
+
+instructlab.train.linux\_train module
+-------------------------------------
+
+.. automodule:: instructlab.train.linux_train
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: instructlab.train
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,6 @@
+ilab cli
+========
+
+.. click:: instructlab.lab:cli
+   :prog: ilab
+   :nested: full

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,12 @@ author = "InstructLab Authors"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["myst_parser", "sphinx.ext.napoleon"]
+extensions = [
+    "myst_parser",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx_click",
+]
 
 templates_path = ["templates"]
 exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
@@ -23,6 +28,33 @@ exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
 autodoc_mock_imports = [
     "fire",
     "mlx",
+]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/", None),
+    "torch": ("https://pytorch.org/docs/stable/", None),
+    "click": ("https://click.palletsprojects.com/en/latest/", None),
+    "pydantic": ("https://docs.pydantic.dev/latest/", None),
+    "transformers": ("https://huggingface.co/docs/transformers/main/en", None),
+}
+
+nitpick_ignore = [
+    ("py:class", "git.repo.base.Repo"),
+    ("py:class", "uvicorn.config.Config"),
+    ("py:class", "uvicorn.server.Server"),
+    ("py:class", "transformers.generation.stopping_criteria.StoppingCriteria"),
+    ("py:class", "mlx.core.array"),
+    ("py:class", "mlx.nn.LayerNorm"),
+    ("py:class", "mlx.nn.Linear"),
+    ("py:class", "mlx.nn.Module"),
+    ("py:class", "nn.Module"),
+    ("py:class", "mx.array"),
+    # stdlib
+    ("py:class", "FrameType"),
+    # pydantic auto-generated doc strings
+    ("py:class", "ComputedFieldInfo"),
+    ("py:class", "ConfigDict"),
+    ("py:class", "FieldInfo"),
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "InstructLab"
+copyright = "2024, InstructLab Authors"
+author = "InstructLab Authors"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ["myst_parser", "sphinx.ext.napoleon"]
+
+templates_path = ["templates"]
+exclude_patterns = ["build", "Thumbs.db", ".DS_Store"]
+
+autodoc_mock_imports = [
+    "fire",
+    "mlx",
+]
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "furo"
+html_static_path = ["static"]

--- a/docs/demo-slides.md
+++ b/docs/demo-slides.md
@@ -1,10 +1,9 @@
 ---
-title: Demo for InstructLab CLI
 author: Kai Xu
 date: April 16th, 2024 | v0.13.0
 ---
 
-## Welcome to Demo for InstructLab CLI
+# Welcome to Demo for InstructLab CLI
 
 A tool to help you contribute to InstructLab Taxonomy.
 <!-- pause -->

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -160,7 +160,7 @@ sudo usermod -a -G render,video $LOGNAME
 
 #### ROCm container
 
-The most convenient approach is the [ROCm toolbox container](../containers/rocm/README.md). The container comes with PyTorch, llama-cpp, and other dependencies pre-installed and ready-to-use.
+The most convenient approach is the [ROCm toolbox container](amd-rocm.md). The container comes with PyTorch, llama-cpp, and other dependencies pre-installed and ready-to-use.
 
 #### Manual installation
 

--- a/docs/habana-gaudi.md
+++ b/docs/habana-gaudi.md
@@ -182,7 +182,7 @@ ilab model train --device=hpu
 
 Output:
 
-```raw
+```shell-session
 LINUX_TRAIN.PY: Using device 'hpu'
 ============================= HABANA PT BRIDGE CONFIGURATION ===========================
  PT_HPU_LAZY_MODE = 0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,13 +7,13 @@ Welcome to InstructLab's documentation!
 
    converting_GGUF.md
    ci.md
+   cli.rst
    demo-slides.md
    gpu-acceleration.md
    amd-rocm.md
    habana-gaudi.md
    README.md
    release-strategy.md
-   STABLE.md
 
    api/index.rst
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,26 @@
+Welcome to InstructLab's documentation!
+=======================================
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+   converting_GGUF.md
+   ci.md
+   demo-slides.md
+   gpu-acceleration.md
+   amd-rocm.md
+   habana-gaudi.md
+   README.md
+   release-strategy.md
+   STABLE.md
+
+   api/index.rst
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+myst-parser
+furo

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 myst-parser
 furo
+sphinx-click

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -280,8 +280,8 @@ def validate_yaml(contents: Mapping[str, Any], taxonomy_path: Path) -> int:
 
     Args:
         contents (Mapping): The parsed yaml document to validate against the schema.
-        taxonomy_path (Path): Relative path of the taxonomy yaml document where the
-        first element is the schema to use.
+        taxonomy_path (pathlib.Path): Relative path of the taxonomy yaml document where the
+            first element is the schema to use.
 
     Returns:
         int: The number of errors found during validation.

--- a/tox.ini
+++ b/tox.ini
@@ -125,8 +125,7 @@ deps =
     # We need https://github.com/click-contrib/click-man/pull/62 to handle hidden options
     git+https://github.com/click-contrib/click-man@24ec8377e3c24378417f6fc4f571b4f585d7df6b
 commands =
-    # add "-n" once all errors are fixed
-    sphinx-build -M html docs docs/build -j auto --keep-going {posargs:--fail-on-warning --fresh-env}
+    sphinx-build -M html docs docs/build -j auto --keep-going {posargs:--fail-on-warning --fresh-env -n}
     click-man --target {toxinidir}/man ilab
 
 [testenv:mypy]

--- a/tox.ini
+++ b/tox.ini
@@ -117,13 +117,16 @@ commands =
 allowlist_externals = sh
 
 [testenv:docs]
-description = docs
+description = sphinx docs and man pages
 basepython = {[testenv:py3]basepython}
 deps =
+    -r docs/requirements.txt
     # TODO: switch to a release tag when it's cut
     # We need https://github.com/click-contrib/click-man/pull/62 to handle hidden options
     git+https://github.com/click-contrib/click-man@24ec8377e3c24378417f6fc4f571b4f585d7df6b
 commands =
+    # add "-n" once all errors are fixed
+    sphinx-build -M html docs docs/build -j auto --keep-going {posargs:--fail-on-warning --fresh-env}
     click-man --target {toxinidir}/man ilab
 
 [testenv:mypy]


### PR DESCRIPTION
# Changes

**Description of your changes:**

Add infrastructure to build documentation and API docs with Sphinx, MyST (for markdown parsing), napoelon autodoc (for automatic API documentation), and furo theme. An untested RDT config is included, too.

`tox -e docs` and `make docs` now builds the documentation

I had to fix several minor issues in our markdown documents. For example Pygments does not recognize `ShellSession` and Sphinx cannot reference files outside the doc tree.