### PR TITLE
e2e workflow: add success/failed comments on PR 

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -134,3 +134,17 @@ jobs:
         if: always()
         run: |
           pip cache remove llama_cpp_python
+
+      - name: Add comment to PR if the workflow failed
+        if: failure() && steps.check_pr.outputs.is_pr == 'true'
+        run: |
+          gh pr comment "${{ github.event.inputs.pr_or_branch }}" -b "e2e workflow failed on this PR: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}), please investigate."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add comment to PR if the workflow succeeded
+        if: success() && steps.check_pr.outputs.is_pr == 'true'
+        run: |
+          gh pr comment "${{ github.event.inputs.pr_or_branch }}" -b "e2e workflow succeeded on this PR: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}), congrats!"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,7 +69,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add comment to PR
-        id: pr_comment
         if: steps.check_pr.outputs.is_pr == 'true'
         run: |
           gh pr comment "${{ github.event.inputs.pr_or_branch }}" -b "e2e workflow launched on this PR: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"


### PR DESCRIPTION
Add GitHub Actions steps to comment on PRs based on e2e workflow success
or failure.

Signed-off-by: Sébastien Han <seb@redhat.com>