### PR TITLE
e2e: Always set `--num-cpus` for generate

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -13,7 +13,7 @@ set -euf
 
 MINIMAL=0
 NUM_INSTRUCTIONS=5
-GENERATE_ARGS=()
+GENERATE_ARGS=("--num-cpus" "$(nproc)")
 TRAIN_ARGS=()
 CI=0
 GRANITE=0
@@ -38,8 +38,8 @@ set_defaults() {
         return
     fi
 
+    # Minimal settings to run in less time
     NUM_INSTRUCTIONS=1
-    GENERATE_ARGS+=("--num-cpus" "$(nproc)")
     TRAIN_ARGS+=("--num-epochs" "1")
 }
 


### PR DESCRIPTION
The script only set this parameter when the minimal option was used,
but we should be setting this option in all cases.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
