### PR TITLE
mypy: clean up client.py and chat.py from excludes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,8 +109,6 @@ known-local-folder = ["tuning"]
 [tool.mypy]
 disable_error_code = ["import-not-found", "import-untyped"]
 exclude = [
-    "^src/instructlab/chat/chat\\.py$",
-    "^src/instructlab/client\\.py$",
     "^src/instructlab/generator/generate_data\\.py$",
     "^src/instructlab/generator/utils\\.py$",
     "^src/instructlab/llamacpp/llamacpp_convert_to_gguf\\.py$",


### PR DESCRIPTION
These were tackled by:
https://github.com/instructlab/instructlab/pull/1234
