### PR TITLE
github: Run lint job when any scripts change

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ on:
       - 'pyproject.toml'
       - 'requirements*.txt'
       - 'tox.ini'
-      - 'scripts/*.sh'
+      - 'scripts/**/*.sh'
       - '.github/**'
   pull_request:
     branches:
@@ -23,7 +23,7 @@ on:
       - 'pyproject.toml'
       - 'requirements*.txt'
       - 'tox.ini'
-      - 'scripts/*.sh'
+      - 'scripts/**/*.sh'
       - '.github/**'
 
 env:


### PR DESCRIPTION
This change address a mismatch in configuration between this workflow
and the Mergify configuration. This change makes the lint workflow
align with the Mergify configuration.

PR #1217 introduced a new script within a subdirectory under
`scripts/`. The lint job didn't run and mergify won't merge it because
it's expecting it to run.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
