### PR TITLE
refactor: rename init_config to init

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -249,7 +249,7 @@ class Lab:
         self.logger.setLevel(self.config.general.log_level.upper())
 
 
-def init_config(ctx, config_file):
+def init(ctx, config_file):
     if (
         ctx.invoked_subcommand not in {"config", "init", "sysinfo"}
         and "--help" not in sys.argv[1:]

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -98,7 +98,7 @@ def ilab(ctx, config_file):
 
     If this is your first time running ilab, it's best to start with `ilab init` to create the environment.
     """
-    cfg.init_config(ctx, config_file)
+    cfg.init(ctx, config_file)
 
 
 ilab.add_command(model_group.model)


### PR DESCRIPTION
`ìnit_config()` is already part of the `config` package so it's redundant to call it `init_config()` especially when calling the import like so, `config.init_config()`.

Closes: https://github.com/instructlab/instructlab/issues/1323
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
