### PR TITLE
fix: Indent help epilog alias list

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -60,7 +60,7 @@ class ExpandAliasesGroup(click.Group):
             formatter.write_text("Aliases:")
             with formatter.indentation():
                 for alias, commands in sorted(self.aliases.items()):
-                    formatter.write(
+                    formatter.write_text(
                         "{}: {} {}\n".format(
                             alias, commands["group"].name, commands["cmd"].name
                         )


### PR DESCRIPTION
The list of aliases below the Aliases header should be indented.

**Issue resolved by this Pull Request:**
Resolves #1324 


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
