### PR TITLE
linux_train returns training_results_dir

### DIFF
--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -232,7 +232,7 @@ def train(
         from ..llamacpp.llamacpp_convert_to_gguf import convert_llama_to_gguf
         from ..train.linux_train import linux_train
 
-        linux_train(
+        training_results_dir = linux_train(
             ctx=ctx,
             train_file=train_file,
             test_file=test_file,
@@ -241,8 +241,6 @@ def train(
             device=device,
             four_bit_quant=four_bit_quant,
         )
-
-        training_results_dir = Path("./training_results")
 
         final_results_dir = training_results_dir / "final"
         final_results_dir.mkdir(exist_ok=True)

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -151,13 +151,15 @@ def linux_train(
     num_epochs: Optional[int] = None,
     device: torch.device = torch.device("cpu"),
     four_bit_quant: bool = False,
-):
+    output_dir: Path = Path("training_results"),
+) -> Path:
     """Lab Train for Linux!"""
     print("LINUX_TRAIN.PY: NUM EPOCHS IS: ", num_epochs)
     print("LINUX_TRAIN.PY: TRAIN FILE IS: ", train_file)
     print("LINUX_TRAIN.PY: TEST FILE IS: ", test_file)
 
     print(f"LINUX_TRAIN.PY: Using device '{device}'")
+    output_dir = Path(output_dir)
     if device.type == "cuda":
         # estimated by watching nvtop / radeontop during training
         min_vram = 11 if four_bit_quant else 17
@@ -292,7 +294,6 @@ def linux_train(
     )
 
     tokenizer.padding_side = "right"
-    output_dir = "./training_results"
     per_device_train_batch_size = 1
     max_seq_length = 300
 
@@ -396,6 +397,7 @@ def linux_train(
 
     print("LINUX_TRAIN.PY: MERGING ADAPTERS")
     model = trainer.model.merge_and_unload()
-    model.save_pretrained("./training_results/merged_model")
+    model.save_pretrained(output_dir / "merged_model")
 
     print("LINUX_TRAIN.PY: FINISHED")
+    return output_dir

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -356,7 +356,7 @@ class TestLabTrain:
             is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=False)
-    @patch.object(linux_train, "linux_train")
+    @patch.object(linux_train, "linux_train", return_value=Path("training_results"))
     @patch(
         "instructlab.llamacpp.llamacpp_convert_to_gguf.convert_llama_to_gguf",
         side_effect=mock_convert_llama_to_gguf,
@@ -378,7 +378,7 @@ class TestLabTrain:
             assert result.exit_code == 0
             convert_llama_to_gguf_mock.assert_called_once()
             assert convert_llama_to_gguf_mock.call_args[1]["model"] == Path(
-                "./training_results/final"
+                "training_results/final"
             )
             assert convert_llama_to_gguf_mock.call_args[1]["pad_vocab"] is True
             assert len(convert_llama_to_gguf_mock.call_args[1]) == 2
@@ -398,7 +398,10 @@ class TestLabTrain:
             assert not os.path.isfile(LINUX_GGUF_FILE)
 
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=False)
-    @patch("instructlab.train.linux_train.linux_train")
+    @patch(
+        "instructlab.train.linux_train.linux_train",
+        return_value=Path("training_results"),
+    )
     @patch(
         "instructlab.llamacpp.llamacpp_convert_to_gguf.convert_llama_to_gguf",
         side_effect=mock_convert_llama_to_gguf,


### PR DESCRIPTION
Refactoring to avoid procedural programming and
rigid hard-coded key values in different files
to use functional programming and flexible style.

The "training_results" string can also be easily parameterized when it is necessary.
