### PR TITLE
deps: avoid tenacity 8.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,9 @@ transformers>=4.30.0,<=4.38.2
 trl>=0.7.11,<0.8.0
 wandb>=0.16.4,<0.17.0
 langchain-text-splitters
+# do not use 8.4.0 due to a bug in the library
+# https://github.com/instructlab/instructlab/issues/1389
+tenacity>=8.3.0,!=8.4.0
 # the below library should NOT be imported into any python files
 # it is for CLI usage ONLY
 yamllint>=1.35.1,<1.36.0


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

tenacity 8.4.0 introduced a breaking change and langchain-text-splitters
is not pinning it. So let's pin it ourselves and avoid the 8.4.0
release.

Closes: https://github.com/instructlab/instructlab/issues/1389
Signed-off-by: Sébastien Han <seb@redhat.com>

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
