### PR TITLE
fix: support chat/generate command use custom model path(via '--model')

### DIFF
--- a/src/instructlab/client.py
+++ b/src/instructlab/client.py
@@ -18,6 +18,10 @@ class ClientException(Exception):
     """An exception raised when invoking client operations."""
 
 
+class ModelCheckException(Exception):
+    """An exception raised when checking model."""
+
+
 def list_models(
     api_base,
     api_key=DEFAULTS.API_KEY,
@@ -43,3 +47,23 @@ def check_api_base(api_base: str, http_client: httpx.Client | None = None) -> bo
         return True
     except ClientException:
         return False
+
+
+def check_model(model, api_base: str, endpoint_url=None, http_client=None):
+    """Check if right model is selected or served."""
+    if endpoint_url:
+        api_base = endpoint_url
+    model_list = list_models(
+        api_base=api_base,
+        http_client=http_client,
+    )
+    if len(model_list.data) == 0:
+        raise ModelCheckException("No model is served")
+
+    model_ids = [m.id for m in model_list.data]
+    if model not in model_ids:
+        if endpoint_url:
+            msg = f"Model {model} is not served by the endpoint url {endpoint_url}. These are the served models: {model_ids}. Use '--model' to select right model to use."
+        else:
+            msg = f"Model {model} is not served by the server. These are the served models: {model_ids}. Use '--model' to select right model to use. Serve the model {model} by running 'ilab serve --model-path {model}' or update the configuration file"
+        raise ModelCheckException(msg)

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -9,6 +9,7 @@ import click
 
 # First Party
 from instructlab import clickext
+from instructlab import client as ilabclient
 from instructlab.configuration import DEFAULTS
 
 # Local
@@ -22,7 +23,7 @@ logger = logging.getLogger(__name__)
     "--model",
     default=lambda: DEFAULTS.DEFAULT_MODEL,
     show_default="The default model used by the instructlab system, located in the data directory.",
-    help="Name of the model used during generation.",
+    help="Name of the model used during generation. Note '--model' is used to select model rather than serve model.",
 )
 @click.option(
     "--num-cpus",
@@ -196,6 +197,7 @@ def generate(
             click.secho(f"Failed to start server: {exc}", fg="red")
             raise click.exceptions.Exit(1)
     try:
+        ilabclient.check_model(model, api_base, endpoint_url, http_client(ctx.params))
         click.echo(
             f"Generating synthetic data using '{model}' model, taxonomy:'{taxonomy_path}' against {api_base} server"
         )
@@ -222,7 +224,7 @@ def generate(
             tls_client_passwd=tls_client_passwd,
             pipeline=pipeline,
         )
-    except GenerateException as exc:
+    except (GenerateException, ilabclient.ModelCheckException) as exc:
         click.secho(
             f"Generating dataset failed with the following error: {exc}",
             fg="red",


### PR DESCRIPTION


**Issue resolved by this Pull Request:**
Resolves #1358 #1357 


**Checklist:**

- [* ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [* ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [* ] Documentation has been updated, if necessary.
- [* ] Unit tests have been added, if necessary.
- [* ] Integration tests have been added, if necessary.

Before the fix, can not use mixtral-8x7b model for chat/generate:
```
(dlipy3) [root@llm opt]# ilab chat --model chu/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf
You are using an aliased command, this will be deprecated in a future release. Please consider using `ilab model chat` instead
Executing chat failed with: Model chu/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf is not served by the server. These are the served models: ['models/merlinite-7b-lab-Q4_K_M.gguf']

(dlipy3) [root@llm opt]# ilab generate --model chu/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf --quiet
You are using an aliased command, this will be deprecated in a future release. Please consider using `ilab data generate` instead
Generating synthetic data using 'chu/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf' model, taxonomy:'taxonomy' against http://127.0.0.1:36043/v1 server
Cannot find prompt.txt. Using default prompt depending on model-family.
  0%|                                                                                     | 0/100 [00:00<?, ?it/s]INFO 2024-06-17 07:41:53,444 generate_data.py:505: generate_data Selected taxonomy path knowledge->textbook->movies->awards->oscar
Generating dataset failed with the following error: Model chu/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf is not served by the server. These are the served models ['models/merlinite-7b-lab-Q4_K_M.gguf']
  0%|                                                                                     | 0/100 [00:00<?, ?it/s]
(dlipy3) [root@llm opt]# 
```

After the fix:
```
(dlipy3) [root@llm opt]# ilab chat --model chu/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf
You are using an aliased command, this will be deprecated in a future release. Please consider using `ilab model chat` instead
╭──────────────────────────────────────────────────── system ────────────────────────────────────────────────────╮
│ Welcome to InstructLab Chat w/ CHU/MIXTRAL-8X7B-INSTRUCT-V0.1.Q4_K_M.GGUF (type /h for help)                   │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
>>> hello 

(dlipy3) [root@llm opt]# ilab generate --model chu/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf --num-instructions 10
You are using an aliased command, this will be deprecated in a future release. Please consider using `ilab data generate` instead
Generating synthetic data using 'chu/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf' model, taxonomy:'taxonomy' against http://127.0.0.1:45245/v1 server
Cannot find prompt.txt. Using default prompt depending on model-family.
  0%|                                                                                      | 0/10 [00:00<?, ?it/s]Synthesizing new instructions. If you aren't satisfied with the generated instructions, interrupt training (Ctrl-C) and try adjusting your YAML files. Adding more examples may help.
INFO 2024-06-17 07:51:00,450 generate_data.py:505: generate_data Selected taxonomy path knowledge->textbook->movies->awards->oscar
Q> What was the inspiration behind the stage design for the 2024 Oscars?
I> 
A> The stage was inspired by contemporary spaces where people can meet, exchange, and create, similar to a modern-day plaza.

 10%|███████▊ 


```