### PR TITLE
Harden the GitHub Action workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# GitHub Dependabot configuration file
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "daily"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -24,7 +24,7 @@ pull_request_rules:
     # lint and test must pass if files change that would trigger this job
     - or:
       - and:
-        - check-success=lint
+        - check-success=lint-workflow-complete
         - check-success=test-workflow-complete
         - or:
           # see .github/workflows/lint.yml and test.yml

--- a/.github/workflows/actionlint.dockerfile
+++ b/.github/workflows/actionlint.dockerfile
@@ -1,0 +1,3 @@
+# Since dependabot cannot update workflows using docker,
+# we use this indirection since dependabot can update this file.
+FROM rhysd/actionlint:1.7.1@sha256:435ecdb63b1169e80ca3e136290072548c07fc4d76a044cf5541021712f8f344

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,29 +7,46 @@ on:
       - "main"
       - "release-**"
     paths:
-      - '.github/**'
+      - '.github/workflows/*.ya?ml'
+      - '.github/workflows/actionlint.*' # This workflow
   pull_request:
     branches:
       - "main"
       - "release-**"
     paths:
-      - '.github/**'
+      - '.github/workflows/*.ya?ml'
+      - '.github/workflows/actionlint.*' # This workflow
+
+env:
+  LC_ALL: en_US.UTF-8
 
 defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - name: "Checkout"
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
           submodules: true
-      - name: Download actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.6.27
-      - name: Check workflow files
-        run: PATH=".:$PATH" actionlint -color
+
+      - name: "Download actionlint"
+        run: |
+          docker build --tag actionlint - < .github/workflows/actionlint.dockerfile
+
+      - name: "Check workflow files"
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/actionlint.json"
+          docker run --volume="${PWD}:/repo" --workdir=/repo actionlint -color

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,6 @@
-name: docs
+# SPDX-License-Identifier: Apache-2.0
+
+name: Lint Markdown documents
 
 on:
   push:
@@ -8,6 +10,7 @@ on:
     paths:
       - '**/*.md'
       - '.markdownlint-cli2.yaml'
+      - '.github/workflows/docs.yml' # This workflow
   pull_request:
     branches:
       - "main"
@@ -15,13 +18,31 @@ on:
     paths:
       - '**/*.md'
       - '.markdownlint-cli2.yaml'
+      - '.github/workflows/docs.yml' # This workflow
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
 
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: markdownlint-cli2-action
-        uses: DavidAnson/markdownlint-cli2-action@v15
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+      - name: "Checkout"
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+      - name: "Check Markdown documents"
+        uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8 # v16.0.0
         with:
           globs: '**/*.md'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,8 +18,9 @@ jobs:
       pull-requests: write
 
     steps:
+      # No step-security/harden-runner since this is a self-hosted runner
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
@@ -94,7 +95,7 @@ jobs:
           ls -l /dev/nvidia*
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: 3.11
           cache: pip
@@ -107,7 +108,7 @@ jobs:
           pip cache remove llama_cpp_python
 
       - name: Cache huggingface
-        uses: actions/cache@v4
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: ~/.cache/huggingface
           # config contains DEFAULT_MODEL

--- a/.github/workflows/image-cuda.yml
+++ b/.github/workflows/image-cuda.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Test build cuda container image
 
 on:
@@ -6,13 +8,13 @@ on:
       - main
     paths:
       - 'containers/cuda/Containerfile'
-      - '.github/workflows/image-cuda.yml'
+      - '.github/workflows/image-cuda.yml' # This workflow
   pull_request:
     branches:
       - main
     paths:
       - 'containers/cuda/Containerfile'
-      - '.github/workflows/image-cuda.yml'
+      - '.github/workflows/image-cuda.yml' # This workflow
 
 # Note that the current containerfile builds against a git ref.
 # It is not built against the current source tree. So, we test
@@ -22,6 +24,11 @@ jobs:
     name: Build CUDA image for stable
     runs-on: ubuntu-latest
     steps:
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - name: Free disk space
         run: |
           df -h
@@ -37,20 +44,20 @@ jobs:
           sudo apt-get autoclean -y >/dev/null 2>&1
           df -h
 
-      - name: Check out the repo
-        uses: actions/checkout@v4
+      - name: "Checkout"
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Extract metadata (tags, labels) for gotbot image
         id: gobot_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: |
             ghcr.io/${{ github.repository }}/instructlab-cuda
 
       - name: Build and push gobot image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           context: .
           platforms: linux/amd64
@@ -67,6 +74,11 @@ jobs:
     name: Build CUDA image for main
     runs-on: ubuntu-latest
     steps:
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - name: Free disk space
         run: |
           df -h
@@ -82,20 +94,20 @@ jobs:
           sudo apt-get autoclean -y >/dev/null 2>&1
           df -h
 
-      - name: Check out the repo
-        uses: actions/checkout@v4
+      - name: "Checkout"
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
 
       - name: Extract metadata (tags, labels) for gotbot image
         id: gobot_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: |
             ghcr.io/${{ github.repository }}/instructlab-cuda
 
       - name: Build and push gobot image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,8 @@ on:
       - 'pyproject.toml'
       - 'requirements*.txt'
       - 'tox.ini'
