### PR TITLE
introduce a release note for release

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -84,6 +84,7 @@ backends
 backport
 backported
 cli
+codebase
 compositional
 coreutils
 cpp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## v0.17
+
+### Features
+
+### Breaking Changes

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -68,3 +68,23 @@ The following are the steps for how Y-stream and Z-stream releases gets cut.
 1. Announce release via the following:
     - The `#announce` channel on Slack
     - The `announce` mailing list
+
+## Release Notes
+
+The project maintains a single `CHANGELOG.md` file that documents all releases. To ensure our users
+are well-informed about new features, improvements, and breaking changes, we maintain a
+`CHANGELOG.md` file. This file serves as a centralized place to document changes that will be
+included in the next (X) or (Y) release. Given that the project is in its early stages, we are
+currently focused on documenting changes for the next (Y) release.
+
+### Editing Release Notes
+
+When submitting a Pull Request (PR) that introduces notable features or breaking changes, committers
+need to update the `CHANGELOG.md` file. Clearly describe the changes, their impact, and
+any actions users might need to take. We want clear, concise, and user-friendly notes.
+
+### Branching for a New Release
+
+Each time we prepare for a new (X) or (Y) release, we branch out from the main codebase.
+As part of this branching process, the contents of `CHANGELOG.md` are reviewed and
+finalized.


### PR DESCRIPTION
From now on, let's get into the habit of editing the
`CHANGELOG.md` file on PR adding notable features and/or
breaking changes that users need to be aware of.

Signed-off-by: Sébastien Han <seb@redhat.com>