### PR TITLE
Update error message to refer to `ilab data generate`

### DIFF
--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -306,7 +306,7 @@ def train(
 
         if not train_files or not test_files:
             click.secho(
-                f"{input_dir} does not contain training or test files, did you run `ilab generate`?",
+                f"{input_dir} does not contain training or test files, did you run `ilab data generate`?",
                 fg="red",
             )
             raise click.exceptions.Exit(1)

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -192,7 +192,7 @@ class TestLabTrain:
             )
             assert result.exception is not None
             assert (
-                f"{INPUT_DIR} does not contain training or test files, did you run `ilab generate`?"
+                f"{INPUT_DIR} does not contain training or test files, did you run `ilab data generate`?"
                 in result.output
             )
             assert result.exit_code == 1


### PR DESCRIPTION
Since `ilab generate` is now deprecated.