### PR TITLE
Full e2e train using library and new CI runners

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x1.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x1.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Determine if pr_or_branch is a PR number
         id: check_pr
         run: |
+          nvidia-smi
           if [[ "${{ github.event.inputs.pr_or_branch }}" =~ ^[0-9]+$ ]]; then
             echo "is_pr=true" >> "$GITHUB_OUTPUT"
           else
@@ -116,18 +117,43 @@ jobs:
 
       - name: Install ilab
         run: |
-          export PATH="/home/ec2-user/.local/bin:/usr/local/cuda/bin:$PATH"
-          python3.11 -m venv --upgrade-deps venv
+          export CUDA_HOME="/usr/local/cuda"
+          export LD_LIBRRY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
+          export PATH="$PATH:$CUDA_HOME/bin"
+          python3.11 -m venv venv
           . venv/bin/activate
+          nvidia-smi
           sed 's/\[.*\]//' requirements.txt > constraints.txt
           python3.11 -m pip cache remove llama_cpp_python
           CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-binary llama_cpp_python -c constraints.txt llama_cpp_python
           python3.11 -m pip install bitsandbytes
+
+          # TODO This should be added to instructlab-training
+          python3.11 -m pip install packaging wheel
+
+          python3.11 -m pip install instructlab-training[cuda]
+
           python3.11 -m pip install .
 
       - name: Run e2e test
         run: |
+          nvidia-smi
+          # This env variable is used on GPUs with less vRAM. It only allows cuda to alloc small chunks of vRAM at a time, usually helping to avoid OOM errors.
+          # This is not a good solution for production code, as setting ENV variables for users isn't best practice. However, it is a helpful manual workaround.
+          export PYTORCH_CUDA_ALLOC_CONF=garbage_collection_threshold:0.6,max_split_size_mb:128
           . venv/bin/activate
+          # TODO: for some reason we need to reinstall DS in order to get fused adam support
+          # This means we need to manually rm and re-install a bunch of packages. Investigate why this is.
+          python3.11 -m pip uninstall -y deepspeed
+
+          python3.11 -m pip cache purge
+
+          DS_BUILD_CPU_ADAM=1 BUILD_UTILS=1 python3.11 -m pip install deepspeed
+
+          nvidia-smi
+
+          python3.11 -m pip show nvidia-nccl-cu12
+          
           ./scripts/basic-workflow-tests.sh -cemf
 
       - name: Add comment to PR if the workflow failed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=70.1.0", "setuptools_scm>=8"]
+requires = ["setuptools>=70.1.0", "setuptools_scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/scripts/test-data/train-profile-a10.yaml
+++ b/scripts/test-data/train-profile-a10.yaml
@@ -1,0 +1,37 @@
+torch_args:
+  nnodes: 1
+  node_rank: 0
+  nproc_per_node: 1
+  rdzv_endpoint: 127.0.0.1:12222
+  rdzv_id: 123
+train_args:
+  ckpt_output_dir: checkpoints
+  data_output_dir: train-output
+  data_path: ./taxonomy_data
+  deepspeed_options:
+    cpu_offload_optimizer: true
+    cpu_offload_optimizer_pin_memory: false
+    cpu_offload_optimizer_ratio: 1
+    save_samples: null
+  effective_batch_size: 100
+  is_padding_free: false
+  learning_rate: 2e-6
+  lora:
+    alpha: 32
+    dropout: 0.1
+    quantize_data_type: nf4
+    rank: 2
+    target_modules:
+    - q_proj
+    - k_proj
+    - v_proj
+    - o_proj
+  max_batch_len: 1000
+  max_seq_len: 96
+  mock_data: false
+  mock_data_len: 0
+  model_path: instructlab/granite-7b-lab
+  num_epochs: 1
+  random_seed: 42
+  save_samples: 100
+  warmup_steps: 10


### PR DESCRIPTION
Built on top of #1556 

adds non-legacy training to the A10 runners. These ones should be able to run natively without disabling flash-attn.

adds flash-attn, packaging, wheel pip install's to the e2e yaml. 

adds some generated data to train off of, and the model in use is granite-7b-lab.

This PR  also introduces some new handling for installing all necessary packages and reinstalling some existing ones

when doing dnf upgrade we get a nccl version mismatch because a bunch of the cuda deps are upgraded
also, the path was set to the wrong values. The outdated values were not pointing to the right nvcc or nccl causing issues when running nvidia-smi and any cuda processes.