### PR TITLE
Add pciutils package to the gpu-acceleration docs

### DIFF
--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -77,6 +77,7 @@ you are **not running** with the proprietary Nvidia drivers.
 
 ```shell
 # Check video driver
+sudo dnf install pciutils
 lspci -n -n -k | grep -A 2 -e VGA -e 3D
 ```
 


### PR DESCRIPTION
- Save the user a lookup for what package contains lscpi by adding it to the docs since it's not a default installed package on Fedora cloud images.
- No issue, smol doc change

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
