### PR TITLE
ci: run e2e job when 2 approvals are given on a PR

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -12,6 +12,7 @@ pull_request_rules:
     - label!=do-not-merge
     - label!=needs-rebase
     - check-success=DCO
+    - label=e2e-success # this will wait for the e2e workflow to pass, this label will be set by the workflow
 
     # If files are changed in .github/, the actionlint check must pass
     - or:
@@ -215,3 +216,18 @@ pull_request_rules:
     label:
       remove:
         - e2e-trigger
+
+- name: Trigger e2e workflow when two approvals are given
+  conditions:
+    - "#approved-reviews-by>=2"
+    - or:
+      - files~=.*\.py$
+      - files=scripts/basic-workflow-tests.sh
+      - files=.github/workflows/e2e.yml
+  actions:
+    github_actions:
+      workflow:
+        dispatch:
+          - workflow: e2e.yml
+            inputs:
+              pr_or_branch: "{{ number }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -146,5 +146,6 @@ jobs:
         if: success() && steps.check_pr.outputs.is_pr == 'true'
         run: |
           gh pr comment "${{ github.event.inputs.pr_or_branch }}" -b "e2e workflow succeeded on this PR: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}), congrats!"
+          gh pr edit "${{ github.event.inputs.pr_or_branch }}" --add-label e2e-success
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,7 +2,10 @@
 
 ## End-to-end CI Job
 
-This CI job is manually triggered by `instructlab` repo triagers or maintainers.
+This CI job is triggered right before merging a PR to the `main` branch when a PR received two
+approvals. Alternatively, it can be triggered manually by adding the `e2e-trigger` label to a PR.
+Additionally, the workflow will be triggered manually by a maintainer before branching a new release.
+
 It runs as much of the `ilab` workflow as it can on the GPU-enabled worker we
 have available through GitHub Actions.
 


### PR DESCRIPTION
The follow-up process occurs in two stages.  First, Mergify triggers the end-to-end (e2e) workflow on a pull request (PR) after it receives two approvals.  Once the e2e workflow runs on the PR, if it succeeds, the workflow adds an 'e2e-success' label to the PR.  Mergify then has a new condition for auto-merging, which relies on the presence of the 'e2e-success' label on the PR.