### PR TITLE
fix error: TypeError: 'PosixPath' object is not iterable

### DIFF
--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -175,9 +175,9 @@ def linux_train(
 
     print("LINUX_TRAIN.PY: LOADING DATASETS")
     # Get the file name
-    train_dataset = load_dataset("json", data_files=train_file, split="train")
+    train_dataset = load_dataset("json", data_files=str(train_file), split="train")
 
-    test_dataset = load_dataset("json", data_files=test_file, split="train")
+    test_dataset = load_dataset("json", data_files=str(test_file), split="train")
     train_dataset.to_pandas().head()
 
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)


### PR DESCRIPTION
The error was introduced by 73401138f2e8122a305dd7b3407673b68c0c824a:

+    effective_data_dir = Path(data_dir or "./taxonomy_data")
+    train_file = effective_data_dir / "train_gen.jsonl"
+    test_file = effective_data_dir / "test_gen.jsonl"
