### PR TITLE
e2e: Run on PRs and pushes

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -21,6 +21,21 @@ pull_request_rules:
         - check-success=actionlint
       - -files~=.github/.*$
 
+    # e2e workflow
+    - or:
+      - and:
+        - check-success=e2e
+        - or:
+          - files~='.*\.py$'
+          - files~=pyproject.toml$
+          - files~=requirements.*\.txt$
+          - files~=.github/workflows/e2e.yml$
+      - and:
+        - -files~='.*\.py$'
+        - -files~=pyproject.toml$
+        - -files~=requirements.*\.txt$
+        - -files~=.github/workflows/e2e.yml$
+
     # lint and test must pass if files change that would trigger this job
     - or:
       - and:
@@ -201,17 +216,3 @@ pull_request_rules:
     label:
       remove:
         - one-approval
-
-- name: Trigger e2e workflow based on the 'e2e-trigger' label
-  conditions:
-    - label=e2e-trigger
-  actions:
-    github_actions:
-      workflow:
-        dispatch:
-          - workflow: e2e.yml
-            inputs:
-              pr_or_branch: "{{ number }}"
-    label:
-      remove:
-        - e2e-trigger

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,24 @@ on:
         description: 'pull request number or branch name'
         required: true
         default: 'main'
+  push:
+    branches:
+      - "main"
+      - "release-**"
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - '.github/workflows/e2e.yml'
+  pull_request:
+    branches:
+      - "main"
+      - "release-**"
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - '.github/workflows/e2e.yml'
 
 jobs:
   e2e:


### PR DESCRIPTION
The e2e workflow seems stable and I've cleared the budget side of
running this a lot more often. Turn on running it on all code changes.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
