### PR TITLE
test: clearer banner when func test fails

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -26,7 +26,13 @@ chat_shot="ilab chat -qq"
 cleanup() {
     set +e
     if [ "${1:-0}" -ne 0 ]; then
-        echo "Error occurred in function: ${FUNCNAME[1]} with exit code: $1"
+        printf "\n\n"
+        printf "\e[31m=%.0s\e[0m" {1..80}
+        printf "\n\e[31mERROR OCCURRED\e[0m\n"
+        printf "\e[31mFunction: %s\e[0m\n" "${FUNCNAME[1]}"
+        printf "\e[31mExit Code: %s\e[0m\n" "$1"
+        printf "\e[31m=%.0s\e[0m" {1..80}
+        printf "\n\n"
     fi
     for pid in $PID_SERVE $PID_CHAT; do
         if [ -n "$pid" ]; then


### PR DESCRIPTION
The log error message was a bit lost in the flow of logs, so now we print a banner containing the function that failed and the exit code.

It looks like:

```
================================================================================
ERROR OCCURRED
Function: main
Exit Code: 1
================================================================================
```

And should be printed in red.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
