### PR TITLE
dependabot: Get updates batched together weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,16 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/.github/workflows"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION

83b9857 dependabot: Get updates batched together weekly

commit 83b98571b7c89685653f05f0b464c9745e61521e
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Jun 17 18:14:58 2024 -0400

    dependabot: Get updates batched together weekly
    
    If there are multiple updates for a given ecosystem, include them in a
    single PR once a week.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
