### PR TITLE
Fix slow `ilab` CLI startup

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -452,6 +452,7 @@ disable=raw-checker-failed,
         line-too-long,
         logging-fstring-interpolation,  # FIXME
         duplicate-code,
+        import-outside-toplevel,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ instructlab-eval>=0.0.4
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.2.0
 instructlab-sdg>=0.0.4.1
-instructlab-training>=0.0.3
+instructlab-training>=0.0.5
 jsonschema>=4.21.1
 llama_cpp_python[server]==0.2.79
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -93,7 +93,6 @@ def is_model_gguf(model_path: pathlib.Path) -> bool:
     Returns:
         bool: True if the file is a GGUF file, False otherwise.
     """
-    # pylint: disable=import-outside-toplevel
     # Third Party
     from gguf.constants import GGUF_MAGIC
 
@@ -333,7 +332,6 @@ def get_uvicorn_config(app: uvicorn.Server, host: str, port: int) -> Config:
 
 def select_backend(logger: logging.Logger, cfg: serve_config) -> BackendServer:
     # Local
-    # pylint: disable=import-outside-toplevel
     from .llama_cpp import Server as llama_cpp_server
     from .vllm import Server as vllm_server
 

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -1,28 +1,33 @@
 # Standard
+import enum
 import logging
 import os
+import typing
 
 # Third Party
-from instructlab.eval.evaluator import Evaluator
-from instructlab.eval.mmlu import MMLUBranchEvaluator, MMLUEvaluator
-from instructlab.eval.mt_bench import MTBenchBranchEvaluator, MTBenchEvaluator
 import click
 
 # Local
 from ..utils import http_client
 
+if typing.TYPE_CHECKING:
+    # Third Party
+    from instructlab.eval.evaluator import Evaluator
+
 logger = logging.getLogger(__name__)
 
-BENCHMARK_TO_CLASS_MAP = {
-    "mmlu": MMLUEvaluator,
-    "mmlu_branch": MMLUBranchEvaluator,
-    "mt_bench": MTBenchEvaluator,
-    "mt_bench_branch": MTBenchBranchEvaluator,
-}
 
 JUDGE_MODEL_NAME = "judge_model"
 TEST_MODEL_NAME = "test_model"
 BASE_TEST_MODEL_NAME = "base_test_model"
+
+
+# Python 3.10 does not have StrEnum
+class Benchmark(str, enum.Enum):
+    MMLU = "mmlu"
+    MMLU_BRANCH = "mmlu_branch"
+    MT_BENCH = "mt_bench"
+    MT_BENCH_BRANCH = "mt_bench_branch"
 
 
 def get_evaluator(
@@ -38,14 +43,24 @@ def get_evaluator(
     few_shots,
     batch_size,
     sdg_path,
-) -> Evaluator:
+) -> "Evaluator":
     """takes in arguments from the CLI and uses 'benchmark' to validate other arguments
     if all needed configuration is present, returns the appropriate Evaluator class for the benchmark
     otherwise raises an exception for the missing values
     """
+    # Third Party
+    from instructlab.eval.mmlu import MMLUBranchEvaluator, MMLUEvaluator
+    from instructlab.eval.mt_bench import MTBenchBranchEvaluator, MTBenchEvaluator
+
+    benchmark_map = {
+        Benchmark.MMLU: MMLUEvaluator,
+        Benchmark.MMLU_BRANCH: MMLUBranchEvaluator,
+        Benchmark.MT_BENCH: MTBenchEvaluator,
+        Benchmark.MT_BENCH_BRANCH: MTBenchBranchEvaluator,
+    }
 
     # ensure skills benchmarks have proper arguments if selected
-    if benchmark in ["mt_bench", "mt_bench_branch"]:
+    if benchmark in {Benchmark.MT_BENCH, Benchmark.MT_BENCH_BRANCH}:
         required_args = [
             model,
             judge_model,
@@ -56,7 +71,7 @@ def get_evaluator(
             "model",
             "judge-model",
         ]
-        if benchmark == "mt_bench_branch":
+        if benchmark == Benchmark.MT_BENCH_BRANCH:
             required_args.append(taxonomy_path)
             required_args.append(branch)
             required_args.append(base_branch)
@@ -71,8 +86,8 @@ def get_evaluator(
                 fg="red",
             )
             raise click.exceptions.Exit(1)
-        evaluator_class = BENCHMARK_TO_CLASS_MAP[benchmark]
-        if benchmark == "mt_bench":
+        evaluator_class = benchmark_map[benchmark]
+        if benchmark == Benchmark.MT_BENCH:
             return evaluator_class(
                 TEST_MODEL_NAME, JUDGE_MODEL_NAME, output_dir, max_workers
             )
@@ -86,10 +101,10 @@ def get_evaluator(
         )
 
     # ensure knowledge benchmarks have proper arguments if selected
-    if benchmark in ["mmlu", "mmlu_branch"]:
+    if benchmark in [Benchmark.MMLU, Benchmark.MMLU_BRANCH]:
         required_args = [model, few_shots, batch_size]
         required_arg_names = ["model"]
-        if benchmark == "mmlu_branch":
+        if benchmark == Benchmark.MMLU_BRANCH:
             required_args.append(sdg_path)
             required_args.append(base_model)
             required_arg_names.append("sdg-path")
@@ -100,8 +115,8 @@ def get_evaluator(
                 fg="red",
             )
             raise click.exceptions.Exit(1)
-        evaluator_class = BENCHMARK_TO_CLASS_MAP[benchmark]
-        if benchmark == "mmlu":
+        evaluator_class = benchmark_map[benchmark]
+        if benchmark == Benchmark.MMLU:
             min_tasks = os.environ.get("INSTRUCTLAB_EVAL_MMLU_MIN_TASKS")
             if min_tasks is not None:
                 tasks = ["mmlu_abstract_algebra", "mmlu_anatomy", "mmlu_astronomy"]
@@ -246,8 +261,7 @@ def launch_server(
 )
 @click.option(
     "--benchmark",
-    type=click.Choice(list(BENCHMARK_TO_CLASS_MAP.keys())),
-    # case_sensitive=False,
+    type=click.Choice([m.value for m in Benchmark.__members__.values()]),
     help="Benchmarks to run during evaluation",
 )
 @click.option(
@@ -356,7 +370,7 @@ def evaluate(
         sdg_path,
     )
 
-    if benchmark == "mt_bench":
+    if benchmark == Benchmark.MT_BENCH:
         print("Generating answers...")
         server = None
         try:
@@ -396,7 +410,10 @@ def evaluate(
             turn2_score = round(turn2_score, 2)
         print(turn2_score)
 
-    elif benchmark == "mt_bench_branch":
+    elif benchmark == Benchmark.MT_BENCH_BRANCH:
+        # Third Party
+        from instructlab.eval.mt_bench import MTBenchBranchEvaluator
+
         evaluators = [
             evaluator,
             MTBenchBranchEvaluator(
@@ -476,7 +493,7 @@ def evaluate(
         # display summary of evaluation before exiting
         display_branch_eval_summary(improvements, regressions, no_changes, new_qnas)
 
-    elif benchmark == "mmlu":
+    elif benchmark == Benchmark.MMLU:
         overall_score, individual_scores = evaluator.run()
 
         print("# KNOWLEDGE EVALUATION REPORT")
@@ -489,7 +506,10 @@ def evaluate(
             s = round(score["score"], 2)
             print(f"{task} - {s}")
 
-    elif benchmark == "mmlu_branch":
+    elif benchmark == Benchmark.MMLU_BRANCH:
+        # Third Party
+        from instructlab.eval.mmlu import MMLUBranchEvaluator
+
         evaluators = [
             evaluator,
             MMLUBranchEvaluator(

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -11,7 +11,7 @@ import click
 # First Party
 from instructlab import configuration as config
 from instructlab import log, utils
-from instructlab.model.backends.llama_cpp import ServerException
+from instructlab.model.backends.backends import ServerException
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,6 @@ def serve(
     vllm_args: typing.Iterable[str],
 ):
     """Start a local server"""
-    # pylint: disable=import-outside-toplevel
     # First Party
     from instructlab.model.backends import backends, llama_cpp, vllm
 

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -7,13 +7,12 @@ import os
 import shutil
 
 # Third Party
-# pylint: disable=ungrouped-imports,no-name-in-module
+# pylint: disable=ungrouped-imports
 from instructlab.training import (
     DeepSpeedOptions,
     LoraOptions,
     TorchrunArgs,
     TrainingArgs,
-    run_training,
 )
 import click
 
@@ -263,7 +262,6 @@ def train(
 
     # if macos, preserve that path
     if utils.is_macos_with_m_chip():
-        # pylint: disable=import-outside-toplevel
         # Local
         from ..mlx_explore.gguf_convert_to_mlx import load
         from ..mlx_explore.utils import fetch_tokenizer_from_hub
@@ -331,7 +329,6 @@ def train(
             steps_per_eval=10,
         )
     elif legacy:
-        # pylint: disable=import-outside-toplevel
         # Local
         from ..llamacpp.llamacpp_convert_to_gguf import convert_llama_to_gguf
         from ..train.linux_train import linux_train
@@ -399,7 +396,14 @@ def train(
         # checkpoint_dirs = training_results_dir.glob("checkpoint*")
         # shutil.rmtree(checkpoint_dirs[0])
     else:
-        # pull the training and torch args from the flags
+        # run_training is a dynamic attribute, pylint is not clever enough
+        # to detect it.
+        # Third Party
+        from instructlab.training import (  # pylint: disable=no-name-in-module
+            run_training,
+        )
+
+        # pull the trainrandom.randinting and torch args from the flags
         # the flags are populated from the config as a base.
         params = ctx.params
 

--- a/src/instructlab/sysinfo.py
+++ b/src/instructlab/sysinfo.py
@@ -27,7 +27,6 @@ def _platform_info() -> typing.Dict[str, typing.Any]:
 
 def _torch_info() -> typing.Dict[str, typing.Any]:
     """Torch capabilities and devices"""
-    # pylint: disable=import-outside-toplevel
     # Third Party
     import torch
 
@@ -45,7 +44,6 @@ def _torch_info() -> typing.Dict[str, typing.Any]:
 
 def _torch_cuda_info() -> typing.Dict[str, typing.Any]:
     """Torch Nvidia CUDA / AMD ROCm devices"""
-    # pylint: disable=import-outside-toplevel
     # Third Party
     import torch
 
@@ -71,7 +69,6 @@ def _torch_cuda_info() -> typing.Dict[str, typing.Any]:
 
 def _torch_hpu_info() -> typing.Dict[str, typing.Any]:
     """Intel Gaudi (HPU) devices"""
-    # pylint: disable=import-outside-toplevel
     # Third Party
     import torch
 
@@ -107,7 +104,6 @@ def _torch_hpu_info() -> typing.Dict[str, typing.Any]:
 
 def _llama_cpp_info() -> typing.Dict[str, typing.Any]:
     """llama-cpp-python capabilities"""
-    # pylint: disable=import-outside-toplevel
     # Third Party
     import llama_cpp
 

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -2,6 +2,8 @@
 
 # Standard
 import re
+import subprocess
+import sys
 
 # Third Party
 import click
@@ -27,7 +29,6 @@ class TestConfig:
 
 
 def test_llamap_cpp_import():
-    # pylint: disable=import-outside-toplevel
     # Third Party
     import llama_cpp
 
@@ -42,3 +43,16 @@ def test_import_mlx():
     else:
         with pytest.raises(ModuleNotFoundError):
             __import__("mlx")
+
+
+def test_ilab_cli_imports():
+    # ensure that `ilab` CLI startup is not slowed down by heavy packages
+    unwanted = ["deepspeed", "llama_cpp", "torch", "vllm"]
+    code = ["import json, sys"]
+    for modname in unwanted:
+        # block unwanted imports
+        code.append(f"sys.modules['{modname}'] = None")
+    # import CLI last
+    code.append("import instructlab.lab")
+
+    subprocess.check_call([sys.executable, "-c", "; ".join(code)], text=True)


### PR DESCRIPTION
Avoid importing `llama_cpp` by importing the `ServerException` from its
original module.

Defer import of `run_training` to avoid import of `torch`.

Move imports from `instructlab.eval` into function to avoid import of
`torch`.

Add a test case to test for slow and heavy imports like `torch` and
`llama_cpp`. 

Allow `import-outside-toplevel` globally.

**Issue resolved by this Pull Request:**
See: #1467
See: https://github.com/instructlab/training/pull/116

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
