### PR TITLE
tests: Add missing pytest import

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 # Third Party
 import git
+import pytest
 import yaml
 
 # First Party


### PR DESCRIPTION
PR #1513 added new usage of this import while #1458 removed it. #1458
merged first and #1513 wasn't tested on top before merging, so `main`
broke.

This has happened a few times in the past. The only way to avoid it is
to enforce testing on latest `main` before merge, but we haven't setup
automation for this, yet.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
