### PR TITLE
fix: use all prompts in a batch to generate data

### DIFF
--- a/src/instructlab/data/generator/utils.py
+++ b/src/instructlab/data/generator/utils.py
@@ -146,24 +146,23 @@ def openai_completion(
             raise GenerateException(
                 f"Model {model_name} is not served by the server. These are the served models {model_ids}"
             )
+        for prompt in prompt_batch:
+            messages = [
+                {"role": "system", "content": get_sysprompt()},
+                {"role": "user", "content": prompt},
+            ]
+            # Inference the model
+            try:
+                response = client.chat.completions.create(
+                    messages=messages,
+                    **shared_kwargs,
+                )
+            except OpenAIError as exc:
+                raise GenerateException(
+                    f"There was a problem connecting to the server {exc}"
+                ) from exc
 
-        messages = [
-            {"role": "system", "content": get_sysprompt()},
-            {"role": "user", "content": prompt_batch[batch_id]},
-        ]
-
-        # Inference the model
-        try:
-            response = client.chat.completions.create(
-                messages=messages,
-                **shared_kwargs,
-            )
-        except OpenAIError as exc:
-            raise GenerateException(
-                f"There was a problem connecting to the server {exc}"
-            ) from exc
-
-        completions.extend(response.choices)
+            completions.extend(response.choices)
 
     if return_text:
         completions = [completion.text for completion in completions]


### PR DESCRIPTION
Cnhance the code logic to use all batch prompts when call LLM api.

**Issue resolved by this Pull Request:**
Resolves #1292


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
