### PR TITLE
POC: Sigstore verification in `ilab download`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ click-didyoumean>=0.3.0,<0.4.0
 datasets>=2.18.0,<3.0.0
 gguf>=0.6.0,<0.7.0
 GitPython>=3.1.42,<4.0.0
+sigstore
 # Linux: 4-bit quantization with BitsAndBytes is not ready to use, yet.
 # see https://github.com/instructlab/instructlab/issues/579
 # bitsandbytes; sys_platform=='linux' and platform_machine=='x86_64'

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1373,6 +1373,90 @@ def convert(ctx, model_dir, adapter_file, skip_de_quantize, skip_quantize, model
     os.remove(os.path.join(model_dir_fused_pt, f"{model_name}.gguf"))
 
 
+@cli.command()
+@click.option(
+    "--model-path",
+    type=click.Path(),
+    default=config.DEFAULT_MODEL_PATH,
+    show_default=True,
+    help="Path to the model to be signed.",
+)
+@click.option(
+    "--bundle-path",
+    type=click.Path(),
+    default=None,
+    show_default=True,
+    help="Path to save the Sigstore bundle file after signing.",
+)
+@click.option(
+    "--staging",
+    is_flag=True,
+    help="Use Sigstore's staging environment.",
+)
+def sign(model_path, bundle_path, staging):
+    """Signs a model with Sigstore"""
+    # pylint: disable=import-outside-toplevel
+
+    # Local
+    from .provenance.sigstore import sign_model
+
+    if bundle_path is None:
+        bundle_path = f"{model_path}.sigstore.json"
+
+    sign_model(model_path=model_path, bundle_path=bundle_path, staging=staging)
+
+
+@cli.command()
+@click.option(
+    "--model-path",
+    type=click.Path(),
+    default=config.DEFAULT_MODEL_PATH,
+    show_default=True,
+    help="Path to the model to be signed.",
+)
+@click.option(
+    "--bundle-path",
+    type=click.Path(),
+    default=None,
+    show_default=True,
+    help="Path to save the Sigstore bundle file after signing.",
+)
+@click.option(
+    "--identity",
+    help="Certificate identity to verify against.",
+)
+@click.option(
+    "--issuer",
+    help="Certificate identity's issuing authority.",
+    default="https://github.com/login/oauth",
+    show_default=True,
+)
+@click.option(
+    "--staging",
+    is_flag=True,
+    help="Use Sigstore's staging environment.",
+)
+def verify(model_path, bundle_path, identity, issuer, staging):
+    """Signs a model with Sigstore"""
+    # pylint: disable=import-outside-toplevel
+
+    # Local
+    from .provenance.sigstore import verify_model
+
+    if bundle_path is None:
+        bundle_path = f"{model_path}.sigstore.json"
+
+    result = verify_model(
+        model_path=model_path,
+        bundle_path=bundle_path,
+        identity=identity,
+        issuer=issuer,
+        staging=staging,
+    )
+
+    print(result)
+
+
 @cli.command
 def sysinfo():
     """Print system information"""

--- a/src/instructlab/provenance/sigstore.py
+++ b/src/instructlab/provenance/sigstore.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from pathlib import Path
+import hashlib
+
+# Third Party
+# Third-party
+from sigstore.errors import VerificationError
+from sigstore.hashes import Hashed
+from sigstore.models import Bundle
+from sigstore.oidc import Issuer
+from sigstore.sign import SigningContext
+from sigstore.verify import Verifier
+from sigstore.verify.policy import Identity
+from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
+
+
+def sign_model(model_path: Path, bundle_path: Path, staging: bool = False) -> None:
+    """Signs a model with Sigstore"""
+
+    # Sigstore setup
+    if staging:
+        issuer = Issuer.staging()
+        signing_ctx = SigningContext.staging()
+    else:
+        issuer = Issuer.production()
+        signing_ctx = SigningContext.production()
+    identity = issuer.identity_token()
+
+    # Hash the model file
+    model_hash = incremental_hash(model_path=model_path)
+
+    # Sign the model's hash and write Sigstore bundle to disk
+    with signing_ctx.signer(identity, cache=True) as signer:
+        result = signer.sign_artifact(model_hash)
+    with open(bundle_path, "w", encoding="utf8") as bundle_file:
+        bundle_file.write(result.to_json())
+
+
+def verify_model(
+    model_path: Path,
+    bundle_path: Path,
+    identity: str,
+    issuer: str,
+    staging: bool = False,
+) -> str:
+    """Verifies a model and its bundle with Sigstore"""
+
+    # The input to verify
+    # input_ = model_path.read_bytes()
+
+    # Sigstore setup
+    if staging:
+        verifier = Verifier.staging()
+    else:
+        verifier = Verifier.production()
+
+    # Hash the model file
+    model_hash = incremental_hash(model_path=model_path)
+
+    # Read the Sigstore bundle to verify with from disk
+    bundle = Bundle.from_json(Path(bundle_path).read_bytes())
+
+    # Verify the model hash against the bundle
+    try:
+        verifier.verify_artifact(
+            model_hash,
+            bundle,
+            Identity(
+                identity=identity,
+                issuer=issuer,
+            ),
+        )
+        return f"✅ {bundle_path} passed verification"
+    except VerificationError as e:
+        return f"❌ {bundle_path} failed verification: {str(e)}"
+
+
+def incremental_hash(model_path: Path) -> Hashed:
+    """Incrementally hash a file and create a sigstore.hashes.Hashed object"""
+    h = hashlib.sha256()
+    with open(model_path, "rb") as f:
+        while True:
+            buf = f.read(128 * 1024)
+            if not buf:
+                break
+            h.update(buf)
+    return Hashed(algorithm=HashAlgorithm.SHA2_256, digest=h.digest())


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

This POC requires https://github.com/instructlab/instructlab/pull/1181.

Now, the `ilab download` command will search for a Sigstore bundle present in the remote Huggingface repository and attempt to verify the downloaded model against it, much like the new `ilab verify` command added in #1181.