### PR TITLE
reduce number of list_models and ensure_server arguments

### DIFF
--- a/src/instructlab/client.py
+++ b/src/instructlab/client.py
@@ -1,16 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=duplicate-code
 
-# Standard
-from typing import Optional
-
 # Third Party
 from openai import OpenAI, OpenAIError
-import httpx
 
 # Local
 from .configuration import DEFAULT_API_KEY, DEFAULT_CONNECTION_TIMEOUT
-from .utils import get_ssl_cert_config
 
 
 class ClientException(Exception):
@@ -19,21 +14,16 @@ class ClientException(Exception):
 
 def list_models(
     api_base,
-    tls_insecure,
     api_key=DEFAULT_API_KEY,
-    tls_client_cert: Optional[str] = None,
-    tls_client_key: Optional[str] = None,
-    tls_client_passwd: Optional[str] = None,
+    http_client=None,
 ):
     """List models from OpenAI-compatible server"""
     try:
-        cert = get_ssl_cert_config(tls_client_cert, tls_client_key, tls_client_passwd)
-        verify = not tls_insecure
         client = OpenAI(
             base_url=api_base,
             api_key=api_key,
             timeout=DEFAULT_CONNECTION_TIMEOUT,
-            http_client=httpx.Client(cert=cert, verify=verify),
+            http_client=http_client,
         )
         return client.models.list()
     except OpenAIError as exc:

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -154,6 +154,9 @@ def generate(
     from instructlab.sdg.generate_data import generate_data
     from instructlab.sdg.utils import GenerateException
 
+    # Local
+    from ..utils import http_client
+
     prompt_file_path = config.DEFAULT_PROMPT_FILE
     if ctx.obj is not None:
         prompt_file_path = ctx.obj.config.generate.prompt_file
@@ -171,7 +174,7 @@ def generate(
         try:
             # Run the llama server
             backend_instance.run_detached(
-                tls_insecure, tls_client_cert, tls_client_key, tls_client_passwd
+                http_client(ctx.params),
             )
             # api_base will be set by run_detached
             api_base = backend_instance.api_base

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -78,9 +78,7 @@ class BackendServer(abc.ABC):
         """Run serving backend in foreground (ilab model serve)"""
 
     @abc.abstractmethod
-    def run_detached(
-        self, tls_insecure, tls_client_cert, tls_client_key, tls_client_passwd
-    ):
+    def run_detached(self, http_client):
         """Run serving backend in background ('ilab model chat' when server is not running)"""
 
     @abc.abstractmethod
@@ -218,10 +216,7 @@ def ensure_server(
     logger: logging.Logger,
     backend: str,
     api_base: str,
-    tls_insecure: bool,
-    tls_client_cert: Optional[str] = None,
-    tls_client_key: Optional[str] = None,
-    tls_client_passwd: Optional[str] = None,
+    http_client=None,
     host="localhost",
     port=8000,
     queue=None,
@@ -235,10 +230,7 @@ def ensure_server(
         # pylint: disable=duplicate-code
         list_models(
             api_base=api_base,
-            tls_insecure=tls_insecure,
-            tls_client_cert=tls_client_cert,
-            tls_client_key=tls_client_key,
-            tls_client_passwd=tls_client_passwd,
+            http_client=http_client,
         )
         return (None, None, None)
         # pylint: enable=duplicate-code
@@ -284,10 +276,7 @@ def ensure_server(
                 try:
                     list_models(
                         api_base=temp_api_base,
-                        tls_insecure=tls_insecure,
-                        tls_client_cert=tls_client_cert,
-                        tls_client_key=tls_client_key,
-                        tls_client_passwd=tls_client_passwd,
+                        http_client=http_client,
                     )
                     logger.debug(f"model at {temp_api_base} served on vLLM")
                     break
@@ -315,10 +304,7 @@ def ensure_server(
                 try:
                     list_models(
                         api_base=temp_api_base,
-                        tls_insecure=tls_insecure,
-                        tls_client_cert=tls_client_cert,
-                        tls_client_key=tls_client_key,
-                        tls_client_passwd=tls_client_passwd,
+                        http_client=http_client,
                     )
                     break
                 except ClientException:

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -91,17 +91,15 @@ class Server(BackendServer):
         return server_process
 
     def run_detached(
-        self, tls_insecure, tls_client_cert, tls_client_key, tls_client_passwd
+        self,
+        http_client,
     ):
         try:
             llama_cpp_server_process, _, api_base = ensure_server(
                 logger=self.logger,
                 backend=LLAMA_CPP,
                 api_base=self.api_base,
-                tls_insecure=tls_insecure,
-                tls_client_cert=tls_client_cert,
-                tls_client_key=tls_client_key,
-                tls_client_passwd=tls_client_passwd,
+                http_client=http_client,
                 host=self.host,
                 port=self.port,
                 queue=self.queue,

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -67,19 +67,17 @@ class Server(BackendServer):
         return server_process
 
     def run_detached(
-        self, tls_insecure, tls_client_cert, tls_client_key, tls_client_passwd
+        self,
+        http_client,
     ):
         try:
             _, vllm_server_process, api_base = ensure_server(
                 logger=self.logger,
                 backend=VLLM,
                 api_base=self.api_base,
+                http_client=http_client,
                 host=self.host,
                 port=self.port,
-                tls_insecure=tls_insecure,
-                tls_client_cert=tls_client_cert,
-                tls_client_key=tls_client_key,
-                tls_client_passwd=tls_client_passwd,
                 server_process_func=self.create_server_process,
             )
             self.process = vllm_server_process

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -158,10 +158,10 @@ def chat(
     max_tokens,
     endpoint_url,
     api_key,  # pylint: disable=unused-argument
-    tls_insecure,
-    tls_client_cert,
-    tls_client_key,
-    tls_client_passwd,
+    tls_insecure,  # pylint: disable=unused-argument
+    tls_client_cert,  # pylint: disable=unused-argument
+    tls_client_key,  # pylint: disable=unused-argument
+    tls_client_passwd,  # pylint: disable=unused-argument
     model_family,
 ):
     """Run a chat using the modified model"""
@@ -183,7 +183,7 @@ def chat(
         try:
             # Run the llama server
             backend_instance.run_detached(
-                tls_insecure, tls_client_cert, tls_client_key, tls_client_passwd
+                http_client(ctx.params),
             )
             # api_base will be set by run_detached
             api_base = backend_instance.api_base
@@ -215,10 +215,7 @@ def chat(
             try:
                 models = ilabclient.list_models(
                     api_base=api_base,
-                    tls_insecure=tls_insecure,
-                    tls_client_cert=tls_client_cert,
-                    tls_client_key=tls_client_key,
-                    tls_client_passwd=tls_client_passwd,
+                    http_client=http_client(ctx.params),
                 )
 
                 # Currently, we only present a single model so we can safely assume that the first model


### PR DESCRIPTION
Use one argument http_client instead of four: tls_insecure, tls_client_cert, tls_client_key, tls_client_passwd.