### PR TITLE
fix: Add model path validation to server setup

### DIFF
--- a/src/instructlab/server.py
+++ b/src/instructlab/server.py
@@ -2,6 +2,7 @@
 
 # Standard
 from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
 from time import sleep
 import logging
 import multiprocessing
@@ -163,6 +164,19 @@ def server(
     queue=None,
 ):
     """Start OpenAI-compatible server"""
+
+    class ModelPathError(Exception):
+        pass
+
+    try:
+        if not Path(model_path).is_file():
+            raise ModelPathError(
+                f"Model file does not exist: '{model_path}'. If the model doesn't exist, download it using the 'ilab model download' command. Please verify the model path in 'config.yaml' or pass '--model-path'."
+            )
+    except ModelPathError as e:
+        logger.error(str(e))
+        raise e
+
     settings = Settings(
         host=host,
         port=port,


### PR DESCRIPTION
Checks if the provided model path is valid via 'is_valid_model_path' function. Valid means the file exists, is readable and has '.gguf' extension. This change prevents the server from starting with an invalid model path and it also provides a user-friendly suggestion on how to fix this.

fixes: #1378

**BEFORE**
It throws a huge trace and it even doesn't say what the problem is. See the GH Issue for the complete log.

**AFTER**

See some examples of improved error messaging:

1. Using the `config.yaml`, e.g. `$ ilab serve`:

Output:
```bash  
You are using an aliased command, this will be deprecated in a future release. Please consider using `ilab model serve` instead
INFO 2024-06-18 02:32:58,372 serve.py:51: serve Using model 'models/granite-7b-lab-Q4_K_M.gguf' with -1 gpu-layers and 4096 max context size.
ERROR 2024-06-18 02:32:58,372 server.py:157: is_valid_model_path Model file does not exist: 'models/granite-7b-lab-Q4_K_M.gguf'
---
Please verify the model path in 'config.yaml' or '--model-path'. Ensure it is readable and has a '.gguf' extension.
If the model doesn't exist, download it using the 'ilab download' command.
```

2. Using the parameter and passing an already existing file in my system, `$ ilab serve --model-path='/Users/pgeorgia/script.sh'`:

Output:
```shell
You are using an aliased command, this will be deprecated in a future release. Please consider using `ilab model serve` instead
INFO 2024-06-18 02:33:44,782 serve.py:51: serve Using model '/Users/pgeorgia/script.sh' with -1 gpu-layers and 4096 max context size.
ERROR 2024-06-18 02:33:44,782 server.py:160: is_valid_model_path Invalid file type. Expected '.gguf' but got: '.sh'
---
Please verify the model path in 'config.yaml' or '--model-path'. Ensure it is readable and has a '.gguf' extension.
If the model doesn't exist, download it using the 'ilab download' command.
```

3. Using the parameter with a file that doesn't exist: `$ ilab serve --model-path='/hackme'`:

Output:
```shell
You are using an aliased command, this will be deprecated in a future release. Please consider using `ilab model serve` instead
INFO 2024-06-18 02:34:42,673 serve.py:51: serve Using model '/hackme' with -1 gpu-layers and 4096 max context size.
ERROR 2024-06-18 02:34:42,673 server.py:157: is_valid_model_path Model file does not exist: '/hackme'
---
Please verify the model path in 'config.yaml' or '--model-path'. Ensure it is readable and has a '.gguf' extension.
If the model doesn't exist, download it using the 'ilab download' command.
```


**Issue resolved by this Pull Request:**
Resolves #1378

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
