### PR TITLE
add e2e testing for quantized backend training

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -145,6 +145,8 @@ jobs:
           CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3 -m pip install --no-binary llama_cpp_python -c constraints.txt llama_cpp_python
           # needed for --4-bit-quant option to ilab model train
           python3 -m pip install bitsandbytes
+          python3 -m pip install packaging wheel
+          python3 -m pip install flash-attn --no-build-isolation
           python3 -m pip install .
 
       - name: Run e2e test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
+requires = ["setuptools>=64", "setuptools_scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ instructlab-eval>=0.0.4
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.2.0
 instructlab-sdg>=0.0.4.1
-instructlab-training>=0.0.3
+instructlab-training>=0.0.4
 jsonschema>=4.21.1
 llama_cpp_python[server]==0.2.79
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'

--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -152,6 +152,13 @@ test_train() {
     fi
 
     ilab model train "${TRAIN_ARGS[@]}"
+    # TODO Only cuda for now
+    TRAIN_ARGS=("--device=cuda" "--data-path=${SCRIPTDIR}/test-data/train_all_pruned_SDG.jsonl" "--quantize-data-type=nf4" "--4-bit-quant")
+    if [ "$GRANITE" -eq 1 ]; then
+        TRAIN_ARGS+=("--gguf-model-path models/granite-7b-lab-Q4_K_M.gguf")
+    fi
+
+    ilab model train "${TRAIN_ARGS[@]}"
 }
 
 test_convert() {

--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -153,7 +153,7 @@ test_train() {
 
     ilab model train "${TRAIN_ARGS[@]}"
     # TODO Only cuda for now
-    TRAIN_ARGS=("--device=cuda" "--data-path=${SCRIPTDIR}/test-data/train_all_pruned_SDG.jsonl" "--quantize-data-type=nf4" "--4-bit-quant")
+    TRAIN_ARGS=("--device=cuda" "--model-path=instructlab/merlinite-7b-lab" "--data-path=${SCRIPTDIR}/test-data/train_all_pruned_SDG.jsonl" "--quantize-data-type=nf4" "--4-bit-quant")
     if [ "$GRANITE" -eq 1 ]; then
         TRAIN_ARGS+=("--gguf-model-path models/granite-7b-lab-Q4_K_M.gguf")
     fi

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -36,6 +36,7 @@ DEFAULT_MODEL_OLD = "merlinite-7b-lab-Q4_K_M"
 DEFAULT_MODEL = "models/merlinite-7b-lab-Q4_K_M.gguf"
 DEFAULT_MODEL_PATH = "models/merlinite-7b-lab-Q4_K_M.gguf"
 DEFAULT_MODEL_REPO = "instructlab/granite-7b-lab"
+MERLINITE_MODEL_REPO = "instructlab/merlinite-7b-lab"
 DEFAULT_JUDGE_MODEL_MT = "prometheus-eval/prometheus-8x7b-v2.0"
 DEFAULT_EVAL_PATH = "eval_data"
 DEFAULT_TAXONOMY_REPO = "https://github.com/instructlab/taxonomy.git"
@@ -260,7 +261,7 @@ def get_default_config():
         ),
         train=_train(
             train_args=TrainingArgs(
-                model_path=DEFAULT_MODEL_REPO,
+                model_path=MERLINITE_MODEL_REPO,
                 data_path="./taxonomy_data",
                 ckpt_output_dir=DEFAULT_CKPT_DIR,
                 data_output_dir=DEFAULT_OUT_DIR,

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -409,6 +409,9 @@ def train(
                 fg="red",
             )
             raise click.exceptions.Exit(1)
+        # temp fix to get CI passing, there are multiple options in the train class w/ the same name
+        if params["save_samples"] is None:
+            params["save_samples"] = 250000
         ds_args = DeepSpeedOptions(**params)
         lora_args = LoraOptions(**params)
         train_args = TrainingArgs(**params)


### PR DESCRIPTION
adds another training test which runs after the `--legacy=true` test

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
