### PR TITLE
fix: Add mypy to `make verify`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ tests: check-tox ## Run tox -e unit against code
 
 .PHONY: verify
 verify: check-tox ## Run linting and formatting checks via tox
-	tox p -e ruff,fastlint,spellcheck
+	tox p -e ruff,fastlint,spellcheck,mypy
 
 .PHONY: spellcheck
 spellcheck: .spellcheck.yml ## Spellcheck markdown files


### PR DESCRIPTION
@mbestavros highlighted to me that `make verify` didn't include the `mypy` checks - this PR adds them in

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
