### PR TITLE
ci: wait for the session file to be created

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -197,7 +197,12 @@ test_loading_session_history(){
     '
 
     # verify the session history file was created
-    if ! test -f test_session_history; then
+    if ! timeout 5 bash -c "
+        until test -s test_session_history; do
+        echo 'waiting for session history file to be created'
+        sleep 1
+    done
+"; then
         echo "session history file not found"
         exit 1
     fi


### PR DESCRIPTION
The ci is failing intermittently on this test and I believe the file is created but we check for its existence too quickly. Let's wait a little for the file to be present and if not return an error.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
