### PR TITLE
cli: Fix `--model-family granite`

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -214,6 +214,7 @@ def get_api_base(host_port):
 
 
 def get_model_family(forced, model_path):
+    forced = MODEL_FAMILY_MAPPINGS.get(forced, forced)
     if forced and forced.lower() not in MODEL_FAMILIES:
         raise ConfigException("Unknown model family: %s" % forced)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Standard
+import os
+
 # Third Party
 import pytest
 
@@ -174,3 +177,26 @@ generate:
         assert cfg.general.validate_log_level("CRITICAL") == "CRITICAL"
         assert cfg.general.validate_log_level("ERROR") == "ERROR"
         assert cfg.general.validate_log_level("NOTSET") == "NOTSET"
+
+    def test_get_model_family(self):
+        good_cases = {
+            # two known families
+            "merlinite": "merlinite",
+            "mixtral": "mixtral",
+            # case insensitive
+            "MERLINiTe": "merlinite",
+            # mapping granite to merlinite
+            "granite": "merlinite",
+        }
+        bad_cases = [
+            # unknown family
+            "unknown",
+        ]
+        for model_name, expected_family in good_cases.items():
+            model_path = os.path.join("models", f"{model_name}-7b-lab-Q4_K_M.gguf")
+            assert config.get_model_family(model_name, model_path) == expected_family
+            assert config.get_model_family(None, model_path) == expected_family
+        for model_name in bad_cases:
+            model_path = os.path.join("models", f"{model_name}-7b-lab-Q4_K_M.gguf")
+            with pytest.raises(config.ConfigException):
+                config.get_model_family(model_name, model_path)


### PR DESCRIPTION
Using a granite model works. Using a granite model plus specifying
`--model-family granite` did not work. This is because `granite` is
not one of the defined model families. Instead, we map `granite` to
`merlinite`, which in practice means an instructlab-tuned model.

Without explicitly specifying the model family option, we'd get
`granite` out of the model name and map it to the correct model
family. The code did not attempt to do this mapping when specified
explicitly.

This change makes the code check the model family mappings for
whatever was specified using `--model-family`, which will allow
`--model-family granite` to work.

Closes #1372

Signed-off-by: Russell Bryant <rbryant@redhat.com>
