### PR TITLE
Update to Gaudi 1.16.1, add HPU to sysinfo

### DIFF
--- a/containers/hpu/Containerfile
+++ b/containers/hpu/Containerfile
@@ -1,5 +1,5 @@
-ARG HABANA_VERSION=1.15.1
-ARG BASEIMAGE=vault.habana.ai/gaudi-docker/${HABANA_VERSION}/rhel9.2/habanalabs/pytorch-installer-2.2.0
+ARG HABANA_VERSION=1.16.1
+ARG BASEIMAGE=vault.habana.ai/gaudi-docker/${HABANA_VERSION}/rhel9.2/habanalabs/pytorch-installer-2.2.2
 
 FROM ${BASEIMAGE} AS runtime
 # base image has PyTorch fork with Habana plugins in self-compiled Python 3.10
@@ -25,9 +25,8 @@ COPY containers/bin/debug-* ${VIRTUAL_ENV}/bin/
 COPY requirements.txt requirements-hpu.txt /tmp
 RUN sed 's/\[.*\]//' /tmp/requirements.txt >/tmp/constraints.txt && \
     export PIP_NO_CACHE_DIR=off; \
-    ${VIRTUAL_ENV}/bin/pip install wheel && \
-    CMAKE_ARGS="" \
-        CFLAGS="-mno-avx" \
+    ${VIRTUAL_ENV}/bin/pip install -U wheel pip && \
+    CMAKE_ARGS="-DLLAMA_NATIVE=off" \
         FORCE_CMAKE=1 \
         ${VIRTUAL_ENV}/bin/pip install --no-binary llama_cpp_python -c /tmp/constraints.txt llama_cpp_python && \
     ${VIRTUAL_ENV}/bin/pip install -r /tmp/requirements.txt -r /tmp/requirements-hpu.txt && \
@@ -35,7 +34,7 @@ RUN sed 's/\[.*\]//' /tmp/requirements.txt >/tmp/constraints.txt && \
     find ${VIRTUAL_ENV} -name __pycache__ | xargs rm -rf
 
 COPY . /tmp/instructlab
-RUN ${VIRTUAL_ENV}/bin/pip install "/tmp/instructlab[habana]" && \
+RUN ${VIRTUAL_ENV}/bin/pip install "/tmp/instructlab[hpu]" && \
     pip list && \
     find ${VIRTUAL_ENV} -name __pycache__ | xargs rm -rf
 

--- a/docs/habana-gaudi.md
+++ b/docs/habana-gaudi.md
@@ -8,7 +8,7 @@
 
 - RHEL 9 on `x86_64` (tested with RHEL 9.3 and patched installer)
 - Intel Gaudi 2 device
