### PR TITLE
fix glob import

### DIFF
--- a/src/instructlab/model/convert.py
+++ b/src/instructlab/model/convert.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+from glob import glob
 from pathlib import Path
-import glob
 import os
 import shutil
 


### PR DESCRIPTION
in the old cmd structure, lab.py must have done `from glob import glob`. the new convert.py just has `import glob`.

**Issue resolved by this Pull Request:**
Resolves #1371 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
