### PR TITLE
e2e: Fix a permissions error

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           sudo apt-get install -y cuda-toolkit git cmake build-essential virtualenv
           nvidia-smi
-          ls -l /dev/nvidia*
+          sudo ls -l /dev/nvidia*
 
       - name: Setup Python 3.11
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0


### PR DESCRIPTION

9a36b19 e2e: Fix a permissions error

commit 9a36b19a00e2ea74405c2a3b5610ff65a7438dc0
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Jun 27 18:50:32 2024 -0400

    e2e: Fix a permissions error
    
    This line giving some system config debug output used to work fine,
    but started failing on a permissions error today. Slap some `sudo` on
    it to get things running again.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