-      - 'scripts/*.sh'
-      - '.github/**'
+      - 'scripts/*.sh' # Used by this workflow
+      - '.github/workflows/lint.yml' # This workflow
   pull_request:
     branches:
       - "main"
@@ -23,25 +23,53 @@ on:
       - 'pyproject.toml'
       - 'requirements*.txt'
       - 'tox.ini'
-      - 'scripts/*.sh'
-      - '.github/**'
+      - 'scripts/*.sh' # Used by this workflow
+      - '.github/workflows/lint.yml' # This workflow
 
 env:
-  PYTHON_VERSION: 3.11
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    name: "${{ matrix.lint.name }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        lint:
+          - name: "ruff"
+            commands: |
+              tox -e ruff -- check
+          - name: "pylint"
+            commands: |
+              echo "::add-matcher::.github/workflows/matchers/pylint.json"
+              tox -e lint
+          - name: "mypy"
+            commands: |
+              echo "::add-matcher::.github/workflows/matchers/mypy.json"
+              tox -e mypy
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - name: "Checkout"
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
           submodules: true
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: 3.11
           cache: pip
@@ -51,42 +79,29 @@ jobs:
 
       - name: Remove llama-cpp-python from cache
         run: |
-          pip cache remove llama_cpp_python
+          python -m pip cache remove llama_cpp_python
 
-      - name: Install dependencies
-        id: deps
+      - name: "Install tox"
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox
+          python -m pip install tox tox-gh
 
-      - name: Run Ruff check
+      - name: "${{ matrix.lint.name }}"
         run: |
-          tox -e ruff -- check
-
-      - name: Run linting
-        if: ${{ !cancelled() && (steps.deps.outcome == 'success') }}
-        run: |
-          echo "::add-matcher::.github/workflows/matchers/pylint.json"
-          tox -e lint
-
-      - name: Remove pylint matchers
-        if: ${{ !cancelled() && (steps.deps.outcome == 'success') }}
-        run: |
-          echo "::remove-matcher owner=pylint-error::"
-          echo "::remove-matcher owner=pylint-warning::"
-
-      - name: Run mypy type checks
-        if: ${{ !cancelled() && (steps.deps.outcome == 'success') }}
-        run: |
-          echo "::add-matcher::.github/workflows/matchers/mypy.json"
-          tox -e mypy
-
-      - name: Remove mypy matcher
-        if: ${{ !cancelled() && (steps.deps.outcome == 'success') }}
-        run: |
-          echo "::remove-matcher owner=mypy::"
+          ${{ matrix.lint.commands }}
+        env:
+          RUFF_OUTPUT_FORMAT: github
 
       - name: Remove llama-cpp-python from cache
         if: always()
         run: |
-          pip cache remove llama_cpp_python
+          python -m pip cache remove llama_cpp_python
+
+  lint-workflow-complete:
+    needs:
+      - "lint"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint Workflow Complete
+        run: |
+          echo "Lint Workflow Complete"

--- a/.github/workflows/matchers/actionlint.json
+++ b/.github/workflows/matchers/actionlint.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,4 +1,5 @@
----
+# SPDX-License-Identifier: Apache-2.0
+
 name: Build, test, and upload PyPI package
 
 on:
@@ -16,6 +17,13 @@ on:
         types:
             - published
 
+env:
+    LC_ALL: en_US.UTF-8
+
+defaults:
+    run:
+        shell: bash
+
 permissions:
     contents: read
 
@@ -28,13 +36,18 @@ jobs:
         name: Build and check packages
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - name: "Harden Runner"
+              uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+              with:
+                  egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+            - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
               with:
                   # for setuptools-scm
                   fetch-depth: 0
                   submodules: true
 
-            - uses: hynek/build-and-inspect-python-package@v2
+            - uses: hynek/build-and-inspect-python-package@b4fc3f6ba2b3da04f09659be99e2a29fb6146a61 # v2.6.0
 
     # push to Test PyPI on
     # - a new GitHub release is published
@@ -55,14 +68,19 @@ jobs:
         needs: build-package
 
         steps:
+            - name: "Harden Runner"
+              uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+              with:
+                  egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
             - name: Fetch build artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
               with:
                   name: Packages
                   path: dist
 
             - name: Upload to Test PyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
+              uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
               with:
                   repository-url: https://test.pypi.org/legacy/
 
@@ -83,13 +101,18 @@ jobs:
         needs: build-package
 
         steps:
+            - name: "Harden Runner"
+              uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+              with:
+                  egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
             - name: Fetch build artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
               with:
                   name: Packages
                   path: dist
 
