### PR TITLE
feat: add new pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,21 @@
-# Changes
+<!-- Thank you for contributing to InstructLab! -->
 
-**Which issue is resolved by this Pull Request:**
+<!-- STEPS TO FOLLOW:
+  1. Add a description of the changes (frequently the same as the commit description)
+  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
+  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
+-->
+
+<!-- Uncomment this section with the issue number if an issue is being resolved
+**Issue resolved by this Pull Request:**
 Resolves #
+--->
 
-**Description of your changes:**
+**Checklist:**
+
+- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
+  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
+- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
+- [ ] Documentation has been updated, if necessary.
+- [ ] Unit tests have been added, if necessary.
+- [ ] Integration tests have been added, if necessary.


### PR DESCRIPTION
This commit introduces a new template for pull requests. The template includes sections for a description of the changes, the issue number being resolved, and a checklist for commit message formatting, updating release notes, and adding necessary documentation and tests.

Signed-off-by: Sébastien Han <seb@redhat.com>

