### PR TITLE
get abspath for each served model and the path provided

### DIFF
--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -693,7 +693,14 @@ def chat_cli(
     model_ids = []
     for m in model_list:
         model_ids.append(m.id)
-    if not any(model == m for m in model_ids):
+
+    model_found = False
+    for m in model_ids:
+        if os.path.abspath(m) == os.path.abspath(model):
+            model_found = True
+            break
+
+    if not model_found:
         if model == cfg.DEFAULTS.MODEL_NAME_OLD:
             logger.info(
                 f"Model {model} is not a full path. Try running ilab config init or edit your config to have the full model path for serving, chatting, and generation."


### PR DESCRIPTION
if either the path in the config, the path being served, or the path specified by the user on runtime is an absolute/relative path to the same gguf, we fail since currenty we do not expand relative paths. get the abspath when checking if a model is served.

**Issue resolved by this Pull Request:**
resolves #1338

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
