### PR TITLE
Updated the readme section for M1/M2/M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
 
    #### Install with Apple Metal on M1/M2/M3 Macs
 
+      > **NOTE**: Make sure your system Python build is `Mach-O 64-bit executable arm64` by using `file -b $(command -v python)`.
+
       ```shell
       python3 -m venv --upgrade-deps venv
       source venv/bin/activate


### PR DESCRIPTION
Especially in old M1/M2 devices, python build could be x86 based instead of arm64, which does not let llama.cpp to use metal. Edited the readme to ensure the user can check for it before attempting the build.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
