### PR TITLE
Drop some more sdg-only code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ GitPython>=3.1.42
 httpx>=0.25.0
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.2.0
-instructlab-sdg>=0.0.2
+instructlab-sdg>=0.0.4
 jsonschema>=4.21.1
 llama_cpp_python[server]==0.2.75
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
@@ -39,10 +39,6 @@ tqdm>=4.66.2
 transformers>=4.30.0
 trl>=0.7.11
 wandb>=0.16.4
-langchain-text-splitters
-# do not use 8.4.0 due to a bug in the library
-# https://github.com/instructlab/instructlab/issues/1389
-tenacity>=8.3.0,!=8.4.0
 # the below library should NOT be imported into any python files
 # it is for CLI usage ONLY
 yamllint>=1.35.1

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -16,7 +16,6 @@ import tempfile
 
 # Third Party
 from git import Repo, exc
-from langchain_text_splitters import RecursiveCharacterTextSplitter
 import click
 import git
 import gitdb
@@ -35,8 +34,6 @@ rules:
   line-length:
     max: 120
 """
-
-DEFAULT_CHUNK_OVERLAP = 100
 
 
 class TaxonomyReadingException(Exception):
@@ -233,88 +230,6 @@ def git_clone_checkout(
     if not skip_checkout:
         repo.git.checkout(commit_hash)
     return repo
-
-
-def num_tokens_from_words(num_words) -> int:
-    return int(num_words * 1.3)  # 1 word ~ 1.3 token
-
-
-def num_chars_from_tokens(num_tokens) -> int:
-    return int(num_tokens * 4)  # 1 token ~ 4 English character
-
-
-def num_tokens_from_chars(num_chars) -> int:
-    return int(num_chars / 4)  # 1 token ~ 4 English character
-
-
-def max_seed_example_tokens(server_ctx_size, prompt_num_chars) -> int:
-    """
-    Estimates the maximum number of tokens any seed example can have based
-    on the server context size and number of characters in the selected prompt.
-
-    A lot has to fit into the given server context size:
-      - The prompt itself, which can vary in size a bit based on model family and knowledge vs skill
-      - Two seed examples, which we append to the prompt template.
-      - A knowledge document chunk, if this is a knowledge example.
-      - The generated completion, which can vary substantially in length.
-
-    This is an attempt to roughly estimate the maximum size any seed example
-    (question + answer + context values from the yaml) should be to even have
-    a hope of not often exceeding the server's maximum context size.
-
-    NOTE: This does not take into account knowledge document chunks. It's meant
-    to calculate the maximum size that any seed example should be, whether knowledge
-    or skill. Knowledge seed examples will want to stay well below this limit.
-
-    NOTE: This is a very simplistic calculation, and examples with lots of numbers
-    or punctuation may have quite a different token count than the estimates here,
-    depending on the model (and thus tokenizer) in use. That's ok, as it's only
-    meant to be a rough estimate.
-
-    Args:
-        server_ctx_size (int): Size of the server context, in tokens.
-        prompt_num_chars (int): Number of characters in the prompt (not including the examples)
-    """
-    # Ensure we have at least 1024 tokens available for a response.
-    max_seed_tokens = server_ctx_size - 1024
-    # Subtract the number of tokens in our prompt template
-    max_seed_tokens = max_seed_tokens - num_tokens_from_chars(prompt_num_chars)
-    # Divide number of characters by 2, since we insert 2 examples
-    max_seed_tokens = int(max_seed_tokens / 2)
-    return max_seed_tokens
-
-
-def chunk_document(documents: List, server_ctx_size, chunk_word_count) -> List[str]:
-    """
-    Iterates over the documents and splits them into chunks based on the word count provided by the user.
-    Args:
-        documents (dict): List of documents retrieved from git (can also consist of a single document).
-        server_ctx_size (int): Context window size of server.
-        chunk_word_count (int): Maximum number of words to chunk a document.
-    Returns:
-         List[str]: List of chunked documents.
-    """
-    no_tokens_per_doc = num_tokens_from_words(chunk_word_count)
-    if no_tokens_per_doc > int(server_ctx_size - 1024):
-        raise ValueError(
-            "Error: {}".format(
-                str(
-                    f"Given word count ({chunk_word_count}) per doc will exceed the server context window size ({server_ctx_size})"
-                )
-            )
-        )
-    content = []
-    text_splitter = RecursiveCharacterTextSplitter(
-        separators=["\n\n", "\n", " "],
-        chunk_size=num_chars_from_tokens(no_tokens_per_doc),
-        chunk_overlap=DEFAULT_CHUNK_OVERLAP,
-    )
-
-    for docs in documents:
-        temp = text_splitter.create_documents([docs])
-        content.extend([item.page_content for item in temp])
-
-    return content
 
 
 # pylint: disable=unused-argument

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,56 +5,14 @@ from unittest.mock import Mock, patch
 
 # Third Party
 import git
-import pytest
 import yaml
 
 # First Party
 from instructlab import utils
 
-# Local
-from .testdata import testdata
-
 
 class TestUtils:
     """Test collection in instructlab.utils."""
-
-    def test_chunk_docs_wc_exeeds_ctx_window(self):
-        with pytest.raises(ValueError) as exc:
-            utils.chunk_document(
-                documents=testdata.documents,
-                chunk_word_count=1000,
-                server_ctx_size=1034,
-            )
-        assert (
-            "Given word count (1000) per doc will exceed the server context window size (1034)"
-            in str(exc.value)
-        )
-
-    def test_chunk_docs_chunk_overlap_error(self):
-        with pytest.raises(ValueError) as exc:
-            utils.chunk_document(
-                documents=testdata.documents,
-                chunk_word_count=5,
-                server_ctx_size=1034,
-            )
-        assert (
-            "Got a larger chunk overlap (100) than chunk size (24), should be smaller"
-            in str(exc.value)
-        )
-
-    def test_chunk_docs_long_lines(self):
-        chunk_words = 50
-        chunks = utils.chunk_document(
-            documents=testdata.long_line_documents,
-            chunk_word_count=chunk_words,
-            server_ctx_size=4096,
-        )
-        max_tokens = utils.num_tokens_from_words(chunk_words)
-        max_chars = utils.num_chars_from_tokens(max_tokens)
-        max_chars += utils.DEFAULT_CHUNK_OVERLAP  # add in the chunk overlap
-        max_chars += 50  # and a bit extra for some really long words
-        for chunk in chunks:
-            assert len(chunk) <= max_chars
 
     @patch(
         "instructlab.utils.git_clone_checkout",

--- a/tests/testdata/testdata.py
+++ b/tests/testdata/testdata.py
@@ -1,27 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 documents = [
-    """Knowledge is an awareness of facts, a familiarity with individuals and situations, 
-      or a practical skill. Knowledge of facts, also called propositional knowledge, is often characterized 
-      as true belief that is distinct from opinion or guesswork by virtue of justification. 
-      While there is wide agreement among philosophers that propositional knowledge is a form of true belief, 
-      many controversies focus on justification. This includes questions like how to understand justification, 
-      whether it is needed at all, and whether something else besides it is needed. 
-      These controversies intensified in the latter half of the 20th century due to a series of thought experiments 
+    """Knowledge is an awareness of facts, a familiarity with individuals and situations,
+      or a practical skill. Knowledge of facts, also called propositional knowledge, is often characterized
+      as true belief that is distinct from opinion or guesswork by virtue of justification.
+      While there is wide agreement among philosophers that propositional knowledge is a form of true belief,
+      many controversies focus on justification. This includes questions like how to understand justification,
+      whether it is needed at all, and whether something else besides it is needed.
+      These controversies intensified in the latter half of the 20th century due to a series of thought experiments
       called Gettier cases that provoked alternative definitions."""
-]
-
-long_line_documents = [
-    (
-        "Knowledge is an awareness of facts, a familiarity with individuals and situations,"
-        "or a practical skill. Knowledge of facts, also called propositional knowledge, is often characterized "
-        "as true belief that is distinct from opinion or guesswork by virtue of justification. "
-        "While there is wide agreement among philosophers that propositional knowledge is a form of true belief, "
-        "many controversies focus on justification. This includes questions like how to understand justification, "
-        "whether it is needed at all, and whether something else besides it is needed. "
-        "These controversies intensified in the latter half of the 20th century due to a series of thought experiments "
-        "called Gettier cases that provoked alternative definitions."
-    )
 ]
 
 knowledge_seed_instruction = [


### PR DESCRIPTION
This code was only used by the sdg library. It has been moved there
and is no longer needed here as of instructlab-sdg 0.0.3.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