-- [Habana Labs](https://docs.habana.ai/en/latest/index.html) software stack (tested with 1.15.1)
+- [Habana Labs](https://docs.habana.ai/en/latest/index.html) software stack (tested with 1.15.1, 1.16.0, 1.16.1)
 - software from Habana Vault for [RHEL](https://vault.habana.ai/ui/native/rhel) and [PyTorch](https://vault.habana.ai/ui/native/gaudi-pt-modules)
 - software [HabanaAI GitHub](https://github.com/HabanaAI/) org like [optimum-habana](https://github.com/HabanaAI/optimum-habana-fork) fork
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ package-dir = { "" = "src" }
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
+optional-dependencies.hpu = { file = ["requirements-hpu.txt"] }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -1,16 +1,14 @@
 # Dependencies for Intel Gaudi / Habana Labs HPU devices
 #
 
-# upstream version "optimum[habana]>=1.19.0,<2.0.0" does not work
-# use Habana Lab's fork of optimum-habana
-optimum-habana @ git+https://github.com/HabanaAI/optimum-habana-fork.git@5a47add068cb693986eb101becb58aa666f59600
-# Habana Labs 1.15.1 has NumPy 1.23.5
+optimum-habana>=1.11.1
+# Habana Labs 1.16.1 has NumPy 1.23.5
 numpy>=1.23.5,<2.0.0
-# Habana Labs 1.15.1 has PyTorch 2.2.0a0+git8964477
-torch>=2.2.0a0,<3.0.0
+# Habana Labs 1.16.1 has PyTorch 2.2.2a0+gitb5d0b9b
+torch>=2.2.2a0,<3.0.0
 # Habana Labs frameworks
-habana-torch-plugin
-habana_gpu_migration
+habana-torch-plugin>=1.16.1
+habana_gpu_migration>=1.16.1
 # additional Habana Labs packages (installed, but not used)
 #habana-media-loader
 #habana-pyhlml

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,10 +30,11 @@ rouge-score>=0.1.2
 sentencepiece>=0.2.0
 tokenizers>=0.15.2
 toml>=0.10.2
-# Habana installer has 2.2.0a0+git8964477 with oneMKL
+# Intel Gaudi 1.16.1 has torch 2.2.0a0+git8964477 with oneMKL
 torch>=2.2.0a0,<3.0.0 ; python_version == '3.10'
 torch>=2.2.1,<3.0.0 ; python_version != '3.10'
 tqdm>=4.66.2
+# 'optimum' for Intel Gaudi needs transformers <4.39.0,>=4.38.0
 transformers>=4.30.0
 trl>=0.7.11
 wandb>=0.16.4

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -5,7 +5,7 @@
 # Standard
 import logging
 import multiprocessing
-import typing
+import os
 
 # Third Party
 import click
@@ -29,9 +29,9 @@ multiprocessing.set_start_method(cfg.DEFAULT_MULTIPROCESSING_START_METHOD, force
 logging.getLogger("openai").setLevel(logging.ERROR)
 logging.getLogger("httpx").setLevel(logging.ERROR)
 
-if typing.TYPE_CHECKING:
-    # Third Party
-    import torch
+# Intel Gaudi: workaround for race condition in oneMKL [HS-1795]
+# Must be set before torch is imported by an application.
+os.environ["MKL_NUM_THREADS"] = "1"
 
 
 class ExpandAliasesGroup(click.Group):

--- a/src/instructlab/sysinfo.py
+++ b/src/instructlab/sysinfo.py
@@ -69,6 +69,42 @@ def _torch_cuda_info() -> typing.Dict[str, typing.Any]:
     return info
 
 
+def _torch_hpu_info() -> typing.Dict[str, typing.Any]:
+    """Intel Gaudi (HPU) devices"""
+    # pylint: disable=import-outside-toplevel
+    # Third Party
+    import torch
+
+    try:
+        # Third Party
+        from habana_frameworks.torch import hpu
+    except ImportError:
+        return {}
+
+    info = {
+        # 'habana_frameworks' has package name 'habana_torch_plugin'
+        "habana_torch_plugin.version": importlib.metadata.version(
+            "habana_torch_plugin"
+        ),
+        "torch.hpu.is_available": hpu.is_available(),
+    }
+
+    if not info["torch.hpu.is_available"]:
+        return info
+
+    info["torch.hpu.device_count"] = hpu.device_count()
+    for idx in range(hpu.device_count()):
+        device = torch.device("hpu", idx)
+        info[f"torch.hpu.{idx}.name"] = hpu.get_device_name(device)
+        info[f"torch.hpu.{idx}.capability"] = hpu.get_device_capability(device)
+        prop: str = hpu.get_device_properties(device)
+        info[f"torch.hpu.{idx}.properties"] = prop.strip("()")
+    for key, value in sorted(os.environ.items()):
+        if key.startswith(("PT_", "HABANA", "LOG_LEVEL_", "ENABLE_CONSOLE")):
+            info[f"env.{key}"] = value
+    return info
+
+
 def _llama_cpp_info() -> typing.Dict[str, typing.Any]:
     """llama-cpp-python capabilities"""
     # pylint: disable=import-outside-toplevel
@@ -89,6 +125,7 @@ def get_sysinfo() -> typing.Dict[str, typing.Any]:
     info.update(_platform_info())
     info.update(_torch_info())
     info.update(_torch_cuda_info())
+    info.update(_torch_hpu_info())
     info.update(_llama_cpp_info())
     return info
 


### PR DESCRIPTION
Gaudi software 1.16.1 was released on 2024-06-19. Update highlights:

- PyTorch 2.2.2 fork
- transformers 4.38.2
- habana-torch-plugin 1.16.1.7
- optimum-habana 1.11.1 (fork from git no longer needed)

`ilab sysinfo` now also prints HPU-related information like device
properties and environment variables.


`ilab sysinfo` now also prints HPU-related information like device properties and environment variables.

See: https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix.html
See: https://docs.habana.ai/en/latest/Release_Notes/GAUDI_Release_Notes.html

# Changes

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
