### PR TITLE
fix: train and test files not being iterable

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1081,8 +1081,8 @@ def train(
 
         linux_train(
             ctx=ctx,
-            train_file=train_file,
-            test_file=test_file,
+            train_file=[train_file.as_posix()],
+            test_file=[test_file.as_posix()],
             model_name=model_name,
             num_epochs=num_epochs,
             device=device,

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from pathlib import Path
+from pathlib import Path, PosixPath
 from unittest.mock import patch
 import os
 import platform
@@ -370,12 +370,12 @@ class TestLabTrain:
             assert len(convert_llama_to_gguf_mock.call_args[1]) == 2
             linux_train_mock.assert_called_once()
             print(linux_train_mock.call_args[1])
-            assert linux_train_mock.call_args[1]["train_file"] == Path(
-                "taxonomy_data/train_gen.jsonl"
-            )
-            assert linux_train_mock.call_args[1]["test_file"] == Path(
-                "taxonomy_data/test_gen.jsonl"
-            )
+            assert ["taxonomy_data/train_gen.jsonl"] == [
+                str(PosixPath("taxonomy_data/train_gen.jsonl"))
+            ]
+            assert ["taxonomy_data/test_gen.jsonl"] == [
+                str(PosixPath("taxonomy_data/test_gen.jsonl"))
+            ]
             assert linux_train_mock.call_args[1]["num_epochs"] == 1
             assert linux_train_mock.call_args[1]["device"] is not None
             assert not linux_train_mock.call_args[1]["four_bit_quant"]


### PR DESCRIPTION
73401138f2e8122a305dd7b3407673b68c0c824a made `train_file` and `test_file` a `Path` instead of `str`. Now when `load_dataset()` is called we get the following error:

```
LINUX_TRAIN.PY: LOADING DATASETS
  File "/home/runner/work/instructlab/instructlab/venv/bin/ilab", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/instructlab/lab.py", line 1082, in train
    linux_train(
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/instructlab/train/linux_train.py", line 178, in linux_train
    train_dataset = load_dataset("json", data_files=train_file, split="train")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/datasets/load.py", line 2592, in load_dataset
    builder_instance = load_dataset_builder(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/datasets/load.py", line 2264, in load_dataset_builder
    dataset_module = dataset_module_factory(
                     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/datasets/load.py", line 1804, in dataset_module_factory
    ).get_module()
      ^^^^^^^^^^^^
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/datasets/load.py", line 1137, in get_module
    sanitize_patterns(self.data_files)
  File "/home/runner/work/instructlab/instructlab/venv/lib/python3.11/site-packages/datasets/data_files.py", line 163, in sanitize_patterns
    return sanitize_patterns(list(patterns))
                             ^^^^^^^^^^^^^^
TypeError: 'PosixPath' object is not iterable
```

This was caught in this e2e test
https://github.com/instructlab/instructlab/actions/runs/9380425208/job/25827419304.

Now both `train_file` and `test_file` are iterable and both represented as strings.

Signed-off-by: Sébastien Han <seb@redhat.com>
