### PR TITLE
fix optional_dependencies key not matching python-identifier format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ package-dir = { "" = "src" }
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 optional-dependencies.hpu = { file = ["requirements-hpu.txt"] }
-optional-dependencies.vllm-cuda = { file = ["requirements-vllm-cuda.txt"] }
+optional-dependencies.vllm_cuda = { file = ["requirements-vllm-cuda.txt"] }
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
Related-Bug: https://github.com/instructlab/instructlab/issues/1464
