### PR TITLE
add debug information to display command parameters

### DIFF
--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -8,6 +8,7 @@ import click
 
 # First Party
 from instructlab import configuration as config
+from instructlab import utils
 
 
 @click.command()
@@ -123,6 +124,7 @@ from instructlab import configuration as config
     help="Force model family to use when picking a generation template",
 )
 @click.pass_context
+@utils.display_params
 def generate(
     ctx,
     model,

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -27,6 +27,7 @@ import openai
 # First Party
 from instructlab import client
 from instructlab import configuration as cfg
+from instructlab import utils
 from instructlab.server import is_temp_server_running
 
 # Local
@@ -146,6 +147,7 @@ PROMPT_PREFIX = ">>> "
     help="Force model family to use when picking a chat template",
 )
 @click.pass_context
+@utils.display_params
 def chat(
     ctx,
     question,

--- a/src/instructlab/model/convert.py
+++ b/src/instructlab/model/convert.py
@@ -41,6 +41,7 @@ from instructlab import utils
 )
 @utils.macos_requirement(echo_func=click.secho, exit_exception=click.exceptions.Exit)
 @click.pass_context
+@utils.display_params
 def convert(ctx, model_dir, adapter_file, skip_de_quantize, skip_quantize, model_name):
     """Converts model to GGUF"""
     # pylint: disable=C0415

--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -12,6 +12,7 @@ import click
 
 # First Party
 from instructlab import configuration as config
+from instructlab import utils
 
 
 @click.command()
@@ -46,6 +47,7 @@ from instructlab import configuration as config
     help="User access token for connecting to the Hugging Face Hub.",
 )
 @click.pass_context
+@utils.display_params
 def download(ctx, repository, release, filename, model_dir, hf_token):
     """Download the model(s) to train"""
     click.echo(f"Downloading model from {repository}@{release} to {model_dir}...")

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -5,7 +5,7 @@ import click
 
 # First Party
 from instructlab import configuration as config
-from instructlab import log
+from instructlab import log, utils
 from instructlab.server import ServerException, server
 
 
@@ -39,6 +39,7 @@ from instructlab.server import ServerException, server
     help="Log file path to write server logs to.",
 )
 @click.pass_context
+@utils.display_params
 def serve(
     ctx, model_path, gpu_layers, num_threads, max_ctx_size, model_family, log_file
 ):

--- a/src/instructlab/model/test.py
+++ b/src/instructlab/model/test.py
@@ -31,6 +31,7 @@ from instructlab import utils
     show_default=True,
 )
 @utils.macos_requirement(echo_func=click.secho, exit_exception=click.exceptions.Exit)
+@utils.display_params
 # pylint: disable=function-redefined
 def test(data_dir, model_dir, adapter_file):
     """Runs basic test to ensure model correctness"""

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -154,6 +154,7 @@ TORCH_DEVICE = TorchDeviceParam()
     help="model name to use in training",
 )
 @click.pass_context
+@utils.display_params
 def train(
     ctx,
     data_dir,

--- a/src/instructlab/taxonomy/diff.py
+++ b/src/instructlab/taxonomy/diff.py
@@ -37,6 +37,7 @@ from instructlab.data import generator
     help="Suppress all output. Call returns 0 if check passes, 1 otherwise.",
 )
 @click.pass_context
+@utils.display_params
 def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
     """
     Lists taxonomy files that have changed since <taxonomy-base>

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Mapping, Optional, Union
 import copy
 import glob
 import json
+import logging
 import os
 import platform
 import re
@@ -613,3 +614,26 @@ def http_client(params):
         ),
         verify=not params["tls_insecure"],
     )
+
+
+def display_params(func):
+    """Display command parameters."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            if (args[0].obj.logger.level == logging.DEBUG) and (
+                ("quiet" not in kwargs) or (not kwargs["quiet"])
+            ):
+                print("===================using parameters ========================")
+                max_param_length = max(len(param) for param in kwargs)
+                for param_name, param_value in kwargs.items():
+                    print(
+                        f"{param_name}{' ' * (max_param_length - len(param_name)):s}: {param_value}"
+                    )
+                print("============================================================")
+        except Exception:
+            pass
+        return func(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
Show command parameters when enable debug, e.g.
```
(dlipy3) [root@churh1 lab]# ilab generate
You are using an aliased command, this will be deprecated in a future release. Please consider using `ilab data generate` instead
===================== using parameters ===================
model            : models/merlinite-7b-lab-Q4_K_M.gguf
num_cpus         : 10
chunk_word_count : 1000
num_instructions : 100
taxonomy_path    : taxonomy
taxonomy_base    : origin/main
output_dir       : generated
rouge_threshold  : 0.9
quiet            : False
endpoint_url     : None
api_key          : no_api_key
yaml_rules       : None
server_ctx_size  : 4096
tls_insecure     : False
tls_client_cert  : 
tls_client_key   : 
tls_client_passwd: 
model_family     : None
===========================================================
llama_cpp_python is built without hardware acceleration. ilab generate will be very slow.
....


```

**Issue resolved by this Pull Request:**
Resolves #1223


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
