### PR TITLE
Log funcName

### DIFF
--- a/src/instructlab/log.py
+++ b/src/instructlab/log.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 
-FORMAT = "%(levelname)s %(asctime)s %(filename)s:%(lineno)d %(message)s"
+FORMAT = "%(levelname)s %(asctime)s %(filename)s:%(lineno)d: %(funcName)s %(message)s"
 
 
 class CustomFormatter(logging.Formatter):


### PR DESCRIPTION
Add a colon after `lineno` because it is a widely used convention since `grep`.
