### PR TITLE
Don't pass logger in ctx.obj

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -446,7 +446,8 @@ disable=raw-checker-failed,
         abstract-method,
         pointless-statement,
         wrong-import-order,
-        line-too-long
+        line-too-long,
+        logging-fstring-interpolation,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -4,7 +4,6 @@
 from os import path
 from re import match
 from typing import Optional
-import logging
 import os
 import sys
 
@@ -231,23 +230,6 @@ class Lab:
     def __init__(self, config_obj: Config):
         self.config = config_obj
 
-        # Set up logging for the Lab class
-        self.logger = logging.getLogger(__name__)
-
-        # Create a formatter
-        formatter = log.CustomFormatter(log.FORMAT)
-
-        # Create a handler and set the formatter
-        handler = logging.StreamHandler()
-        handler.setFormatter(formatter)
-
-        logging.basicConfig(
-            format=log.FORMAT,
-            handlers=[handler],
-        )
-
-        self.logger.setLevel(self.config.general.log_level.upper())
-
 
 def init(ctx, config_file):
     if (
@@ -267,6 +249,8 @@ def init(ctx, config_file):
                 config_obj = read_config(config_file)
             except ConfigException as ex:
                 raise click.ClickException(str(ex))
+        # setup logging
+        log.configure_logging(log_level=config_obj.general.log_level.upper())
         ctx.obj = Lab(config_obj)
         # default_map holds a dictionary with default values for each command parameters
         ctx.default_map = get_dict(ctx.obj.config)

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -10,6 +10,8 @@ import click
 from instructlab import configuration as config
 from instructlab import utils
 
+logger = logging.getLogger(__name__)
+
 
 @click.command()
 @click.option(
@@ -157,10 +159,8 @@ def generate(
 
     server_process = None
     server_queue = None
-    logger = logging.getLogger("TODO")
     prompt_file_path = config.DEFAULT_PROMPT_FILE
     if ctx.obj is not None:
-        logger = ctx.obj.logger
         prompt_file_path = ctx.obj.config.generate.prompt_file
 
     if endpoint_url:
@@ -180,7 +180,6 @@ def generate(
 
         try:
             server_process, api_base, server_queue = ensure_server(
-                ctx.obj.logger,
                 ctx.obj.config.serve,
                 tls_insecure,
                 tls_client_cert,
@@ -198,7 +197,7 @@ def generate(
             f"Generating synthetic data using '{model}' model, taxonomy:'{taxonomy_path}' against {api_base} server"
         )
         generate_data(
-            logger=logger,
+            logger=logging.getLogger("instructlab.sdg"),  # TODO: remove
             api_base=api_base,
             api_key=api_key,
             model_family=model_family,

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -3,9 +3,7 @@
 # pylint: disable=too-many-lines
 
 # Standard
-import logging
 import multiprocessing
-import os
 
 # Third Party
 import click
@@ -24,14 +22,6 @@ from .taxonomy import taxonomy as taxonomy_group
 # 'fork' is unsafe and incompatible with some hardware accelerators.
 # Python 3.14 will switch to 'spawn' on all platforms.
 multiprocessing.set_start_method(cfg.DEFAULT_MULTIPROCESSING_START_METHOD, force=True)
-
-# Set logging level of OpenAI client and httpx library to ERROR to suppress INFO messages
-logging.getLogger("openai").setLevel(logging.ERROR)
-logging.getLogger("httpx").setLevel(logging.ERROR)
-
-# Intel Gaudi: workaround for race condition in oneMKL [HS-1795]
-# Must be set before torch is imported by an application.
-os.environ["MKL_NUM_THREADS"] = "1"
 
 
 class ExpandAliasesGroup(click.Group):

--- a/src/instructlab/log.py
+++ b/src/instructlab/log.py
@@ -50,3 +50,26 @@ def stdout_stderr_to_logger(logger, log_file):
 
     sys.stdout = LoggerWriter(logger.info)
     sys.stderr = LoggerWriter(logger.error)
+
+
+def configure_logging(
+    *,
+    log_level: str,
+    fmt: str = FORMAT,
+) -> None:
+    """Configure logging framework"""
+    root = logging.getLogger()
+
+    # reset handlers, removes existing stream logger
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+        handler.close()
+
+    stream = logging.StreamHandler()
+    stream.setFormatter(CustomFormatter(fmt=fmt))
+    root.addHandler(stream)
+    root.setLevel(log_level)
+
+    # Set logging level of OpenAI client and httpx library to ERROR to suppress INFO messages
+    logging.getLogger("openai").setLevel(logging.ERROR)
+    logging.getLogger("httpx").setLevel(logging.ERROR)

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -4,6 +4,7 @@
 from typing import Optional
 import datetime
 import json
+import logging
 import os
 import sys
 import time
@@ -31,6 +32,8 @@ from instructlab import utils
 
 # Local
 from ..utils import get_sysprompt, http_client
+
+logger = logging.getLogger(__name__)
 
 HELP_MD = """
 Help / TL;DR
@@ -176,7 +179,6 @@ def chat(
     else:
         try:
             server_process, api_base, server_queue = ensure_server(
-                ctx.obj.logger,
                 ctx.obj.config.serve,
                 tls_insecure,
                 tls_client_cert,
@@ -674,7 +676,6 @@ def chat_cli(
     max_tokens,
 ):
     """Starts a CLI-based chat with the server"""
-    logger = ctx.obj.logger
     client = OpenAI(
         base_url=api_base,
         api_key=ctx.params["api_key"],

--- a/src/instructlab/model/convert.py
+++ b/src/instructlab/model/convert.py
@@ -3,6 +3,7 @@
 # Standard
 from glob import glob
 from pathlib import Path
+import logging
 import os
 import shutil
 
@@ -13,6 +14,8 @@ import click
 
 # First Party
 from instructlab import utils
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -81,7 +84,7 @@ def convert(ctx, model_dir, adapter_file, skip_de_quantize, skip_quantize, model
         )
         raise click.exceptions.Exit(1)
 
-    ctx.obj.logger.info(f"deleting {source_model_dir}...")
+    logger.info(f"deleting {source_model_dir}...")
     shutil.rmtree(source_model_dir)
 
     model_dir_fused_pt = f"{model_name}-trained"
@@ -90,7 +93,7 @@ def convert(ctx, model_dir, adapter_file, skip_de_quantize, skip_quantize, model
         hf_path=model_dir_fused, mlx_path=model_dir_fused_pt, local=True, to_pt=True
     )
 
-    ctx.obj.logger.info(f"deleting {model_dir_fused}...")
+    logger.info(f"deleting {model_dir_fused}...")
     shutil.rmtree(model_dir_fused)
 
     convert_llama_to_gguf(
@@ -100,7 +103,7 @@ def convert(ctx, model_dir, adapter_file, skip_de_quantize, skip_quantize, model
         outfile=f"{model_dir_fused_pt}/{model_name}.gguf",
     )
 
-    ctx.obj.logger.info(f"deleting safetensors files from {model_dir_fused_pt}...")
+    logger.info(f"deleting safetensors files from {model_dir_fused_pt}...")
     for file in glob(os.path.join(model_dir_fused_pt, "*.safetensors")):
         os.remove(file)
 
@@ -110,5 +113,5 @@ def convert(ctx, model_dir, adapter_file, skip_de_quantize, skip_quantize, model
         gguf_model_q_dir = f"{model_dir_fused_pt}/{model_name}-Q4_K_M.gguf"
         run_quantize(gguf_model_dir, gguf_model_q_dir, "Q4_K_M")
 
-    ctx.obj.logger.info(f"deleting {model_dir_fused_pt}/{model_name}.gguf...")
+    logger.info(f"deleting {model_dir_fused_pt}/{model_name}.gguf...")
     os.remove(os.path.join(model_dir_fused_pt, f"{model_name}.gguf"))

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Standard
+import logging
+
 # Third Party
 import click
 
@@ -7,6 +10,8 @@ import click
 from instructlab import configuration as config
 from instructlab import log, utils
 from instructlab.model.backends.llama import ServerException, server
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -46,9 +51,9 @@ def serve(
     """Start a local server"""
 
     # Redirect server stdout and stderr to the logger
-    log.stdout_stderr_to_logger(ctx.obj.logger, log_file)
+    log.stdout_stderr_to_logger(logger, log_file)
 
-    ctx.obj.logger.info(
+    logger.info(
         f"Using model '{model_path}' with {gpu_layers} gpu-layers and {max_ctx_size} max context size."
     )
 
@@ -60,7 +65,7 @@ def serve(
 
     # Instantiate the llama server
     llama_server = llama.Server(
-        logger=ctx.obj.logger,
+        logger=logger,
         model_path=model_path,
         gpu_layers=gpu_layers,
         max_ctx_size=max_ctx_size,

--- a/src/instructlab/taxonomy/diff.py
+++ b/src/instructlab/taxonomy/diff.py
@@ -13,6 +13,8 @@ import yaml
 from instructlab import configuration as config
 from instructlab import utils
 
+logger = logging.getLogger(__name__)
+
 
 @click.command()
 @click.option(
@@ -50,10 +52,6 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
         taxonomy_base = ctx.obj.config.generate.taxonomy_base
     if not taxonomy_path:
         taxonomy_path = ctx.obj.config.generate.taxonomy_path
-    if not ctx.obj:
-        logger = logging.getLogger(__name__)
-    else:
-        logger = ctx.obj.logger
 
     if not quiet:
         is_file = os.path.isfile(taxonomy_path)
@@ -71,7 +69,7 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
             for f in updated_taxonomy_files:
                 click.echo(f)
     try:
-        read_taxonomy(logger, taxonomy_path, taxonomy_base, yaml_rules)
+        read_taxonomy(None, taxonomy_path, taxonomy_base, yaml_rules)
     except (SystemExit, yaml.YAMLError) as exc:
         if not quiet:
             click.secho(

--- a/tests/test_lab_generate.py
+++ b/tests/test_lab_generate.py
@@ -144,7 +144,7 @@ class TestLabGenerate:
                 )
                 with pytest.raises(GenerateException) as exc:
                     generate_data(
-                        logger=logging.getLogger("test_logger"),
+                        logger=logging.getLogger("instructlab.sdg"),  # TODO: remove
                         api_base="localhost:8000",
                         api_key="",
                         model_family="merlinite",
@@ -215,7 +215,7 @@ class TestLabGenerate:
                     "compositional_skills/tracked/qna.yaml", qnafile.read()
                 )
                 generate_data(
-                    logger=logging.getLogger("test_logger"),
+                    logger=logging.getLogger("instructlab.sdg"),  # TODO: remove
                     api_base="localhost:8000",
                     api_key="",
                     model_name="my-model",
@@ -260,7 +260,7 @@ class TestLabGenerate:
                     "knowledge/technical-manual/test/qna.yaml", qnafile.read()
                 )
                 generate_data(
-                    logger=logging.getLogger("test_logger"),
+                    logger=logging.getLogger("instructlab.sdg"),  # TODO: remove
                     api_base="localhost:8000",
                     api_key="",
                     model_name="my-model",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@
 
 # Standard
 from unittest.mock import Mock, patch
-import logging
 
 # Third Party
 import git
@@ -68,7 +67,6 @@ class TestUtils:
             documents = utils.get_documents(
                 source=yaml.safe_load(qnafile).get("document"),
                 skip_checkout=True,
-                logger=logging.getLogger("_test_"),
             )
             git_clone_checkout.assert_called_once()
             assert len(documents) == 2


### PR DESCRIPTION
InstructLab no longer passes a single logging instance in its `ctx.obj` instance. Instead the code uses the recommended approach for logging. Every module has its own logging instance. Logging is configured in the root logger and sub-loggers are automatically inheriting all settings.

The change also revealed several issues and code violations in the old setup. Several modules were using the deprecated alias `logger.warn` instead of `logger.warning`. Some loggers are passing f-strings to logging functions instead of delegating formatting to logging framework. `logger.level == logging.DEBUG` is the wrong approach to check if the logger has debug mode enabled. The correct way is `logger.isEnabledFor(logging.DEBUG)`. This also takes parent + root logger into account.

`logging-fstring-interpolation` can be addressed in a future PR.

**Issue resolved by this Pull Request:**
Resolves #1411


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
