### PR TITLE
ci: try to fix flaky test_generate() functional test

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -231,8 +231,11 @@ EOF
 
     sed -i.bak -e 's/num_instructions:.*/num_instructions: 1/g' config.yaml
 
-    # This should be finished in a minut or so but time it out incase it goes wrong
-    timeout 10m ilab generate --taxonomy-path test_taxonomy/compositional_skills/simple_math.yaml
+    # This should be finished in a minute or so but time it out incase it goes wrong
+    if ! timeout 20m ilab generate --taxonomy-path test_taxonomy/compositional_skills/simple_math.yaml; then
+        echo "Error: ilab generate command took more than 20 minutes and was cancelled"
+        exit 1
+    fi
 
     # Test if generated was created and contains files
     ls -l generated/*


### PR DESCRIPTION
The test seems to fail intermittently, so let's try to push the timeout to 20m as well as printing a clear indication of why the functional test is going to fail.

Signed-off-by: Sébastien Han <seb@redhat.com>

Failure example: https://github.com/leseb/rook/blob/bcd2511a7269ceb72c5c4a255fa760de85dea1e1/pkg/operator/ceph/cluster/osd/spec.go#L169-L182