### PR TITLE
fix: do not fail when sending 'exit' to the chat

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -40,10 +40,10 @@ cleanup() {
     rm -rf test_taxonomy
     # revert port change from test_bind_port()
     sed -i.bak 's/9999/8000/g' config.yaml
-    rm -f config.yaml.bak
     # revert model name change from test_model_print()
     sed -i.bak "s/baz/merlinite-7b-lab-Q4_K_M/g" config.yaml
     mv models/foo.gguf models/merlinite-7b-lab-Q4_K_M.gguf || true
+    rm -f config.yaml.bak
     set -e
 }
 

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -43,7 +43,7 @@ cleanup() {
     rm -f config.yaml.bak
     # revert model name change from test_model_print()
     sed -i.bak "s/baz/merlinite-7b-lab-Q4_K_M/g" config.yaml
-    mv models/foo.gguf models/merlinite-7b-lab-Q4_K_M.gguf
+    mv models/foo.gguf models/merlinite-7b-lab-Q4_K_M.gguf || true
     set -e
 }
 

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -294,7 +294,14 @@ test_temp_server_ignore_internal_messages(){
             "Disconnected from client (via refresh/close)" { exit 1 }
         }
         send "exit\r"
-        expect eof
+        expect {
+            "Traceback (most recent call last):" { set exp_result 1 }
+            default { set exp_result 0 }
+        }
+        if { $exp_result != 0 } {
+            puts stderr "Error: ilab chat command failed"
+            exit 1
+        }
     '
 }
 

--- a/src/instructlab/chat/chat.py
+++ b/src/instructlab/chat/chat.py
@@ -144,7 +144,7 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
             ]
         )
 
-    def _handle_quit(self):
+    def _handle_quit(self, _):
         raise ChatQuitException
 
     def _handle_help(self):


### PR DESCRIPTION
This is a partial revert of https://github.com/instructlab/instructlab/commit/b8c9e63c550d07369f5381eb92b5285440cfa24b
which removes the unused 'content' argument of the `_handle_quit()`
function signature. Most of the time the function is not called with two
arguments unless the user types 'exit' in the chat, then `_handle_quit()`
is called with two arguments and we get:

```
TypeError: ConsoleChatBot._handle_quit() takes 1 positional argument but
2 were given
```

To avoid linters complaining about an argument not being accessed we use
the  `_` keyword.

Fixes: https://github.com/instructlab/instructlab/issues/1196
Signed-off-by: Sébastien Han <seb@redhat.com>