### PR TITLE
mergify: allow auto-merge for specific script without requiring lint/…

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -32,13 +32,13 @@ pull_request_rules:
           - files~=pyproject.toml$
           - files~=requirements.*\.txt$
           - files~=tox.ini$
-          - files~=scripts/.*\.sh$
+          - files~=scripts/[^/]+\.sh$
       - and:
         - -files~=.*\.py$
         - -files~=pyproject.toml$
         - -files~=requirements.*\.txt$
         - -files~=tox.ini$
-        - -files~=scripts/.*\.sh$
+        - -files~=scripts/[^/]+\.sh$
 
     - or:
       - and:


### PR DESCRIPTION
…test checks

Updated Mergify configuration to support automatic merging when shell files
in `scripts/infra/` are modified. This change modifies the current
linter's regex to ignore all .sh files of not at the root of `scripts`.

This change aims to improve the merge workflow and reduce unnecessary
blocking for specific file changes.

Signed-off-by: Sébastien Han <seb@redhat.com>

Alternative approach to https://github.com/instructlab/instructlab/pull/1330

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
