### PR TITLE
fix: add list of supported backends in the CLI help

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -172,7 +172,9 @@ class _serve(BaseModel):
 
     # additional fields with defaults
     host_port: StrictStr = "127.0.0.1:8000"
-    backend: str = ""  # we don't set a default value here since it's auto-detected
+    backend: Optional[str] = (
+        None  # we don't set a default value here since it's auto-detected
+    )
 
     def api_base(self):
         """Returns server API URL, based on the configured host and port"""

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -112,21 +112,6 @@ def is_model_gguf(model_path: pathlib.Path) -> bool:
         return first_four_bytes_int == GGUF_MAGIC
 
 
-def validate_backend(backend: str) -> None:
-    """
-    Validate the backend.
-    Args:
-        backend (str): The backend to validate.
-    Raises:
-        ValueError: If the backend is not supported.
-    """
-    # lowercase backend for comparison in case of user input like 'Llama'
-    if backend.lower() not in SUPPORTED_BACKENDS:
-        raise ValueError(
-            f"Backend '{backend}' is not supported. Supported: {', '.join(SUPPORTED_BACKENDS)}"
-        )
-
-
 def determine_backend(model_path: pathlib.Path) -> str:
     """
     Determine the backend to use based on the model file properties.
@@ -172,7 +157,7 @@ def get(logger: logging.Logger, model_path: pathlib.Path, backend: str) -> str:
     # When the backend is not set using the --backend flag, determine the backend automatically
     # 'backend' is optional so we still check for None or empty string in case 'config.yaml' hasn't
     # been updated via 'ilab config init'
-    if backend is None or backend == "":
+    if backend is None:
         logger.debug(
             f"Backend is not set using auto-detected value: {auto_detected_backend}"
         )
@@ -180,7 +165,6 @@ def get(logger: logging.Logger, model_path: pathlib.Path, backend: str) -> str:
     # If the backend was set using the --backend flag, validate it.
     else:
         logger.debug(f"Validating '{backend}' backend")
-        validate_backend(backend)
         # TODO: keep this code logic and implement a `--force` flag to override the auto-detected backend
         # If the backend was set explicitly, but we detected the model should use a different backend, raise an error
         # if backend != auto_detected_backend:

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -11,6 +11,7 @@ import click
 # First Party
 from instructlab import configuration as config
 from instructlab import log, utils
+from instructlab.model.backends import backends
 from instructlab.model.backends.backends import ServerException
 
 logger = logging.getLogger(__name__)
@@ -47,11 +48,10 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--backend",
-    type=click.STRING,  # purposely not using click.Choice to allow for auto-detection
+    type=click.Choice(backends.SUPPORTED_BACKENDS),
     help=(
-        "The backend to use for serving the model."
-        "Automatically detected based on the model file properties."
-        "Supported: 'llama-cpp'."
+        "The backend to use for serving the model.\n"
+        "Automatically detected based on the model file properties.\n"
     ),
 )
 @click.option(
@@ -79,7 +79,7 @@ def serve(
 ):
     """Start a local server"""
     # First Party
-    from instructlab.model.backends import backends, llama_cpp, vllm
+    from instructlab.model.backends import llama_cpp, vllm
 
     host, port = utils.split_hostport(ctx.obj.config.serve.host_port)
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -17,31 +17,6 @@ def mock_supported_backends(monkeypatch):
     )
 
 
-@pytest.mark.usefixtures("mock_supported_backends")
-class TestValidateBackend:
-    def test_validate_backend_valid(self):
-        # Test with a valid backend
-        try:
-            backends.validate_backend("llama-cpp")
-        except ValueError:
-            pytest.fail("validate_backend raised ValueError unexpectedly!")
-        # Test with a valid backend
-        try:
-            backends.validate_backend("LLAMA-CPP")
-        except ValueError:
-            pytest.fail("validate_backend raised ValueError unexpectedly!")
-        # Test with a valid backend
-        try:
-            backends.validate_backend("vllm")
-        except ValueError:
-            pytest.fail("validate_backend raised ValueError unexpectedly!")
-
-    def test_validate_backend_invalid(self):
-        # Test with an invalid backend
-        with pytest.raises(ValueError):
-            backends.validate_backend("foo")
-
-
 def test_free_port():
     host = "localhost"
     port = backends.free_tcp_ipv4_port(host)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,7 +48,7 @@ class TestConfig:
         assert cfg.serve.vllm is not None
         assert cfg.serve.vllm.vllm_args == []
         assert cfg.serve.host_port == "127.0.0.1:8000"
-        assert cfg.serve.backend == ""
+        assert cfg.serve.backend is None
 
         assert cfg.evaluate is not None
 
@@ -119,7 +119,7 @@ generate:
   taxonomy_path: taxonomy
   chunk_word_count: 1000
 serve:
-  backend: ''
+  backend: null
   host_port: 127.0.0.1:8000
   llama_cpp:
     gpu_layers: -1


### PR DESCRIPTION
We support two backends: llama-cpp and vllm, the helper text was only displaying 'llama-ccp' so now we print the correct list of supported backends.

CLI output:

```
  --backend [llama-cpp|vllm]  The backend to use for serving the model.
                              Automatically detected based on the model file
                              properties.
```
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
