### PR TITLE
fix: do not stack trace when no data dir

### DIFF
--- a/src/instructlab/model/test.py
+++ b/src/instructlab/model/test.py
@@ -52,6 +52,12 @@ def test(data_dir, model_dir, adapter_file):
 
     # Load the JSON Lines file
     test_data_dir = f"{data_dir}/test.jsonl"
+    if not os.path.exists(test_data_dir):
+        click.secho(
+            f"'{test_data_dir}' not such file or directory. Did you run 'ilab model train'?",
+            fg="red",
+        )
+        raise click.exceptions.Exit(1)
     with open(test_data_dir, "r", encoding="utf-8") as f:
         test_data = [json.loads(line) for line in f]
 

--- a/src/instructlab/model/test.py
+++ b/src/instructlab/model/test.py
@@ -46,7 +46,7 @@ def test(data_dir, model_dir, adapter_file):
     adapter_file_exists = adapter_file and os.path.exists(adapter_file)
     if adapter_file and not adapter_file_exists:
         print(
-            "NOTE: Adapter file does not exist. Testing behavior before training only. - %s\n"
+            "NOTE: Adapter file does not exist. Testing behavior before training only. - %s"
             % adapter_file
         )
 


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

When running 'ilab model test' with an empty of non-existent data dir
(`taxonomy_data`), the CLI was stack tracing, now we gently print an
error.

Closes: #1360
Signed-off-by: Sébastien Han <seb@redhat.com>

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
