### PR TITLE
Intel Gaudi: Update Gaudi software and optimum-habana

### DIFF
--- a/containers/hpu/Containerfile
+++ b/containers/hpu/Containerfile
@@ -1,4 +1,4 @@
-ARG HABANA_VERSION=1.16.1
+ARG HABANA_VERSION=1.16.2
 ARG BASEIMAGE=vault.habana.ai/gaudi-docker/${HABANA_VERSION}/rhel9.2/habanalabs/pytorch-installer-2.2.2
 
 FROM ${BASEIMAGE} AS runtime

--- a/docs/habana-gaudi.md
+++ b/docs/habana-gaudi.md
@@ -8,7 +8,7 @@
 
 - RHEL 9 on `x86_64` (tested with RHEL 9.3 and patched installer)
 - Intel Gaudi 2 device
-- [Habana Labs](https://docs.habana.ai/en/latest/index.html) software stack (tested with 1.15.1, 1.16.0, 1.16.1)
+- [Habana Labs](https://docs.habana.ai/en/latest/index.html) software stack (tested with 1.16.2)
 - software from Habana Vault for [RHEL](https://vault.habana.ai/ui/native/rhel) and [PyTorch](https://vault.habana.ai/ui/native/gaudi-pt-modules)
 - software [HabanaAI GitHub](https://github.com/HabanaAI/) org like [optimum-habana](https://github.com/HabanaAI/optimum-habana-fork) fork
 

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -1,14 +1,15 @@
 # Dependencies for Intel Gaudi / Habana Labs HPU devices
 #
 
-optimum-habana>=1.11.1
-# Habana Labs 1.16.1 has NumPy 1.23.5
+optimum>=1.20.1
+optimum-habana>=1.12.0
+# Habana Labs 1.16.2 has NumPy 1.23.5
 numpy>=1.23.5,<2.0.0
-# Habana Labs 1.16.1 has PyTorch 2.2.2a0+gitb5d0b9b
+# Habana Labs 1.16.2 has PyTorch 2.2.2a0+gitxxx pre-release
 torch>=2.2.2a0,<3.0.0
 # Habana Labs frameworks
-habana-torch-plugin>=1.16.1
-habana_gpu_migration>=1.16.1
+habana-torch-plugin>=1.16.2
+habana_gpu_migration>=1.16.2
 # additional Habana Labs packages (installed, but not used)
 #habana-media-loader
 #habana-pyhlml

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 # versions of some dependencies. Use '3.10' as an indicator.
 # Habana installer has NumPy 1.23.5
 numpy>=1.23.5,<2.0.0 ; python_version == '3.10'
-numpy>=1.26.4,<2.0.0 ; python_version != '3.10'
+numpy>=1.26.4,<2.0.0 ; python_version >= '3.11'
 openai>=1.13.3
 peft>=0.9.0
 platformdirs>=4.2
@@ -35,13 +35,15 @@ sentencepiece>=0.2.0
 # "old" version required for vLLM on CUDA to build
 tokenizers>=0.11.1
 toml>=0.10.2
-# Intel Gaudi 1.16.1 has torch 2.2.0a0+git8964477 with oneMKL
-torch>=2.3.0a0,<3.0.0 ; python_version == '3.10'
-torch>=2.3.0,<3.0.0 ; python_version != '3.10'
+# Habana Labs 1.16.2 has PyTorch 2.2.2a0+gitxxx pre-release
+torch>=2.2.2a0,<3.0.0 ; python_version == '3.10'
+torch>=2.3.0,<3.0.0 ; python_version >= '3.11'
 tqdm>=4.66.2
-# 'optimum' for Intel Gaudi needs transformers <4.39.0,>=4.38.0
-transformers>=4.41.2
-trl>=0.9.4
+# 'optimum' for Intel Gaudi needs transformers <4.41.0,>=4.40.0
+transformers>=4.40.0 ; python_version == '3.10'
+transformers>=4.41.2 ; python_version >= '3.11'
+trl>=0.7.11 ; python_version == '3.10'
+trl>=0.9.4 ; python_version >= '3.11'
 wandb>=0.16.4
 # the below library should NOT be imported into any python files
 # it is for CLI usage ONLY


### PR DESCRIPTION
Update Gaudi software to 1.16.2

Update optimum to 1.20.1 and optimum-habana to 1.12.0. The new versions support recent version of transformers library that is compatible with HabanaAI's vllm-fork.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
