### PR TITLE
docs: fix link to repo in demo-slides

### DIFF
--- a/docs/demo-slides.md
+++ b/docs/demo-slides.md
@@ -34,7 +34,7 @@ source venv/bin/activate.fish
 Install CLI
 
 ```fish
-pip install git+https://github.com/instructlab/cli.git@stable
+pip install git+https://github.com/instructlab/instructlab.git@stable
 ```
 
 <!-- pause -->

--- a/docs/demo-slides.md
+++ b/docs/demo-slides.md
@@ -34,7 +34,7 @@ source venv/bin/activate.fish
 Install CLI
 
 ```fish
-pip install git+https://github.com/instructlab/instructlab.git@stable
+pip install instructlab
 ```
 
 <!-- pause -->


### PR DESCRIPTION
The current link still points to the old repo.