### PR TITLE
Update requires-python to exclude Python 3.12+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "InstructLab", email = "dev@instructlab.ai" }]
 description = "CLI for interacting with InstructLab"
 readme = "README.md"
 license = { text = "Apache-2.0 AND MIT" }
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.12"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",


### PR DESCRIPTION
InstructLab no longer works with Python 3.12. Update `requires-python` field in `pyproject.toml` to tell pip that 3.12 is not supported.

**Issue resolved by this Pull Request:**
See #1491 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
