### PR TITLE
e2e: Install gh command if it's missing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,15 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
 
+      - name: Install GitHub CLI
+        run: |
+          if ! command -v gh &> /dev/null ; then
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+            sudo apt-add-repository https://cli.github.com/packages
+            sudo apt update
+            sudo apt install gh
+          fi
+
       - name: Determine if pr_or_branch is a PR number
         id: check_pr
         run: |


### PR DESCRIPTION
Commenting on PRs is failing because `gh` is not present. This should
install it.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
