### PR TITLE
schema: Remove references to schema folder

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -16,7 +16,6 @@ ignores:
   - ".tox/**"
   - ".venv/**"
   - "build/**"
-  - "src/instructlab/schema/**"
   - "tests/**"
   - "venv/**"
   - ".github/ISSUE_TEMPLATE/**"

--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -8,7 +8,7 @@ matrix:
     camel-case: true
     mode: markdown
   sources:
-  - "**/*.md|!REVIEWERS.md|!build/**|!.tox/**|!src/instructlab/schema/**|!venv/**|!taxonomy/**"
+  - "**/*.md|!REVIEWERS.md|!build/**|!.tox/**|!venv/**|!taxonomy/**"
   dictionary:
     wordlists:
     - .spellcheck-en-custom.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,13 +59,7 @@ include = [
   "instructlab.train.lora_mlx.models",
   "instructlab.llamacpp",
   "instructlab.mlx_explore",
-  "instructlab.schema.v1",
-  "instructlab.schema.v2",
 ]
-
-[tool.setuptools.package-data]
-"instructlab.schema.v1" = ["*.json"]
-"instructlab.schema.v2" = ["*.json"]
 
 [tool.check-wheel-contents]
 # W002 - Wheel contains duplicate files:


### PR DESCRIPTION
The schema is now provided by the instructlab-schema python package and we no longer submodule the code. So we should remove all references to the removed src/instructlab/schema folder in this repo.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
