### PR TITLE
fix: Remove duplicate --version option

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -81,7 +81,6 @@ aliases = {
 
 
 @click.group(cls=ExpandAliasesGroup, aliases=aliases)
-@click.version_option(package_name="instructlab")
 @click.option(
     "--config",
     "config_file",


### PR DESCRIPTION
This commit removes the duplicate `--version` option from the `--help` command. The `--version` option was previously added twice, causing confusion and redundancy in the help menu.

Fixes #1355

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
