### PR TITLE
Log funcName instead of asctime.

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -3,6 +3,7 @@
 # pylint: disable=too-many-lines
 
 # Standard
+from datetime import datetime
 from glob import glob
 from os.path import basename, dirname, exists
 from pathlib import Path
@@ -65,6 +66,7 @@ class Lab:
         )
 
         self.logger.setLevel(self.config.general.log_level.upper())
+        self.logger.debug("%s", datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
 
 
 @click.group(cls=DYMGroup)

--- a/src/instructlab/log.py
+++ b/src/instructlab/log.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 
-FORMAT = "%(levelname)s %(asctime)s %(filename)s:%(lineno)d %(message)s"
+FORMAT = "%(levelname)s %(filename)s:%(lineno)d: %(funcName)s %(message)s"
 
 
 class CustomFormatter(logging.Formatter):


### PR DESCRIPTION
Logging timetstamp is very noisy and is not very useful.

Logging function name is much more valuable.
To compensate lack of timestamp dump it on initialization.
