### PR TITLE
sdg: Remove unnecessary config access

### DIFF
--- a/src/instructlab/generator/generate_data.py
+++ b/src/instructlab/generator/generate_data.py
@@ -20,7 +20,7 @@ import click
 import tqdm
 
 # Local
-from ..config import DEFAULT_MULTIPROCESSING_START_METHOD, get_model_family
+from ..config import get_model_family
 from ..utils import (
     chunk_document,
     max_seed_example_tokens,
@@ -493,7 +493,7 @@ def generate_data(
             "Synthesizing new instructions. If you aren't satisfied with the generated instructions, interrupt training (Ctrl-C) and try adjusting your YAML files. Adding more examples may help."
         )
 
-    mpctx = multiprocessing.get_context(DEFAULT_MULTIPROCESSING_START_METHOD)
+    mpctx = multiprocessing.get_context(None)
 
     all_taxonomy_paths = list(set(e["taxonomy_path"] for e in seed_instruction_data))
     total_discarded = 0


### PR DESCRIPTION
Calling `get_context()` with an arg of `DEFAULT_MULTIPROCESSING_START_METHOD`
is not necessary. The parent `lab.py` is already setting the default
before this code runs. Calling `get_context(None)` will return a
context using whatever the current default is set to.

This removes one bit of coupling from this sdg code and the rest of
the CLI, making it easier to extract into a library.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
