### PR TITLE
fix: output right trained model path

### DIFF
--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -288,6 +288,7 @@ def train(
             file.unlink()
 
         shutil.move(gguf_file_path, gguf_models_file)
+        print(f"Save trained model to {gguf_models_file}")
 
         # cleanup checkpoint dir since it's name is unpredictable
         # TODO: figure out how checkpoint dirs should be cleaned up


### PR DESCRIPTION
The fix is output right trained model path on linux.


**Issue resolved by this Pull Request:**
Resolves #https://github.com/instructlab/instructlab/issues/1289


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
