### PR TITLE
add debug logging to chat

### DIFF
--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -279,6 +279,7 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
         greedy_mode=False,
         max_tokens=None,
     ):
+        logger.debug("ConsoleChatBot")
         self.client = client
         self.model = model
         self.vi_mode = vi_mode
@@ -515,10 +516,10 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
 
     def start_prompt(
         self,
-        logger,  # pylint: disable=redefined-outer-name
         content=None,
         box=True,
     ):
+        logger.debug("")
         handlers = {
             "/q": self._handle_quit,
             "quit": self._handle_quit,
@@ -675,6 +676,7 @@ def chat_cli(
     max_tokens,
 ):
     """Starts a CLI-based chat with the server"""
+    logger.debug("creating OpenAI client")
     client = OpenAI(
         base_url=api_base,
         api_key=ctx.params["api_key"],
@@ -753,7 +755,7 @@ def chat_cli(
         if not qq:
             print(f"{PROMPT_PREFIX}{question}")
         try:
-            ccb.start_prompt(logger, content=question, box=not qq)
+            ccb.start_prompt(content=question, box=not qq)
         except ChatException as exc:
             raise ChatException(f"API issue found while executing chat: {exc}") from exc
         except (ChatQuitException, KeyboardInterrupt, EOFError):
@@ -769,7 +771,7 @@ def chat_cli(
     # Start chatting
     while True:
         try:
-            ccb.start_prompt(logger)
+            ccb.start_prompt()
         except KeyboardInterrupt:
             continue
         except ChatException as exc:


### PR DESCRIPTION
To assist debugging and reverse engineering.

Samples of messages:
```
DEBUG 2024-06-11 13:59:39,057 lab.py:697: chat 
DEBUG 2024-06-11 15:43:01,308 chat.py:482: chat_cli creating OpenAI client
DEBUG 2024-06-11 15:43:01,351 chat.py:81: __init__ ConsoleChatBot
DEBUG 2024-06-11 14:01:23,895 chat.py:315: start_prompt 

```
