### PR TITLE
Use clang++-17 as CUDA host compiler resolving F40 GCC incompatibility

### DIFF
--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -119,7 +119,7 @@ existing package: `--force-reinstall`. Your final
 command should look like this:
 
 ```shell
-# Veryify CUDA can be found in your PATH variable
+# Verify CUDA can be found in your PATH variable
 export CUDA_HOME=/usr/local/cuda
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64
 export PATH=$PATH:$CUDA_HOME/bin
@@ -130,6 +130,16 @@ pip install --force-reinstall llama_cpp_python==0.2.79 -C cmake.args="-DLLAMA_CU
 
 # Re-install InstructLab
 pip install instructlab/.
+```
+
+If you are running Fedora 40, you need to replace the `Recompile llama-cpp-python using CUDA` section above with the
+following until [CUDA](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#host-compiler-support-policy)
+supports GCC v14.1+.
+
+```shell
+# Recompile llama-cpp-python using CUDA
+sudo dnf install clang17
+CUDAHOSTCXX=$(which clang++-17) pip install --force-reinstall llama_cpp_python==0.2.79 -C cmake.args="-DLLAMA_CUDA=on"
 ```
 
 Proceed to the `Initialize` section of


### PR DESCRIPTION
Fedora40 ships with GCC v14.1.1 which is currently not supported by CUDA. This enables the user to be able to run ilab with CUDA support on F40. EC2 AMIs don't have F39 AMIs listed so this helps users run on EC2 as well.

I have only validated this on EC2 Fedora 40 cloud image. You can view the results in this external runner workflow [output](https://github.com/nerdalert/ilab-runner/actions/runs/9737488509) getting prepped.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
