### PR TITLE
Update llama-cpp-python to 0.2.79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Add `--backend` flag to `ilab model serve` command to allow for specifying the backend to use
    when serving a model. This is useful when you have multiple backends installed and want to
    specify which one to use. Currently, the only supported backend are `llama-cpp` and `vllm`.
+* Update `llama-cpp-python` to latest upstream release 0.2.79 to address poor
+  results of synthetic data generation and local training.
 
 ### Breaking Changes
 

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -45,7 +45,7 @@ With Python 3.11 installed, it's time to replace some packages!
 ### llama-cpp-python backends
 
 Go to the project's GitHub to see
-the [supported backends](https://github.com/abetlen/llama-cpp-python/tree/v0.2.75?tab=readme-ov-file#supported-backends).
+the [supported backends](https://github.com/abetlen/llama-cpp-python/tree/v0.2.79?tab=readme-ov-file#supported-backends).
 
 Whichever backend you choose, you'll see a `pip install` command. First
 you have to purge pip's wheel cache to force a rebuild of llama-cpp-python:
@@ -58,7 +58,7 @@ You'll want to add a few options to ensure it gets installed over the
 existing package, has the desired backend, and the correct version.
 
 ```shell
-pip install --force-reinstall llama_cpp_python==0.2.75 -C cmake.args="-DLLAMA_$BACKEND=on"
+pip install --force-reinstall llama_cpp_python==0.2.79 -C cmake.args="-DLLAMA_$BACKEND=on"
 ```
 
 where `$BACKEND` is one of `HIPBLAS` (ROCm), `CUDA`, `METAL`
@@ -111,7 +111,7 @@ sudo dnf -y install cuda-toolkit-12-4 nvtop
 ```
 
 Go to the project's GitHub to see the
-[supported backends](https://github.com/abetlen/llama-cpp-python/tree/v0.2.75?tab=readme-ov-file#supported-backends).
+[supported backends](https://github.com/abetlen/llama-cpp-python/tree/v0.2.79?tab=readme-ov-file#supported-backends).
 Find the `CUDA` backend. You'll see a `pip install` command.
 You'll want to add a few options to ensure it gets installed over the
 existing package: `--force-reinstall`. Your final
@@ -125,7 +125,7 @@ export PATH=$PATH:$CUDA_HOME/bin
 
 # Recompile llama-cpp-python using CUDA
 pip cache remove llama_cpp_python
-pip install --force-reinstall llama_cpp_python==0.2.75 -C cmake.args="-DLLAMA_CUDA=on"
+pip install --force-reinstall llama_cpp_python==0.2.79 -C cmake.args="-DLLAMA_CUDA=on"
 
 # Re-install InstructLab
 pip install instructlab/.
@@ -213,7 +213,7 @@ we'll include that in our build command as follows:
 ```shell
 export PATH=/opt/rocm/llvm/bin:$PATH
 pip cache remove llama_cpp_python
-CMAKE_ARGS="-DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER='/opt/rocm/llvm/bin/clang' -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ -DCMAKE_PREFIX_PATH=/opt/rocm -DAMDGPU_TARGETS=gfx1100" FORCE_CMAKE=1 pip install --force-reinstall llama_cpp_python==0.2.75
+CMAKE_ARGS="-DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER='/opt/rocm/llvm/bin/clang' -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ -DCMAKE_PREFIX_PATH=/opt/rocm -DAMDGPU_TARGETS=gfx1100" FORCE_CMAKE=1 pip install --force-reinstall llama_cpp_python==0.2.79
 ```
 
 > **Note:** This is explicitly forcing the build to use the ROCm compilers and
@@ -241,7 +241,7 @@ Your final command should look like so (this uses `CLBlast`):
 
 ```shell
 pip cache remove llama_cpp_python
-pip install --force-reinstall llama_cpp_python==0.2.75 -C cmake.args="-DLLAMA_CLBLAST=on"
+pip install --force-reinstall llama_cpp_python==0.2.79 -C cmake.args="-DLLAMA_CLBLAST=on"
 ```
 
 Once that package is installed, recompile `ilab` with `pip install .` and skip
@@ -261,7 +261,7 @@ add a few options to ensure it gets installed over the existing package:
 
 ```shell
 pip cache remove llama_cpp_python
-pip install --force-reinstall llama_cpp_python==0.2.75 -C cmake.args="-DLLAMA_METAL=on"
+pip install --force-reinstall llama_cpp_python==0.2.79 -C cmake.args="-DLLAMA_METAL=on"
 ```
 
 Once that package is installed, recompile `ilab` with `pip install .` and skip

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ instructlab-quantize>=0.1.0
 instructlab-schema>=0.2.0
 instructlab-sdg>=0.0.2
 jsonschema>=4.21.1
-llama_cpp_python[server]==0.2.75
+llama_cpp_python[server]==0.2.79
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 # HabanaLabs / Intel Gaudi env comes with Python 3.10 and slightly older
 # versions of some dependencies. Use '3.10' as an indicator.


### PR DESCRIPTION
Update `llama-cpp-python` to latest upstream release 0.2.79. In #1305, users have reported that SDG with 0.2.75 produces poor results. The latest version is not affected.

```shell
find -name '*.txt' -or -name '*.md' | xargs sed -i 's/0.2.75/0.2.79/g'
```

**Issue resolved by this Pull Request:**
See: #1305

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
