### PR TITLE
e2e: Give e2e workflow write access to PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,9 @@ jobs:
   e2e:
     runs-on: ubuntu-gpu
 
+    permissions:
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The workflow is trying to comment on PRs when run against a PR number,
but this currently fails due to a lack of permission to do so.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
