### PR TITLE
e2e: Make use of `--non-interactive` for `ilab init`

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -51,7 +51,7 @@ test_smoke() {
 
 test_init() {
     task Initializing ilab
-    [ -f config.yaml ] || printf "taxonomy\ny" | ilab init
+    [ -f config.yaml ] || ilab init --non-interactive
 
     step Checking config.yaml
     cat config.yaml | grep merlinite


### PR DESCRIPTION
The current implementation is a bit fragile. If the interactive flow
changed at all, this code would break. It also results in some
confusing output in a CI log.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
