### PR TITLE
Support namespace packages under `instructlab`

### DIFF
--- a/src/instructlab/__init__.py
+++ b/src/instructlab/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)


### PR DESCRIPTION
The new `sdg` repository includes a new Python library. The current
consensus on the following issue is that it should be published as a
Python namespace package, `instructlab.sdg`.

This magic snippet is required to allow this. See the discussion on
the issue for further discussion:

https://github.com/instructlab/sdg/issues/2

Signed-off-by: Russell Bryant <rbryant@redhat.com>
