### PR TITLE
Stripped off html tags from knowledge document

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ import yaml
 
 # First Party
 from instructlab import utils
+from instructlab.utils import HTMLTagStripper
 
 
 class TestUtils:
@@ -57,3 +58,8 @@ def test_split_hostport(url, expected_host, expected_port):
 def test_split_hostport_err(url):
     with pytest.raises(ValueError):
         utils.split_hostport(url)
+
+
+def test_html_tag_stripper():
+    tag_stripper = HTMLTagStripper()
+    assert tag_stripper.strip_html_tags("<table><tr><td>abc") == "abc"


### PR DESCRIPTION
Issue: #1508

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->
This PR stripped off html tags from knowledge document as they didn't contain meaningful information and removing them save precious context space

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
