### PR TITLE
fix ilab chat run /h command failed issue

### DIFF
--- a/src/instructlab/chat/chat.py
+++ b/src/instructlab/chat/chat.py
@@ -147,7 +147,7 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
     def _handle_quit(self, _):
         raise ChatQuitException
 
-    def _handle_help(self):
+    def _handle_help(self, _):
         self._sys_print(Markdown(HELP_MD))
         raise KeyboardInterrupt
 


### PR DESCRIPTION
# Changes

**Which issue is resolved by this Pull Request:**
Resolves #https://github.com/instructlab/instructlab/issues/1236

**Description of your changes:**
chat.py: def _handle_help(slef) missed one parameter even it does not use it. Update to def _handle_help(self, _)