### PR TITLE
Extend sysinfo to include instructlab packages

### DIFF
--- a/src/instructlab/sysinfo.py
+++ b/src/instructlab/sysinfo.py
@@ -117,12 +117,22 @@ def _llama_cpp_info() -> typing.Dict[str, typing.Any]:
     }
 
 
+def _instructlab_info():
+    """InstructLab packages"""
+    # auto-detect all instructlab packages
+    pkgs = sorted(
+        (dist.name, dist.version)
+        for dist in importlib.metadata.distributions()
+        if dist.name.startswith("instructlab")
+    )
+    return {f"{name}.version": ver for name, ver in pkgs}
+
+
 def get_sysinfo() -> typing.Dict[str, typing.Any]:
     """Get system information"""
-    info = {
-        "instructlab.version": importlib.metadata.version("instructlab"),
-    }
+    info = {}
     info.update(_platform_info())
+    info.update(_instructlab_info())
     info.update(_torch_info())
     info.update(_torch_cuda_info())
     info.update(_torch_hpu_info())


### PR DESCRIPTION
`ilab sysinfo` now prints versions of other InstructLab packages:

```
$ ilab sysinfo
...
instructlab-quantize.version: 0.1.0
instructlab-schema.version: 0.2.0
instructlab-sdg.version: 0.0.4
instructlab-training.version: 0.0.3
...
```

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
