### PR TITLE
Fix CUDA path to account for update

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install ilab
         run: |
-          export PATH="/home/runner/.local/bin:/usr/local/cuda-12.4/bin:$PATH"
+          export PATH="/home/runner/.local/bin:/usr/local/cuda/bin:$PATH"
           python3 -m venv venv
           . venv/bin/activate
           sed 's/\[.*\]//' requirements.txt > constraints.txt


### PR DESCRIPTION

ced8c71 e2e: Fix build error after cuda upgrade

commit ced8c7110791cf396398b4cfeb9ce9a6e5a6c097
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed May 22 10:04:59 2024 -0400

    e2e: Fix build error after cuda upgrade
    
    Don't embed the CUDA version in the path. Symlinks are in place so
    `/usr/local/cuda/` is fine.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
