### PR TITLE
chat: Fix ssl when only cert file is passed

### DIFF
--- a/src/instructlab/chat/chat.py
+++ b/src/instructlab/chat/chat.py
@@ -23,7 +23,7 @@ import openai
 
 # Local
 from ..config import DEFAULT_CONNECTION_TIMEOUT, DEFAULT_MODEL_OLD
-from ..utils import get_sysprompt
+from ..utils import get_ssl_cert_config, get_sysprompt
 
 HELP_MD = """
 Help / TL;DR
@@ -473,8 +473,7 @@ def chat_cli(
     tls_client_passwd: Optional[str] = None,
 ):
     """Starts a CLI-based chat with the server"""
-    orig_cert = (tls_client_cert, tls_client_key, tls_client_passwd)
-    cert = tuple(item for item in orig_cert if item)
+    cert = get_ssl_cert_config(tls_client_cert, tls_client_key, tls_client_passwd)
     verify = not tls_insecure
     client = OpenAI(
         base_url=api_base,

--- a/src/instructlab/client.py
+++ b/src/instructlab/client.py
@@ -10,6 +10,7 @@ import httpx
 
 # Local
 from .config import DEFAULT_API_KEY, DEFAULT_CONNECTION_TIMEOUT
+from .utils import get_ssl_cert_config
 
 
 class ClientException(Exception):
@@ -26,8 +27,7 @@ def list_models(
 ):
     """List models from OpenAI-compatible server"""
     try:
-        orig_cert = (tls_client_cert, tls_client_key, tls_client_passwd)
-        cert = tuple(item for item in orig_cert if item)
+        cert = get_ssl_cert_config(tls_client_cert, tls_client_key, tls_client_passwd)
         verify = not tls_insecure
         client = OpenAI(
             base_url=api_base,

--- a/src/instructlab/generator/utils.py
+++ b/src/instructlab/generator/utils.py
@@ -17,7 +17,7 @@ import httpx
 
 # Local
 from ..config import DEFAULT_API_KEY, DEFAULT_MODEL_OLD
-from ..utils import get_sysprompt
+from ..utils import get_ssl_cert_config, get_sysprompt
 
 StrOrOpenAIObject = Union[str, object]
 
@@ -124,8 +124,7 @@ def openai_completion(
 
         # do not pass a lower timeout to this client since generating a dataset takes some time
         # pylint: disable=R0801
-        orig_cert = (tls_client_cert, tls_client_key, tls_client_passwd)
-        cert = tuple(item for item in orig_cert if item)
+        cert = get_ssl_cert_config(tls_client_cert, tls_client_key, tls_client_passwd)
         verify = not tls_insecure
         client = OpenAI(
             base_url=api_base,

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -599,5 +599,5 @@ def read_taxonomy(logger, taxonomy, taxonomy_base, yaml_rules):
 
 
 def get_ssl_cert_config(tls_client_cert, tls_client_key, tls_client_passwd):
-    orig_cert = (tls_client_cert, tls_client_key, tls_client_passwd)
-    return tuple(item for item in orig_cert if item)
+    if tls_client_cert:
+        return tls_client_cert, tls_client_key, tls_client_passwd

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -596,3 +596,8 @@ def read_taxonomy(logger, taxonomy, taxonomy_base, yaml_rules):
                 yaml.YAMLError(f"{total_errors} taxonomy files with errors! Exiting.")
             )
     return seed_instruction_data
+
+
+def get_ssl_cert_config(tls_client_cert, tls_client_key, tls_client_passwd):
+    orig_cert = (tls_client_cert, tls_client_key, tls_client_passwd)
+    return tuple(item for item in orig_cert if item)


### PR DESCRIPTION
httpx.Client expects cert argument to be one of: a 2+ tuple, or a string, or None.

Before the change, we were passing a 1-tuple when only the cert file was configured through cli, which is violating the typing requirements of the library; and it also made the library not initialize SSL context at all. See:

https://github.com/encode/httpx/blob/37593c1952f4972040f6163da67e3777fd3d2e94/httpx/_config.py#L183