### PR TITLE
Fix: No str.split or f-string for subprocess args

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -144,7 +144,7 @@ class _serve_vllm(BaseModel):
     """Class describing configuration of vllm serving backend."""
 
     # arguments to pass into vllm process
-    vllm_args: str = ""
+    vllm_args: list[str] | None = None
 
 
 class _serve_llama_cpp(BaseModel):
@@ -255,7 +255,7 @@ def get_default_config():
                 llm_family="",
             ),
             vllm=_serve_vllm(
-                vllm_args="",
+                vllm_args=[],
             ),
         ),
         train=_train(

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -3,6 +3,7 @@
 # Standard
 import logging
 import pathlib
+import typing
 
 # Third Party
 import click
@@ -56,7 +57,12 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--vllm-args",
     type=str,
-    help="Specific arguments to pass into vllm. The value passed into this flag must be surrounded by double quotes.\n Example: --vllm-args '--dtype auto --enable-lora'",
+    multiple=True,
+    help=(
+        "Specific arguments to pass into vllm. Each arg must be passed "
+        "separately and surrounded by quotes.\n"
+        " Example: --vllm-args='--dtype=auto' --vllm-args='--enable-lora'"
+    ),
 )
 @click.pass_context
 @utils.display_params
@@ -69,7 +75,7 @@ def serve(
     model_family,
     log_file,
     backend,
-    vllm_args,
+    vllm_args: typing.Iterable[str],
 ):
     """Start a local server"""
     # pylint: disable=import-outside-toplevel
@@ -116,9 +122,6 @@ def serve(
 
     if backend == backends.VLLM:
         # Instantiate the vllm server
-        if vllm_args is None:
-            vllm_args = ""
-
         backend_instance = vllm.Server(
             logger=logger,
             api_base=ctx.obj.config.serve.api_base(),


### PR DESCRIPTION
Never use `str.split` to split arguments to subprocess or f-strings to create arguments for subprocess. This breaks as soon as there a non-ASCII characters in any path, e.g. file names with a white space.

You either need `shlex.split` and `shlex.quote` (which does not work on non-Unix shells) or use list of string all the way.

Also fix a typing bug with port. It's now an `int` all the way.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
