### PR TITLE
Bump minimum version of pydantic to work on Python 3.12.4.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ numpy>=1.26.4,<2.0.0 ; python_version != '3.10'
 openai>=1.13.3,<2.0.0
 peft>=0.9.0,<0.10.0
 prompt-toolkit>=3.0.38,<4.0.0
-pydantic>=2.6.0,<3.0.0
+pydantic>=2.7.4,<3.0.0
 pydantic_yaml>=1.2.0,<2.0.0
 PyYAML>=6.0.0,<7.0.0
 rich>=13.3.1,<14.0.0


### PR DESCRIPTION
Bump minimum pydantic version to 2.7.4 which works on Python 3.12.4. Fresh installs get it automatically, but in-place updates fail to do so with the old requirements.txt, as the version on disk is already satisfied.
Fixes #1391

**Issue resolved by this Pull Request:**
Resolves #1391

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
