### PR TITLE
Use new vllm/llama-cpp backends for evaluate

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -80,6 +80,7 @@ Miniforge
 Mixtral
 mlx
 MLX
+mmlu
 MPS
 nb
 Nvidia

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
    specify which one to use. Currently, the only supported backend are `llama-cpp` and `vllm`.
 * Update `llama-cpp-python` to latest upstream release 0.2.79 to address poor
   results of synthetic data generation and local training.
+* Adding `ilab model evaluate` which uses the new backend serving functionality.  Evaluate offers
+   two standard benchmarks (mt-bench and mmlu) as well as two variations (mt-bench-branch and
+   mmlu-branch) which are integrated with the ilab workflow to evaluate new skills and knowledge.
 
 ### Breaking Changes
 

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -159,7 +159,7 @@ def generate(
     pipeline,
 ):
     """Generates synthetic data to enhance your example data"""
-    # pylint: disable=C0415
+    # pylint: disable=import-outside-toplevel
     # Third Party
     from instructlab.sdg.generate_data import generate_data
     from instructlab.sdg.utils import GenerateException

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -165,7 +165,7 @@ def chat(
     model_family,
 ):
     """Run a chat using the modified model"""
-    # pylint: disable=C0415
+    # pylint: disable=import-outside-toplevel
     # First Party
     from instructlab.model.backends.llama_cpp import is_temp_server_running
 

--- a/src/instructlab/model/convert.py
+++ b/src/instructlab/model/convert.py
@@ -56,7 +56,7 @@ def convert(
     model_name,
 ):
     """Converts model to GGUF"""
-    # pylint: disable=C0415
+    # pylint: disable=import-outside-toplevel
     # Third Party
     from instructlab_quantize import run_quantize  # pylint: disable=import-error
 

--- a/src/instructlab/model/test.py
+++ b/src/instructlab/model/test.py
@@ -35,7 +35,7 @@ from instructlab import utils
 # pylint: disable=function-redefined
 def test(data_dir, model_dir, adapter_file):
     """Runs basic test to ensure model correctness"""
-    # pylint: disable=C0415
+    # pylint: disable=import-outside-toplevel
     # Local
     from ..train.lora_mlx.lora import load_and_train
 

--- a/src/instructlab/taxonomy/diff.py
+++ b/src/instructlab/taxonomy/diff.py
@@ -44,7 +44,7 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
     Lists taxonomy files that have changed since <taxonomy-base>
     and checks that taxonomy is valid. Similar to 'git diff <ref>'.
     """
-    # pylint: disable=C0415
+    # pylint: disable=import-outside-toplevel
     # Local
     from ..utils import get_taxonomy_diff, read_taxonomy
 

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -258,7 +258,7 @@ def _load_schema(path: "importlib.resources.abc.Traversable") -> "referencing.Re
     Returns:
         Resource: A Resource containing the requested schema.
     """
-    # pylint: disable=C0415
+    # pylint: disable=import-outside-toplevel
     # Third Party
     from referencing import Resource
     from referencing.exceptions import NoSuchResource
@@ -287,7 +287,7 @@ def validate_yaml(contents: Mapping[str, Any], taxonomy_path: Path) -> int:
         int: The number of errors found during validation.
         Messages for each error have been logged.
     """
-    # pylint: disable=C0415
+    # pylint: disable=import-outside-toplevel
     # Standard
     from importlib import resources
 


### PR DESCRIPTION
Followup to #1369

This PR is using the new serving backends and support the vllm and llama_cpp path.  It replaces temporary code serving vllm directly.

**Checklist:**

- [ x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
