### PR TITLE
Attempt minimal approach to restructuring ilab commands

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -85,6 +85,7 @@ def cli(ctx, config_file):
     If this is your first time running InstructLab, it's best to start with `ilab init` to create the environment.
     """
     deprecated_cmds = {
+        "diff": "taxonomy diff",
         "generate": "data generate",
         "init": "config init",
     }
@@ -326,6 +327,15 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
 # ilab list => ilab diff
 # ilab check => ilab diff --quiet
 utils.make_lab_diff_aliases(cli, diff)
+
+
+@click.group(name="taxonomy", cls=DYMGroup)
+def taxonomy_group():
+    """Commands for managing InstructLab taxonomy."""
+
+
+cli.add_command(taxonomy_group)
+taxonomy_group.add_command(diff)
 
 
 @cli.command()

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -86,6 +86,7 @@ def cli(ctx, config_file):
     """
     deprecated_cmds = {
         "chat": "model chat",
+        "convert": "model convert",
         "diff": "taxonomy diff",
         "generate": "data generate",
         "init": "config init",
@@ -1420,6 +1421,7 @@ def model_group():
 
 cli.add_command(model_group)
 model_group.add_command(chat)
+model_group.add_command(convert)
 
 
 @cli.command

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -84,9 +84,14 @@ def cli(ctx, config_file):
 
     If this is your first time running InstructLab, it's best to start with `ilab init` to create the environment.
     """
-    if ctx.invoked_subcommand == "init":
+    deprecated_cmds = {
+        "generate": "data generate",
+        "init": "config init",
+    }
+    if ctx.invoked_subcommand in deprecated_cmds:
+        new_cmd = deprecated_cmds[ctx.invoked_subcommand]
         click.secho(
-            "This command is deprecated. Use `ilab config init` instead.", fg="red"
+            "This command is deprecated. Use `ilab %s` instead." % new_cmd, fg="red"
         )
 
     # ilab init or "--help" have no config file. ilab sysinfo does not need one.
@@ -598,6 +603,15 @@ def generate(
             server_process.join(timeout=30)
             server_queue.close()
             server_queue.join_thread()
+
+
+@click.group(name="data", cls=DYMGroup)
+def data_group():
+    """Commands for generating synthetic data."""
+
+
+cli.add_command(data_group)
+data_group.add_command(generate)
 
 
 @cli.command()

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -93,6 +93,7 @@ def cli(ctx, config_file):
         "init": "config init",
         "serve": "model serve",
         "sysinfo": "system info",
+        "test": "model evaluate",
     }
     if ctx.invoked_subcommand in deprecated_cmds:
         new_cmd = deprecated_cmds[ctx.invoked_subcommand]
@@ -1426,6 +1427,7 @@ model_group.add_command(chat)
 model_group.add_command(convert)
 model_group.add_command(download)
 model_group.add_command(serve)
+model_group.add_command(test, name="evaluate")
 
 
 @cli.command

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -84,11 +84,16 @@ def cli(ctx, config_file):
 
     If this is your first time running InstructLab, it's best to start with `ilab init` to create the environment.
     """
+    if ctx.invoked_subcommand == "init":
+        click.secho(
+            "This command is deprecated. Use `ilab config init` instead.", fg="red"
+        )
+
     # ilab init or "--help" have no config file. ilab sysinfo does not need one.
     # CliRunner does fill ctx.invoke_subcommand in option callbacks. We have
     # to validate config_file here.
     if (
-        ctx.invoked_subcommand not in {"init", "sysinfo"}
+        ctx.invoked_subcommand not in {"config", "init", "sysinfo"}
         and "--help" not in sys.argv[1:]
     ):
         if config_file == "DEFAULT":
@@ -226,6 +231,15 @@ def init(
     click.echo(
         "Initialization completed successfully, you're ready to start using `ilab`. Enjoy!"
     )
+
+
+@click.group(name="config", cls=DYMGroup)
+def config_group():
+    """Commands for managing InstructLab configuration."""
+
+
+cli.add_command(config_group)
+config_group.add_command(init)
 
 
 @cli.command()

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -118,6 +118,11 @@ def cli(ctx, config_file):
         ctx.obj = Lab(config_obj)
         # default_map holds a dictionary with default values for each command parameters
         ctx.default_map = config.get_dict(ctx.obj.config)
+        for old_cmd, new_cmd in deprecated_cmds.items():
+            new_cmd = new_cmd.split()
+            new_cmd_cfg = ctx.default_map.get(new_cmd[0], {})
+            new_cmd_cfg[new_cmd[1]] = ctx.default_map.get(old_cmd, {})
+            ctx.default_map[new_cmd[0]] = new_cmd_cfg
 
 
 @cli.command()

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -88,6 +88,7 @@ def cli(ctx, config_file):
         "chat": "model chat",
         "convert": "model convert",
         "diff": "taxonomy diff",
+        "download": "model download",
         "generate": "data generate",
         "init": "config init",
         "sysinfo": "system info",
@@ -1422,6 +1423,7 @@ def model_group():
 cli.add_command(model_group)
 model_group.add_command(chat)
 model_group.add_command(convert)
+model_group.add_command(download)
 
 
 @cli.command

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -94,6 +94,7 @@ def cli(ctx, config_file):
         "serve": "model serve",
         "sysinfo": "system info",
         "test": "model evaluate",
+        "train": "model train",
     }
     if ctx.invoked_subcommand in deprecated_cmds:
         new_cmd = deprecated_cmds[ctx.invoked_subcommand]
@@ -1428,6 +1429,7 @@ model_group.add_command(convert)
 model_group.add_command(download)
 model_group.add_command(serve)
 model_group.add_command(test, name="evaluate")
+model_group.add_command(train)
 
 
 @cli.command

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -91,6 +91,7 @@ def cli(ctx, config_file):
         "download": "model download",
         "generate": "data generate",
         "init": "config init",
+        "serve": "model serve",
         "sysinfo": "system info",
     }
     if ctx.invoked_subcommand in deprecated_cmds:
