### PR TITLE
feat: Allow .yml in addition to .yaml taxonomy files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,21 @@
-# Changes
+<!-- Thank you for contributing to InstructLab! -->
 
-**Which issue is resolved by this Pull Request:**
+<!-- STEPS TO FOLLOW:
+  1. Add a description of the changes (frequently the same as the commit description)
+  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
+  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
+-->
+
+<!-- Uncomment this section with the issue number if an issue is being resolved
+**Issue resolved by this Pull Request:**
 Resolves #
+--->
 
-**Description of your changes:**
+**Checklist:**
+
+- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
+  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
+- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
+- [ ] Documentation has been updated, if necessary.
+- [ ] Unit tests have been added, if necessary.
+- [ ] Integration tests have been added, if necessary.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,7 +78,13 @@ jobs:
       - name: Run mypy type checks
         if: ${{ !cancelled() && (steps.deps.outcome == 'success') }}
         run: |
+          echo "::add-matcher::.github/workflows/matchers/mypy.json"
           tox -e mypy
+
+      - name: Remove mypy matcher
+        if: ${{ !cancelled() && (steps.deps.outcome == 'success') }}
+        run: |
+          echo "::remove-matcher owner=mypy::"
 
       - name: Remove llama-cpp-python from cache
         if: always()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,6 +69,12 @@ jobs:
           echo "::add-matcher::.github/workflows/matchers/pylint.json"
           tox -e lint
 
+      - name: Remove pylint matchers
+        if: ${{ !cancelled() && (steps.deps.outcome == 'success') }}
+        run: |
+          echo "::remove-matcher owner=pylint-error::"
+          echo "::remove-matcher owner=pylint-warning::"
+
       - name: Run mypy type checks
         if: ${{ !cancelled() && (steps.deps.outcome == 'success') }}
         run: |

--- a/.github/workflows/matchers/mypy.json
+++ b/.github/workflows/matchers/mypy.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "mypy",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):\\s(error|warning):\\s(.+)$",
+          "file": 1,
+          "line": 2,
+          "severity": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -30,7 +30,6 @@ permissions:
 
 jobs:
   shellcheck:
-    name: Shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v0.17
 
 ### Features
+We now allow taxonomy qna files with the .yml extension in addion to .yaml.
 
 ### Breaking Changes

--- a/src/instructlab/log.py
+++ b/src/instructlab/log.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 
-FORMAT = "%(levelname)s %(asctime)s %(filename)s:%(lineno)d %(message)s"
+FORMAT = "%(levelname)s %(asctime)s %(filename)s:%(lineno)d: %(funcName)s %(message)s"
 
 
 class CustomFormatter(logging.Formatter):

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -130,7 +130,9 @@ TAXONOMY_FOLDERS: List[str] = ["compositional_skills", "knowledge"]
 
 def istaxonomyfile(fn):
     path = Path(fn)
-    if (path.suffix == ".yaml" or path.suffix == ".yml") and path.parts[0] in TAXONOMY_FOLDERS:
+    if path.suffix in ('.yaml', '.yml') and path.parts[
+        0
+    ] in TAXONOMY_FOLDERS:
         return True
     return False
 
@@ -449,8 +451,10 @@ def read_taxonomy_file(
     errors = 0
     file_path = Path(file_path).resolve()
     # file should end with ".yaml" or ".yml" explicitly
-    if (file_path.suffix != ".yaml" or file_path.suffix != ".yml"):
-        logger.warn(f"Skipping {file_path}! Use lowercase '.yaml' or '.yml' extension instead.")
+    if file_path.suffix not in ('.yaml', '.yml'):
+        logger.warn(
+            f"Skipping {file_path}! Use lowercase '.yaml' or '.yml' extension instead."
+        )
         warnings += 1
         return None, warnings, errors
     for i in range(len(file_path.parts) - 1, -1, -1):

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -130,9 +130,7 @@ TAXONOMY_FOLDERS: List[str] = ["compositional_skills", "knowledge"]
 
 def istaxonomyfile(fn):
     path = Path(fn)
-    if path.suffix in ('.yaml', '.yml') and path.parts[
-        0
-    ] in TAXONOMY_FOLDERS:
+    if path.suffix in ('.yaml', '.yml') and path.parts[0] in TAXONOMY_FOLDERS:
         return True
     return False
 
@@ -452,9 +450,7 @@ def read_taxonomy_file(
     file_path = Path(file_path).resolve()
     # file should end with ".yaml" or ".yml" explicitly
     if file_path.suffix not in ('.yaml', '.yml'):
-        logger.warn(
-            f"Skipping {file_path}! Use lowercase '.yaml' or '.yml' extension instead."
-        )
+        logger.warn(f"Skipping {file_path}! Use lowercase '.yaml' or '.yml' extension instead.")
         warnings += 1
         return None, warnings, errors
     for i in range(len(file_path.parts) - 1, -1, -1):

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -130,7 +130,7 @@ TAXONOMY_FOLDERS: List[str] = ["compositional_skills", "knowledge"]
 
 def istaxonomyfile(fn):
     path = Path(fn)
-    if path.suffix == ".yaml" and path.parts[0] in TAXONOMY_FOLDERS:
+    if (path.suffix == ".yaml" or path.suffix == ".yml") and path.parts[0] in TAXONOMY_FOLDERS:
         return True
     return False
 
@@ -448,9 +448,9 @@ def read_taxonomy_file(
     warnings = 0
     errors = 0
     file_path = Path(file_path).resolve()
-    # file should end with ".yaml" explicitly
-    if file_path.suffix != ".yaml":
-        logger.warn(f"Skipping {file_path}! Use lowercase '.yaml' extension instead.")
+    # file should end with ".yaml" or ".yml" explicitly
+    if (file_path.suffix != ".yaml" or file_path.suffix != ".yml"):
+        logger.warn(f"Skipping {file_path}! Use lowercase '.yaml' or '.yml' extension instead.")
         warnings += 1
         return None, warnings, errors
     for i in range(len(file_path.parts) - 1, -1, -1):


### PR DESCRIPTION
Small change to allow .yml in addition to .yaml taxonomy files

**Issue resolved by this Pull Request:**
Resolves #1306 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [X ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
