### PR TITLE
Misc code cleanup in lab.train endpoint

### DIFF
--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -387,8 +387,7 @@ def generate_data(
     machine_seed_instruction_data = []
     generate_start = time.time()
 
-    if not os.path.exists(output_dir):
-        os.mkdir(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
 
     # check taxonomy first then seed_tasks_path
     # throw an error if both not found

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1107,11 +1107,11 @@ def train(
         ):
             file_ = next(training_results_dir.glob(fpath))
             shutil.copy(file_, final_results_dir)
-            print("Copied ", file_, "to ", final_results_dir)
+            print(f"Copied {file_} to {final_results_dir}")
 
         for file in training_results_dir.glob("merged_model/*.safetensors"):
             shutil.move(file, final_results_dir)
-            print("Moved ", file, "to ", final_results_dir)
+            print(f"Moved {file} to {final_results_dir}")
 
         if four_bit_quant:
             print(

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1041,31 +1041,32 @@ def train(
 
         try:
             os.makedirs(data_dir, exist_ok=True)
-            # generated input files reverse sorted by name (contains timestamp)
-            train_files = sorted(glob(input_dir + "/train_*"), reverse=True)
-            test_files = sorted(glob(input_dir + "/test_*"), reverse=True)
-
-            if not train_files or not test_files:
-                click.secho(
-                    f"{input_dir} does not contain training or test files, did you run `ilab generate`?",
-                    fg="red",
-                )
-                raise click.exceptions.Exit(1)
-            if len(train_files) > 1 or len(test_files) > 1:
-                # pylint: disable=f-string-without-interpolation
-                click.secho(
-                    f"Found multiple files from `ilab generate`. Using the most recent generation.",
-                    fg="yellow",
-                )
-            # First file is latest (by above reverse sort and timestamped names)
-            shutil.copy(train_files[0], data_dir + "/train_gen.jsonl")
-            shutil.copy(test_files[0], data_dir + "/test_gen.jsonl")
         except OSError as exc:
             click.secho(
                 f"Could not create data dir: {exc}",
                 fg="red",
             )
             raise click.exceptions.Exit(1)
+
+        # generated input files reverse sorted by name (contains timestamp)
+        train_files = sorted(glob(input_dir + "/train_*"), reverse=True)
+        test_files = sorted(glob(input_dir + "/test_*"), reverse=True)
+
+        if not train_files or not test_files:
+            click.secho(
+                f"{input_dir} does not contain training or test files, did you run `ilab generate`?",
+                fg="red",
+            )
+            raise click.exceptions.Exit(1)
+        if len(train_files) > 1 or len(test_files) > 1:
+            # pylint: disable=f-string-without-interpolation
+            click.secho(
+                f"Found multiple files from `ilab generate`. Using the most recent generation.",
+                fg="yellow",
+            )
+        # First file is latest (by above reverse sort and timestamped names)
+        shutil.copy(train_files[0], data_dir + "/train_gen.jsonl")
+        shutil.copy(test_files[0], data_dir + "/test_gen.jsonl")
 
     if not utils.is_macos_with_m_chip():
         # Local

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -5,6 +5,7 @@
 # Standard
 from glob import glob
 from os.path import basename, dirname, exists
+from pathlib import Path
 import json
 import logging
 import multiprocessing
@@ -1089,10 +1090,9 @@ def train(
         gguf_models_dir = "./models"
         os.makedirs(gguf_models_dir, exist_ok=True)
 
-        gguf_models_file = os.path.join(gguf_models_dir, "ggml-model-f16.gguf")
         # Remove previously trained model, its taking up space we may need in the next step
-        if os.path.isfile(gguf_models_file):
-            os.remove(gguf_models_file)
+        gguf_models_file = Path(gguf_models_dir) / "ggml-model-f16.gguf"
+        gguf_models_file.unlink(missing_ok=True)
 
         # TODO: Figure out what to do when there are multiple checkpoint dirs.
         # Right now it's just copying files from the first one numerically not necessarily the best one

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1097,36 +1097,19 @@ def train(
 
         # TODO: Figure out what to do when there are multiple checkpoint dirs.
         # Right now it's just copying files from the first one numerically not necessarily the best one
-        added_tokens_file = glob(
-            training_results_dir + "/checkpoint-*/added_tokens.json"
-        )
-        special_tokens_map = glob(
-            training_results_dir + "/checkpoint-*/special_tokens_map.json"
-        )
-        tokenizer_json = glob(training_results_dir + "/checkpoint-*/tokenizer.json")
-        tokenizer_model = glob(training_results_dir + "/checkpoint-*/tokenizer.model")
-        tokenizer_config_json = glob(
-            training_results_dir + "/checkpoint-*/tokenizer_config.json"
-        )
-        config_json = glob(training_results_dir + "/merged_model/config.json")
-        generation_config_json = glob(
-            training_results_dir + "/merged_model/generation_config.json"
-        )
+        for fpath in (
+            "/checkpoint-*/added_tokens.json",
+            "/checkpoint-*/special_tokens_map.json",
+            "/checkpoint-*/tokenizer.json",
+            "/checkpoint-*/tokenizer.model",
+            "/checkpoint-*/tokenizer_config.json",
+            "/merged_model/config.json",
+            "/merged_model/generation_config.json",
+        ):
+            file_ = glob(training_results_dir + fpath)[0]
+            shutil.copy(file_, final_results_dir)
+            print("Copied ", file_, "to ", final_results_dir)
 
-        shutil.copy(added_tokens_file[0], final_results_dir)
-        print("Copied ", added_tokens_file[0], "to ", final_results_dir)
-        shutil.copy(special_tokens_map[0], final_results_dir)
-        print("Copied ", special_tokens_map[0], "to ", final_results_dir)
-        shutil.copy(tokenizer_json[0], final_results_dir)
-        print("Copied ", tokenizer_json[0], "to ", final_results_dir)
-        shutil.copy(tokenizer_model[0], final_results_dir)
-        print("Copied ", tokenizer_model[0], "to ", final_results_dir)
-        shutil.copy(tokenizer_config_json[0], final_results_dir)
-        print("Copied ", tokenizer_config_json[0], "to ", final_results_dir)
-        shutil.copy(config_json[0], final_results_dir)
-        print("Copied ", config_json[0], "to ", final_results_dir)
-        shutil.copy(generation_config_json[0], final_results_dir)
-        print("Copied ", generation_config_json[0], "to ", final_results_dir)
         for file in glob(training_results_dir + "/merged_model/*.safetensors"):
             shutil.move(file, final_results_dir)
             print("Moved ", file, "to ", final_results_dir)

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1049,8 +1049,11 @@ def train(
             raise click.exceptions.Exit(1)
 
         # generated input files reverse sorted by name (contains timestamp)
-        train_files = sorted(glob(input_dir + "/train_*"), reverse=True)
-        test_files = sorted(glob(input_dir + "/test_*"), reverse=True)
+        def get_files(pattern):
+            return sorted(Path(input_dir).glob(pattern), reverse=True)
+
+        train_files = get_files("train_*")
+        test_files = get_files("test_*")
 
         if not train_files or not test_files:
             click.secho(

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1021,7 +1021,6 @@ def train(
     Takes synthetic data generated locally with `ilab generate` and the previous model and learns a new model using the MLX API.
     On success, writes newly learned model to {model_dir}/mlx_model, which is where `chatmlx` will look for a model.
     """
-    # pylint: disable=C0415
     if not input_dir:
         # By default, generate output-dir is used as train input-dir
         input_dir = ctx.obj.config.generate.output_dir
@@ -1074,6 +1073,7 @@ def train(
         shutil.copy(train_files[0], train_file)
         shutil.copy(test_files[0], test_file)
 
+    # pylint: disable=import-outside-toplevel
     if not utils.is_macos_with_m_chip():
         # Local
         from .llamacpp.llamacpp_convert_to_gguf import convert_llama_to_gguf

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1029,9 +1029,13 @@ def train(
     if four_bit_quant and device.type != "cuda":
         ctx.fail("--4-bit-quant option requires --device=cuda")
 
+    effective_data_dir = Path(data_dir or "./taxonomy_data")
+    train_file = effective_data_dir / "train_gen.jsonl"
+    test_file = effective_data_dir / "test_gen.jsonl"
+
     # NOTE: If given a data_dir, input-dir is ignored in favor of existing!
     if data_dir is None:
-        data_dir = "./taxonomy_data"
+        data_dir = effective_data_dir
         if not os.path.exists(input_dir):
             click.secho(
                 f"Could not read directory: {input_dir}",
@@ -1068,8 +1072,8 @@ def train(
                 fg="yellow",
             )
         # First file is latest (by above reverse sort and timestamped names)
-        shutil.copy(train_files[0], data_dir + "/train_gen.jsonl")
-        shutil.copy(test_files[0], data_dir + "/test_gen.jsonl")
+        shutil.copy(train_files[0], train_file)
+        shutil.copy(test_files[0], test_file)
 
     if not utils.is_macos_with_m_chip():
         # Local
@@ -1078,8 +1082,8 @@ def train(
 
         linux_train(
             ctx=ctx,
-            train_file=train_files[0],
-            test_file=test_files[0],
+            train_file=train_file,
+            test_file=test_file,
             model_name=model_name,
             num_epochs=num_epochs,
             device=device,

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1066,9 +1066,8 @@ def train(
             )
             raise click.exceptions.Exit(1)
         if len(train_files) > 1 or len(test_files) > 1:
-            # pylint: disable=f-string-without-interpolation
             click.secho(
-                f"Found multiple files from `ilab generate`. Using the most recent generation.",
+                "Found multiple files from `ilab generate`. Using the most recent generation.",
                 fg="yellow",
             )
         # First file is latest (by above reverse sort and timestamped names)

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1033,8 +1033,7 @@ def train(
         data_dir = "./taxonomy_data"
         try:
             os.listdir(input_dir)  # Test to throw FileNotFound exception
-            if not os.path.isdir(data_dir):
-                os.mkdir(data_dir)
+            os.makedirs(data_dir, exist_ok=True)
             # generated input files reverse sorted by name (contains timestamp)
             train_files = sorted(glob(input_dir + "/train_*"), reverse=True)
             test_files = sorted(glob(input_dir + "/test_*"), reverse=True)
@@ -1088,8 +1087,8 @@ def train(
         os.makedirs(final_results_dir, exist_ok=True)
 
         gguf_models_dir = "./models"
-        if not os.path.isdir(gguf_models_dir):
-            os.mkdir(gguf_models_dir)
+        os.makedirs(gguf_models_dir, exist_ok=True)
+
         gguf_models_file = os.path.join(gguf_models_dir, "ggml-model-f16.gguf")
         # Remove previously trained model, its taking up space we may need in the next step
         if os.path.isfile(gguf_models_file):

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1032,8 +1032,14 @@ def train(
     # NOTE: If given a data_dir, input-dir is ignored in favor of existing!
     if data_dir is None:
         data_dir = "./taxonomy_data"
+        if not os.path.exists(input_dir):
+            click.secho(
+                f"Could not read directory: {input_dir}",
+                fg="red",
+            )
+            raise click.exceptions.Exit(1)
+
         try:
-            os.listdir(input_dir)  # Test to throw FileNotFound exception
             os.makedirs(data_dir, exist_ok=True)
             # generated input files reverse sorted by name (contains timestamp)
             train_files = sorted(glob(input_dir + "/train_*"), reverse=True)
@@ -1054,12 +1060,6 @@ def train(
             # First file is latest (by above reverse sort and timestamped names)
             shutil.copy(train_files[0], data_dir + "/train_gen.jsonl")
             shutil.copy(test_files[0], data_dir + "/test_gen.jsonl")
-        except FileNotFoundError as exc:
-            click.secho(
-                f"Could not read directory: {exc}",
-                fg="red",
-            )
-            raise click.exceptions.Exit(1)
         except OSError as exc:
             click.secho(
                 f"Could not create data dir: {exc}",

--- a/src/instructlab/llamacpp/llamacpp_convert_to_gguf.py
+++ b/src/instructlab/llamacpp/llamacpp_convert_to_gguf.py
@@ -1613,7 +1613,7 @@ def do_dump_model(model_plus: ModelPlus) -> None:
 
 
 def convert_llama_to_gguf(
-    model: str,
+    model: Path,
     awq_path: Optional[str] = None,
     dump: bool = False,
     dump_single: bool = False,
@@ -1637,9 +1637,6 @@ def convert_llama_to_gguf(
     #     case_sensitive=True,
     # )
 
-    # click.argument doesn't seem to be returning a Path for model
-    if isinstance(model, str):
-        model = Path(model)
     if awq_path:
         sys.path.insert(1, str(Path(__file__).parent / "awq-py"))
         # Third Party

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -370,13 +370,11 @@ class TestLabTrain:
             assert len(convert_llama_to_gguf_mock.call_args[1]) == 2
             linux_train_mock.assert_called_once()
             print(linux_train_mock.call_args[1])
-            assert (
-                linux_train_mock.call_args[1]["train_file"]
-                == "test_generated/train_1.jsonl"
+            assert linux_train_mock.call_args[1]["train_file"] == Path(
+                "test_generated/train_1.jsonl"
             )
-            assert (
-                linux_train_mock.call_args[1]["test_file"]
-                == "test_generated/test_1.jsonl"
+            assert linux_train_mock.call_args[1]["test_file"] == Path(
+                "test_generated/test_1.jsonl"
             )
             assert linux_train_mock.call_args[1]["num_epochs"] == 1
             assert linux_train_mock.call_args[1]["device"] is not None

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -159,7 +159,7 @@ class TestLabTrain:
                 lab.cli, ["--config=DEFAULT", "train", "--input-dir", "invalid"]
             )
             assert result.exception is not None
-            assert "No such file or directory: 'invalid'" in result.output
+            assert "Could not read directory: invalid" in result.output
             assert result.exit_code == 1
 
     def test_invalid_taxonomy(self):

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+from pathlib import Path
 from unittest.mock import patch
 import os
 import platform
@@ -362,9 +363,8 @@ class TestLabTrain:
             )
             assert result.exit_code == 0
             convert_llama_to_gguf_mock.assert_called_once()
-            assert (
-                convert_llama_to_gguf_mock.call_args[1]["model"]
-                == "./training_results/final"
+            assert convert_llama_to_gguf_mock.call_args[1]["model"] == Path(
+                "./training_results/final"
             )
             assert convert_llama_to_gguf_mock.call_args[1]["pad_vocab"] is True
             assert len(convert_llama_to_gguf_mock.call_args[1]) == 2

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -94,7 +94,7 @@ class TestLabTrain:
             load_and_train_mock.assert_called_once()
             assert load_and_train_mock.call_args[1]["model"] is not None
             assert load_and_train_mock.call_args[1]["train"]
-            assert load_and_train_mock.call_args[1]["data"] == "./taxonomy_data"
+            assert load_and_train_mock.call_args[1]["data"] == Path("./taxonomy_data")
             assert load_and_train_mock.call_args[1]["adapter_file"] is not None
             assert load_and_train_mock.call_args[1]["iters"] == 100
             assert load_and_train_mock.call_args[1]["save_every"] == 10
@@ -112,7 +112,7 @@ class TestLabTrain:
             assert not convert_between_mlx_and_pytorch_mock.call_args[1]["local"]
             assert len(convert_between_mlx_and_pytorch_mock.call_args[1]) == 4
             make_data_mock.assert_called_once()
-            assert make_data_mock.call_args[1]["data_dir"] == "./taxonomy_data"
+            assert make_data_mock.call_args[1]["data_dir"] == Path("./taxonomy_data")
             assert len(make_data_mock.call_args[1]) == 1
             is_macos_with_m_chip_mock.assert_called_once()
 
@@ -371,10 +371,10 @@ class TestLabTrain:
             linux_train_mock.assert_called_once()
             print(linux_train_mock.call_args[1])
             assert linux_train_mock.call_args[1]["train_file"] == Path(
-                "test_generated/train_1.jsonl"
+                "taxonomy_data/train_gen.jsonl"
             )
             assert linux_train_mock.call_args[1]["test_file"] == Path(
-                "test_generated/test_1.jsonl"
+                "taxonomy_data/test_gen.jsonl"
             )
             assert linux_train_mock.call_args[1]["num_epochs"] == 1
             assert linux_train_mock.call_args[1]["device"] is not None


### PR DESCRIPTION
This is code cleanup (see each commit message in the series for details of what is done and why). It also fixes a `NameError` issue when `data-dir` is passed on linux (found the issue during code cleanup).