### PR TITLE
Create issue template for nominating members for teams

### DIFF
--- a/.github/ISSUE_TEMPLATE/team_recommend.md
+++ b/.github/ISSUE_TEMPLATE/team_recommend.md
@@ -1,0 +1,19 @@
+---
+name: Team recommendation
+about: Nominate yourself or another Organization Member to join a team
+title: ''
+labels: nomination
+assignees: ''
+
+---
+
+*For details on how this process works, please see our [contributor roles documentation](https://github.com/instructlab/community/blob/main/CONTRIBUTOR_ROLES.md)*
+
+**Which member are you nominating for a team change?**
+<!-- The GitHub username of the Organization Member you are nominating -->
+
+**Which team are you nominating for this member for?**
+<!-- CLI Triages or CLI Maintainers, see the above document for more details -->
+
+**Make your case here: Why should the nominated member be on the proposed team?**
+<!-- Feel free to write a brief testimonial here, try to include as many Pull Requests, Issues, etc. as possible -->


### PR DESCRIPTION
**Description of your changes:**
Our [contribution roles](https://github.com/instructlab/community/blob/main/CONTRIBUTOR_ROLES.md) document states that to nominate organization members to teams, a GitHub Issue must be opened for the nomination. This PR introduces a template to do so with.