@@ -1424,6 +1425,7 @@ cli.add_command(model_group)
 model_group.add_command(chat)
 model_group.add_command(convert)
 model_group.add_command(download)
+model_group.add_command(serve)
 
 
 @cli.command

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1412,6 +1412,14 @@ def convert(ctx, model_dir, adapter_file, skip_de_quantize, skip_quantize, model
     os.remove(os.path.join(model_dir_fused_pt, f"{model_name}.gguf"))
 
 
+@click.group(name="model", cls=DYMGroup)
+def model_group():
+    """Commands for interacting with models."""
+
+
+cli.add_command(model_group)
+
+
 @cli.command
 def sysinfo():
     """Print system information"""

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -88,6 +88,7 @@ def cli(ctx, config_file):
         "diff": "taxonomy diff",
         "generate": "data generate",
         "init": "config init",
+        "sysinfo": "system info",
     }
     if ctx.invoked_subcommand in deprecated_cmds:
         new_cmd = deprecated_cmds[ctx.invoked_subcommand]
@@ -1416,3 +1417,12 @@ def sysinfo():
     """Print system information"""
     for key, value in get_sysinfo().items():
         print(f"{key}: {value}")
+
+
+@click.group(name="system", cls=DYMGroup)
+def system_group():
+    """Commands for gathering system information."""
+
+
+cli.add_command(system_group)
+system_group.add_command(sysinfo, name="info")

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -85,6 +85,7 @@ def cli(ctx, config_file):
     If this is your first time running InstructLab, it's best to start with `ilab init` to create the environment.
     """
     deprecated_cmds = {
+        "chat": "model chat",
         "diff": "taxonomy diff",
         "generate": "data generate",
         "init": "config init",
@@ -1418,6 +1419,7 @@ def model_group():
 
 
 cli.add_command(model_group)
+model_group.add_command(chat)
 
 
 @cli.command

--- a/tests/test_lab_diff.py
+++ b/tests/test_lab_diff.py
@@ -39,6 +39,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
@@ -60,6 +61,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
@@ -79,6 +81,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
@@ -99,6 +102,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     taxonomy_base,
@@ -120,6 +124,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
@@ -139,6 +144,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
@@ -158,6 +164,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
@@ -177,6 +184,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
@@ -197,6 +205,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
@@ -218,6 +227,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
@@ -238,6 +248,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
@@ -260,6 +271,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,
@@ -284,6 +296,7 @@ class TestLabDiff:
                 lab.cli,
                 [
                     "--config=DEFAULT",
+                    "taxonomy",
                     "diff",
                     "--taxonomy-base",
                     TAXONOMY_BASE,


### PR DESCRIPTION
This started while I was reviewing #990. I was trying to understand the specific
changes necessary to implement the new `ilab` command structure. This PR is what
I ended up with.

These changes do not attempt to implement the full scope of what is envisioned
with restructuring the code base in a structure that is similar to the commands.
Instead, it tries to only make the new commands work with the smallest amount of
change.

What it does:

- New commands are functional
- Old commands are still supported, but emit a deprecation warning
- Config file remains the same

What is not included:

- Reorganizing the code to more logically follow the command structure
- test changes to exercise the new commands
- doc changes to reflect new commands


51ddd7a Create `ilab config init` command
4f33406 Add `ilab data generate`
fd04c30 Map configuration file to the new commands
8ab8a5e Add `ilab taxonomy diff`
495773a Add `ilab system info`
36e4c49 Add `ilab model` command group
bcc9057 Add `ilab model chat`
daa522b Add `ilab model convert`
96b43f5 Add `ilab model download`
b27eb3b Add `ilab model serve`
6ebf165 Add `ilab model evaluate`
d34a628 Add `ilab model train`
e6c7f6f Adjust `ilab diff` tests to use new `ilab taxonomy diff`

commit 51ddd7a49dbe29e539afa7fb15b2a8e1f2e57743
Author: Russell Bryant <rbryant@redhat.com>
Date:   Tue Jun 4 20:36:04 2024 -0400

    Create `ilab config init` command
    
    This change adds a new command, `ilab config init`, which shares the
    same implementation with `ilab init`. If a user runs `ilab init`
    instead, they will get a red warning message saying that this command
    is deprecated.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 4f334064e99c9914e2dee032ed0d99c8002d4faa
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jun 5 15:31:22 2024 -0400

    Add `ilab data generate`
    
    This change adds a new command `ilab data generate`. `ilab generate`
    works as an alias and will emit a deprecation warning when used.
    
    Part of https://github.com/instructlab/dev-docs/blob/main/docs/ilab-model-engine.md
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit fd04c304b32a0274d6b8efa6a86c077e8cd00968
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jun 5 20:12:17 2024 -0400

    Map configuration file to the new commands
    
    This commit makes all configuration work for the new commands. It does
    not change the configuration format to a new structure. That should be
    considered in some follow-up work.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 8ab8a5e08479877c7e966d383b98e6f1cc83cb36
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jun 5 15:43:50 2024 -0400

    Add `ilab taxonomy diff`
    
    This change adds a new command `ilab taxonomy diff`. `ilab diff`
    works as an alias and will emit a deprecation warning when used.
    
    Part of https://github.com/instructlab/dev-docs/blob/main/docs/ilab-model-engine.md
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 495773a68882fa40d148305e35536966ee9dabd6
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jun 5 15:47:33 2024 -0400

    Add `ilab system info`
    
    This change adds a new command `ilab system info`. `ilab sysinfo`
    works as an alias and will emit a deprecation warning when used.
    
    Part of https://github.com/instructlab/dev-docs/blob/main/docs/ilab-model-engine.md
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 36e4c49e22ce656ba55ccf688f0d95ba59057706
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jun 5 15:49:30 2024 -0400

    Add `ilab model` command group
    
    This introduces the command group `model`. Several commands will be
    moved into this group in commits following this one.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit bcc905753b3122b2515ad34ff704df99687c626b
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jun 5 15:52:12 2024 -0400

    Add `ilab model chat`
    
    Add `ilab model chat`. Use of `ilab chat` will emit a deprecation
    warning.
    
    https://github.com/instructlab/dev-docs/blob/main/docs/ilab-model-engine.md
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit daa522bc5f428c9eb9d8057143905301fab6963f
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jun 5 15:54:31 2024 -0400

    Add `ilab model convert`
    
    Add `ilab model convert` command. `ilab convert` will emit a
    deprecation warning if used.
    
    Part of https://github.com/instructlab/dev-docs/blob/main/docs/ilab-model-engine.md
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 96b43f510b163766007915778ed98bf59308ceb4
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jun 5 15:56:12 2024 -0400

    Add `ilab model download`
    
    Add command `ilab model download`. The old command `ilab download`
    still works and will emit a deprecation warning if used.
    
    https://github.com/instructlab/dev-docs/blob/main/docs/ilab-model-engine.md
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit b27eb3b035a1360f1710a4e882f14a07033431da
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jun 5 20:46:10 2024 -0400

    Add `ilab model serve`
    
    Both the new command and `ilab serve` both work. The old command will
    emit a deprecation warning if used.
    
    https://github.com/instructlab/dev-docs/blob/main/docs/ilab-model-engine.md
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 6ebf16528e6ee1e0c6c47a79a67e858432ed2397
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jun 5 20:51:45 2024 -0400

    Add `ilab model evaluate`
    
    This new command and `ilab test` both work. The old command will emit
    a deprecation warning if used.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit d34a62870d169395e42b5a6907280771a1f56c72
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jun 5 20:53:34 2024 -0400

    Add `ilab model train`
    
    This command and `ilab train` both work, but the old command will emit
    a deprecation warning if used.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit e6c7f6f93a9b2f75a09ee6a26484f54c253db9b4
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jun 5 21:43:22 2024 -0400

    Adjust `ilab diff` tests to use new `ilab taxonomy diff`
    
    Some of the tests in this file were checking the output of the
    command, which now included a message about using a deprecated
    command. To make all the tests work as before, use the new command
    name.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
