### PR TITLE
docs: A method is needed to manage Python version if >3.11 installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,22 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
 - Python 3.9+ (<3.12 for PyTorch JIT)
 - Approximately 60GB disk space (entire process)
 
-> **NOTE:** PyTorch 2.2.1 does not support `torch.compile` with Python 3.12. On Fedora 39+, install `python3.11-devel` and create the virtual env with `python3.11` if you wish to use PyTorch's JIT compiler.
+> **NOTE:** PyTorch 2.2.1 does not support `torch.compile` with Python 3.12. On Fedora 39+, install `python3.11-devel` and create the virtual env with `python3.11` if you wish to use PyTorch's JIT compiler. 
+
+> **NOTE:** When a version greater than Python 3.11 is already installed (e.g. on Mac) use pyenv to help manage python versions:
+
+```shell
+brew install pyenv
+# Set up environment variables 
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
+echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
+echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
+# Apply changes to the current session
+source ~/.bash_profile
+# Install and set Python 3.11
+pyenv install 3.11
+pyenv global 3.11
+```
 <!-- -->
 > **NOTE:** When installing the `ilab` CLI on macOS, you may have to run the `xcode select --install` command, installing the required packages previously listed.
 


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->
Many users will have machines that have already installed the latest version of Python which will be greater than 3.11. As InstructLab is meant to be for non-developers then some instruction is needed on how they can resolve their Python dependence.  The change to the `README.md` file includes some brief instructions on how user can manage python versions using `pyenv` rather than uninstalling a newer incompatible version and reinstalling a compatible version.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
