### PR TITLE
Made the local training a tad more fun.

### DIFF
--- a/src/instructlab/train/lora_mlx/lora.py
+++ b/src/instructlab/train/lora_mlx/lora.py
@@ -295,7 +295,11 @@ def load_and_train(
         model.load_weights(resume_adapter_file, strict=False)
 
     if train:
-        print("Training")
+        print("*********")
+        print("")
+        print("ᕙ(•̀‸•́‶)ᕗ  Training has started! ᕙ(•̀‸•́‶)ᕗ ")
+        print("")
+        print("*********")
         opt = optim.Adam(learning_rate=learning_rate)
 
         # Train model


### PR DESCRIPTION
Having "Training" in the output was hard to see:
```
Using model_type='mistral'
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
Total parameters 1244.079M
Trainable parameters 1.704M
Loading datasets
Training
Epoch 1: Iter 1: Val loss 3.317, Val took 6.840s
Iter 010: Train loss 2.194, It/sec 0.289, Tokens/sec 193.114
Epoch 1: Iter 10: Val loss 1.594, Val took 6.865s
```

This PR adds a more obvious "Training" notification.