-            - uses: sigstore/gh-action-sigstore-python@v2.1.1
+            - uses: sigstore/gh-action-sigstore-python@61f6a500bbfdd9a2a339cf033e5421951fbc1cd2 # v2.1.1
               with:
                   inputs: >-
                       ./dist/*.tar.gz
@@ -107,4 +130,4 @@ jobs:
               run: rm ./dist/*.sigstore
 
             - name: Upload to PyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
+              uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -32,15 +32,20 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
           submodules: true
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           check_together: 'yes'
           format: gcc

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -9,7 +9,16 @@ on:
       - "release-**"
     paths:
       - '**.md'
-      - .github/**
+      - 'tox.ini'
+      - '.spellcheck*'
+      - '.github/workflows/spellcheck.yaml' # This workflow file
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
 
 permissions:
   contents: read
@@ -19,8 +28,13 @@ jobs:
     name: Spellcheck (en_US)
     runs-on: ubuntu-latest
     steps:
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -1,7 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: 'Close stale issues and PRs'
+
 on:
   schedule:
     - cron: '30 1 * * *'
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
 
 permissions:
   issues: write
@@ -11,7 +21,12 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           days-before-stale: 90
           days-before-close: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ on:
       - 'pyproject.toml'
       - 'requirements*.txt'
       - 'tox.ini'
-      - 'scripts/*.sh'
-      - '.github/**'
+      - 'scripts/*.sh' # Used by this workflow
+      - '.github/workflows/test.yml' # This workflow
   pull_request:
     branches:
       - "main"
@@ -24,8 +24,18 @@ on:
       - 'pyproject.toml'
       - 'requirements*.txt'
       - 'tox.ini'
-      - 'scripts/*.sh'
-      - '.github/**'
+      - 'scripts/*.sh' # Used by this workflow
+      - '.github/workflows/test.yml' # This workflow
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -48,8 +58,13 @@ jobs:
           - python: "3.11"
             platform: "macos-latest"
     steps:
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
@@ -66,7 +81,7 @@ jobs:
           brew install expect coreutils bash
 
       - name: Setup Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: ${{ matrix.python }}
           cache: pip
@@ -79,7 +94,7 @@ jobs:
           pip cache remove llama_cpp_python
 
       - name: Cache huggingface
-        uses: actions/cache@v4
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: ~/.cache/huggingface
           # config contains DEFAULT_MODEL
@@ -91,7 +106,8 @@ jobs:
           python -m pip install tox tox-gh>=1.2
 
       - name: Run unit and functional tests with tox
-        run: tox
+        run: |
+          tox
 
       - name: Remove llama-cpp-python from cache
         if: always()
@@ -108,15 +124,20 @@ jobs:
   man:
     runs-on: ubuntu-latest
     steps:
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
           submodules: true
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: 3.11
           cache: pip
@@ -129,12 +150,14 @@ jobs:
           pip cache remove llama_cpp_python
 
       - name: Run tox docs target (expect failure since tox is not present)
-        run: make man
+        run: |
+          make man
         continue-on-error: true
 
       - name: Run tox docs target
         id: tox-docs
-        run: make man || echo "status=failed" >> "$GITHUB_OUTPUT"
+        run: |
+          make man || echo "status=failed" >> "$GITHUB_OUTPUT"
         continue-on-error: true
 
       - name: Check for 'make man' failure
@@ -150,10 +173,11 @@ jobs:
           python -m pip install tox
 
       - name: Run tox docs target
-        run: make man
+        run: |
+          make man
 
       - name: Check that man pages were generated
-        uses: andstor/file-existence-action@v3
+        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
         with:
           files: 'man/*.1'
           fail: true

--- a/.github/workflows/validate-notebooks.yml
+++ b/.github/workflows/validate-notebooks.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Validate Notebooks
 
 on:
@@ -7,29 +9,44 @@ on:
       - "release-**"
     paths:
       - 'notebooks/*.ipynb'
+      - 'scripts/*.sh' # Used by this workflow
+      - '.github/workflows/validate-notebooks.yml' # This workflow
   pull_request:
     branches:
       - "main"
       - "release-**"
     paths:
       - 'notebooks/*.ipynb'
+      - 'scripts/*.sh' # Used by this workflow
+      - '.github/workflows/validate-notebooks.yml' # This workflow
 
 env:
-  PYTHON_VERSION: 3.11
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
 
 jobs:
   validate-notebook:
     runs-on: ubuntu-latest
     steps:
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           # https://github.com/actions/checkout/issues/249
           fetch-depth: 0
           submodules: true
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: 3.11
           cache: pip
@@ -40,4 +57,5 @@ jobs:
           python -m pip install nbformat
 
       - name: Validate Jupyter Notebooks
-        run: find notebooks/ -name "*.ipynb" -print0 | xargs python scripts/validate_notebook.py
+        run: |
+          find notebooks/ -name "*.ipynb" -print0 | xargs python scripts/validate_notebook.py


### PR DESCRIPTION
We use SHAs instead of tag names to refer to action versions. Dependabot
will help us manage the SHAs.

Update permissions to minimum necessary.

Add harden-runner to monitor egress of action. After some time, we can
tighten the egress to limit hosts/ports.

We also parallelize the lint workflow's linting work.

**Issue resolved by this Pull Request:**
Resolves #1218 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
