### PR TITLE
refactored "Optimize CPU training on Linux"

### DIFF
--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -340,7 +340,7 @@ def linux_train(
             num_train_epochs=num_epochs,
             per_device_train_batch_size=per_device_train_batch_size,
             fp16=use_fp16,
-            bf16=not use_fp16,
+            bf16=not use_fp16 and device.type != "cpu",
             # use_ipex=True, # TODO CPU test this possible optimization
             use_cpu=model.device.type == "cpu",
             save_strategy="epoch",

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -214,7 +214,7 @@ def linux_train(
 
     model = AutoModelForCausalLM.from_pretrained(
         model_name,
-        torch_dtype="auto",
+        torch_dtype="auto" if device.type != "cpu" else None,
         quantization_config=bnb_config,
         config=config,
         trust_remote_code=True,


### PR DESCRIPTION
This is a refactored subset of valuable changed of #1109 and #1222.

Fixes #1006.

# Changes
- Turn off auto for dtype when loading the model for cpu mode
- Disable fp16 and bf16 in cpu mode.

#1193 is already merged:

But, ilab is terminated by OOM killer on my i7 with 32GB of RAM.

