### PR TITLE
fix: make all bash script pass shellcheck

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -58,6 +58,14 @@ pull_request_rules:
       - and:
         - -files~='notebooks/.*\.ipynb$'
 
+    - or:
+      - and:
+        - or:
+          - files~='.*\.sh$'
+        - check-success=shellcheck
+      - and:
+        - -files~='.*\.sh$'
+
   actions:
     merge:
       method: merge

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Shellcheck
+
+on:
+  push:
+    branches:
+      - "main"
+      - "release-**"
+    paths:
+      - '**.sh'
+      - '.github/workflows/shellcheck.yaml' # This workflow file
+  pull_request:
+    branches:
+      - "main"
+      - "release-**"
+    paths:
+      - '**.sh'
+      - '.github/workflows/shellcheck.yaml' # This workflow file
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # https://github.com/actions/checkout/issues/249
+          fetch-depth: 0
+          submodules: true
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          check_together: 'yes'
+          format: gcc

--- a/containers/rocm/remove-gfx.sh
+++ b/containers/rocm/remove-gfx.sh
@@ -13,9 +13,9 @@ case "$AMDGPU_ARCH" in
 		rm -f /usr/lib*/rocblas/library/*gfx8*
 		rm -f /usr/lib*/rocblas/library/*gfx10*
 		rm -f /usr/lib*/rocblas/library/*gfx11*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx8*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx10*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx11*
+		rm -f "${TORCH}"/lib/rocblas/library/*gfx8*
+		rm -f "${TORCH}"/lib/rocblas/library/*gfx10*
+		rm -f "${TORCH}"/lib/rocblas/library/*gfx11*
 		;;
 	gfx10*)
 		rm -rf /usr/lib*/rocm/gfx8
@@ -24,9 +24,9 @@ case "$AMDGPU_ARCH" in
 		rm -f /usr/lib*/rocblas/library/*gfx8*
 		rm -f /usr/lib*/rocblas/library/*gfx9*
 		rm -f /usr/lib*/rocblas/library/*gfx11*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx8*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx9*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx11*
+		rm -f "${TORCH}"/lib/rocblas/library/*gfx8*
+		rm -f "${TORCH}"/lib/rocblas/library/*gfx9*
+		rm -f "${TORCH}"/lib/rocblas/library/*gfx11*
 		;;
 	gfx11*)
 		rm -rf /usr/lib*/rocm/gfx8
@@ -35,9 +35,9 @@ case "$AMDGPU_ARCH" in
 		rm -f /usr/lib*/rocblas/library/*gfx8*
 		rm -f /usr/lib*/rocblas/library/*gfx9*
 		rm -f /usr/lib*/rocblas/library/*gfx10*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx8*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx9*
-		rm -f ${TORCH}/lib/rocblas/library/*gfx10*
+		rm -f "${TORCH}"/lib/rocblas/library/*gfx8*
+		rm -f "${TORCH}"/lib/rocblas/library/*gfx9*
+		rm -f "${TORCH}"/lib/rocblas/library/*gfx10*
 		;;
 	*)
 		echo "ERROR: $0 unknown AMDGPU_ARCH=$AMDGPU_ARCH"

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -131,24 +131,24 @@ test_ctx_size(){
     PID_CHAT=$!
 
     # look for the context size error in the server logs
-    if ! timeout 20 bash -c '
-        until grep -q "exceed context window of" "$TEST_CTX_SIZE_LAB_SERVE_LOG_FILE"; do
-        echo "waiting for context size error"
+    if ! timeout 20 bash -c "
+        until grep -q 'exceed context window of' $TEST_CTX_SIZE_LAB_SERVE_LOG_FILE; do
+        echo 'waiting for context size error'
         sleep 1
     done
-'; then
+"; then
         echo "context size error not found in server logs"
         cat $TEST_CTX_SIZE_LAB_SERVE_LOG_FILE
         exit 1
     fi
 
     # look for the context size error in the chat logs
-    if ! timeout 20 bash -c '
-        until grep -q "Message too large for context size." "$TEST_CTX_SIZE_LAB_CHAT_LOG_FILE"; do
-        echo "waiting for chat error"
+    if ! timeout 20 bash -c "
+        until grep -q 'Message too large for context size.' $TEST_CTX_SIZE_LAB_CHAT_LOG_FILE; do
+        echo 'waiting for chat error'
         sleep 1
     done
-'; then
+"; then
         echo "context size error not found in chat logs"
         cat $TEST_CTX_SIZE_LAB_CHAT_LOG_FILE
         exit 1
@@ -236,7 +236,7 @@ EOF
 
     # Test if generated was created and contains files
     ls -l generated/*
-    if [ $(cat $(ls -tr generated/generated_* | tail -n 1) | jq ". | length" ) -lt 1 ] ; then
+    if [ "$(jq ". | length" < "$(find generated/generated_* | tail -n 1)")" -lt 1 ] ; then
         echo "Not enough generated results"
         exit 1
     fi
@@ -284,7 +284,9 @@ test_no_chat_logs(){
         '
 }
 
+
 test_temp_server_ignore_internal_messages(){
+    # shellcheck disable=SC2016
     expect -c '
         set timeout 20
         spawn ilab chat
@@ -335,6 +337,7 @@ test_model_print(){
     wait_for_server
 
     # validate that we print the model from the server since it is different from the config
+    # shellcheck disable=SC2154,SC1001,SC2016
     expect -c '
         spawn ilab chat
         expect {
@@ -355,6 +358,7 @@ test_model_print(){
 
     # If we don't specify a model, validate that we print the model reported
     # by the server since it is different from the config.
+    # shellcheck disable=SC2016
     expect -c '
         spawn ilab chat
         expect {


### PR DESCRIPTION
All our bash scripts are now passing the shellcheck linter.

Signed-off-by: Sébastien Han <seb@redhat.com>