### PR TITLE
fix: add chat module to linting and fix errors

### DIFF
--- a/src/instructlab/client.py
+++ b/src/instructlab/client.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=duplicate-code
 
 # Standard
 from typing import Optional


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves #864

**Description of your changes:**
This PR does the following:
- Adds `__init__.py` to the `chat` module, which was previously preventing `chat.py` from getting linted
- Fix lint errors in `chat.py` - I've added folks that previously touched this file to ensure I didn't break anything, can run an E2E job on this as well if folks feel it is worth it