### PR TITLE
train: fix type violation when passing test_file and train_file

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -1081,8 +1081,8 @@ def train(
 
         linux_train(
             ctx=ctx,
-            train_file=[train_file.as_posix()],
-            test_file=[test_file.as_posix()],
+            train_file=train_file,
+            test_file=test_file,
             model_name=model_name,
             num_epochs=num_epochs,
             device=device,

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+from pathlib import Path
 from typing import Optional
 import logging
 import os
@@ -144,8 +145,8 @@ def report_hpu_device(args_device: torch.device) -> None:
 
 def linux_train(
     ctx: click.Context,
-    train_file: str,
-    test_file: str,
+    train_file: Path,
+    test_file: Path,
     model_name: str,
     num_epochs: Optional[int] = None,
     device: torch.device = torch.device("cpu"),
@@ -175,9 +176,11 @@ def linux_train(
 
     print("LINUX_TRAIN.PY: LOADING DATASETS")
     # Get the file name
-    train_dataset = load_dataset("json", data_files=train_file, split="train")
+    train_dataset = load_dataset(
+        "json", data_files=os.fspath(train_file), split="train"
+    )
 
-    test_dataset = load_dataset("json", data_files=test_file, split="train")
+    test_dataset = load_dataset("json", data_files=os.fspath(test_file), split="train")
     train_dataset.to_pandas().head()
 
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from pathlib import Path, PosixPath
+from pathlib import Path
 from unittest.mock import patch
 import os
 import platform
@@ -370,12 +370,12 @@ class TestLabTrain:
             assert len(convert_llama_to_gguf_mock.call_args[1]) == 2
             linux_train_mock.assert_called_once()
             print(linux_train_mock.call_args[1])
-            assert ["taxonomy_data/train_gen.jsonl"] == [
-                str(PosixPath("taxonomy_data/train_gen.jsonl"))
-            ]
-            assert ["taxonomy_data/test_gen.jsonl"] == [
-                str(PosixPath("taxonomy_data/test_gen.jsonl"))
-            ]
+            assert linux_train_mock.call_args[1]["train_file"] == Path(
+                "taxonomy_data/train_gen.jsonl"
+            )
+            assert linux_train_mock.call_args[1]["test_file"] == Path(
+                "taxonomy_data/test_gen.jsonl"
+            )
             assert linux_train_mock.call_args[1]["num_epochs"] == 1
             assert linux_train_mock.call_args[1]["device"] is not None
             assert not linux_train_mock.call_args[1]["four_bit_quant"]


### PR DESCRIPTION
The linux_train function defines these arguments as `str`, but we are now passing lists of strings. The `load_dataset` function down the stream accepts either a `str` or a sequence of strings.

This patch changes the type of the arguments to `Path` since it's a stronger type. It then converts to string before passing it further to `load_dataset`.

This also reverts a test case change that made the check ineffective because it no longer validated what the code under test did (instead checking that pathlib library behavior is valid.)

This is a follow-up to e1d59105.

