### PR TITLE
change instructlab logger instead of root

### DIFF
--- a/src/instructlab/log.py
+++ b/src/instructlab/log.py
@@ -68,7 +68,7 @@ def configure_logging(
     stream = logging.StreamHandler()
     stream.setFormatter(CustomFormatter(fmt=fmt))
     root.addHandler(stream)
-    root.setLevel(log_level)
+    logging.getLogger("instructlab").setLevel(log_level)
 
     # Set logging level of OpenAI client and httpx library to ERROR to suppress INFO messages
     logging.getLogger("openai").setLevel(logging.ERROR)


### PR DESCRIPTION
Setting the root log level to DEBUG or INFO generates noisy logs from all modules, not just from openai and httpx.

Changing only the instructlab log level produces more desirable results and avoids the need for workarounds like explicitly setting the log level of external modules.
