### PR TITLE
Configure coverage to merge and exclude paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,3 +143,23 @@ exclude = [
 ]
 # honor excludes by not following there through imports
 follow_imports = "silent"
+
+[tool.coverage.run]
+branch = false
+relative_files = true
+source = ["instructlab", "tests/"]
+omit = [
+  # omit instructlab code in different packages
+  "*/instructlab/dolomite/*",
+  "*/instructlab/eval/*",
+  "*/instructlab/schema/*",
+  "*/instructlab/sdg/*",
+  "*/instructlab/training/*",
+]
+
+[tool.coverage.paths]
+source = ["src/instructlab", "*.tox/*/lib*/python*/site-packages/instructlab"]
+tests = ["tests/"]
+
+[tool.coverage.report]
+exclude_lines = ["@abc.abstractmethod", "if typing.TYPE_CHECKING"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,6 @@ pylint>=2.16.2,<4.0
 pylint-pydantic
 pytest
 pytest-asyncio
-pytest-cov
+pytest-cov[toml]
 pytest-html
 tox>=4.4.2,<5


### PR DESCRIPTION
`coverage` is now configured to correctly merge local paths and tox paths. External InstructLab packages such as `instructlab.sdg` are excluded from coverage.

`coverage[toml]` is needed to enable `pyproject.toml` parsing in Python 3.10.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
