### PR TITLE
IPv6-safe hostname/port split

### DIFF
--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -188,8 +188,7 @@ def generate(
             click.secho(f"Failed to determine backend: {e}", fg="red")
             raise click.exceptions.Exit(1)
 
-        host = ctx.obj.config.serve.host_port.split(":")[0]
-        port = int(ctx.obj.config.serve.host_port.split(":")[1])
+        host, port = utils.split_hostport(ctx.obj.config.serve.host_port)
 
         if backend == backends.LLAMA_CPP:
             # Instantiate the llama server

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -193,8 +193,7 @@ def chat(
             click.secho(f"Failed to determine backend: {e}", fg="red")
             raise click.exceptions.Exit(1)
 
-        host = ctx.obj.config.serve.host_port.split(":")[0]
-        port = int(ctx.obj.config.serve.host_port.split(":")[1])
+        host, port = utils.split_hostport(ctx.obj.config.serve.host_port)
 
         if backend == backends.LLAMA_CPP:
             # Instantiate the llama server

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -68,13 +68,9 @@ def serve(
     """Start a local server"""
 
     # First Party
-    from instructlab.model.backends import llama_cpp, vllm
+    from instructlab.model.backends import backends, llama_cpp, vllm
 
-    host = ctx.obj.config.serve.host_port.split(":")[0]
-    port = int(ctx.obj.config.serve.host_port.split(":")[1])
-
-    # First Party
-    from instructlab.model.backends import backends
+    host, port = utils.split_hostport(ctx.obj.config.serve.host_port)
 
     model_path = pathlib.Path(model_path)
     try:

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -4,6 +4,7 @@
 from functools import cache, wraps
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Union
+from urllib.parse import urlparse
 import copy
 import glob
 import json
@@ -635,3 +636,16 @@ def display_params(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+
+def split_hostport(hostport: str) -> tuple[str, int]:
+    """Split server:port into server and port (IPv6 safe)"""
+    if "//" not in hostport:
+        # urlparse expects an URL-like input like '//host:port'
+        hostport = f"//{hostport}"
+    parsed = urlparse(hostport)
+    hostname = parsed.hostname
+    port = parsed.port
+    if not hostname or not port:
+        raise ValueError(f"Invalid host-port string: '{hostport}'")
+    return hostname, port

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,3 +70,31 @@ class TestUtils:
             )
             git_clone_checkout.assert_called_once()
             assert len(documents) == 2
+
+
+@pytest.mark.parametrize(
+    "url,expected_host,expected_port",
+    [
+        ("127.0.0.1:8080", "127.0.0.1", 8080),
+        ("[::1]:8080", "::1", 8080),
+        ("host.test:9090", "host.test", 9090),
+        ("https://host.test:443/egg/spam", "host.test", 443),
+    ],
+)
+def test_split_hostport(url, expected_host, expected_port):
+    host, port = utils.split_hostport(url)
+    assert host == expected_host
+    assert port == expected_port
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "127.0.0.1",
+        "",
+        "::1:8080",
+    ],
+)
+def test_split_hostport_err(url):
+    with pytest.raises(ValueError):
+        utils.split_hostport(url)


### PR DESCRIPTION
Add a helper method to correctly split a `host:port` combination into hostname and port. The naive approach is not IPv6-safe and does not correctly validate the host and port.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
