### PR TITLE
mergify: fix e2e workflow file name

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -201,7 +201,7 @@ pull_request_rules:
     github_actions:
       workflow:
         dispatch:
-          - workflow: e2e.yaml
+          - workflow: e2e.yml
             inputs:
               pr_or_branch: "{{ number }}"
     label:


### PR DESCRIPTION
The file is `e2e.yml` not `e2e.yaml`.
Failure run:
https://github.com/instructlab/instructlab/pull/1211/checks?check_run_id=25741927743

Signed-off-by: Sébastien Han <seb@redhat.com>

![Screenshot 2024-06-03 at 17 20 57](https://github.com/instructlab/instructlab/assets/912735/abeaa5c5-27d8-4db2-945a-0f913bcea95d)
