### PR TITLE
docs: fix type in xcode install instructions for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
 
 > **NOTE:** Python 3.12 is currently not supported, because some dependencies don't work on Python 3.12, yet.
 <!-- -->
-> **NOTE:** When installing the `ilab` CLI on macOS, you may have to run the `xcode select --install` command, installing the required packages previously listed.
+> **NOTE:** When installing the `ilab` CLI on macOS, you may have to run the `xcode-select --install` command, installing the required packages previously listed.
 
 ## ✅ Getting started
 


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
 fix type in xcode install instructions for Mac
  3. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->



**Checklist:**

- [X ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [X ] Documentation has been updated, if necessary.
changed `xcode select` to `xcode-select`
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
