### PR TITLE
Modify the Eval config to operate like training and serving

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -315,13 +315,13 @@ def get_uvicorn_config(app: fastapi.FastAPI, host: str, port: int) -> Config:
     )
 
 
-def select_backend(cfg: serve_config) -> BackendServer:
+def select_backend(cfg: serve_config, backend: Optional[str] = None) -> BackendServer:
     # Local
     from .llama_cpp import Server as llama_cpp_server
     from .vllm import Server as vllm_server
 
     model_path = pathlib.Path(cfg.model_path)
-    backend_name = cfg.backend
+    backend_name = backend if backend is not None else cfg.backend
     try:
         backend = get(model_path, backend_name)
     except ValueError as e:

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -245,9 +245,6 @@ def launch_server(
     # pylint: disable=import-outside-toplevel
     # First Party
 
-    # we shouldn't be in the business of editing a user's cfg.
-    # with eval, this is tricky since there are a few things we want to help them out with if they do not exist.
-    # if the user did not set a backend, or model_path, set that for them. Everything else needs to be in the cfg. or in the cmd as flag overrides.
     eval_serve = copy(ctx.obj.config.serve)
     if backend is None:
         eval_serve.backend = backends.VLLM
@@ -256,9 +253,7 @@ def launch_server(
         if gpus:
             # Don't override from vllm_args
             if "--tensor-parallel-size" not in eval_serve.vllm.vllm_args:
-                eval_serve.vllm.vllm_args.extend(
-                    ["--tensor-parallel-size", str(gpus)]
-                )
+                eval_serve.vllm.vllm_args.extend(["--tensor-parallel-size", str(gpus)])
             else:
                 click.echo(
                     "Ignoring --gpus with --tensor-parallel-size configured in serve vllm_args"
@@ -279,7 +274,7 @@ def launch_server(
 
     eval_serve.model_path = model
 
-    backend_instance = backends.select_backend(eval_serve)
+    backend_instance = backends.select_backend(eval_serve, backend)
     try:
         # http_client is handling tls params
         api_base = backend_instance.run_detached(http_client(ctx.params))
@@ -382,7 +377,7 @@ def launch_server(
 )
 @click.option(
     "--backend",
-    type=click.Choice([backends.VLLM, backends.LLAMA_CPP]),
+    type=click.Choice(tuple(backends.SUPPORTED_BACKENDS)),
     help="Serving backend to use for evaluation. Options are vllm and llama-cpp.",
 )
 @click.option(


### PR DESCRIPTION
Training and Serving now operate under the following workflow when it comes to the config.yaml

1. user sets the config in `ilab config init`
2. user can edit portions of the config as they see fit
3. when they run a command like `ilab model serve` or `ilab model train` the values on the cfg are flattened and used as the defaults for the cmd flags
4. the user can at runtime override the defaults by using the flags.

Eval is a special case as it has its own cfg section but also needs to use bits from the serve portion of the cfg.

This PR flattens and includes the serve cfg in the eval default flag map. In order to make this work properly I added `--backend` as a flag for eval. This serves as an override depending on if the user intends to use vllm or llama-cpp. 

The current code overrides some stuff manually in the serve config, I don't think we should be in the buisness of doing this behind the scenes. If the users wants to change their max-ctx-size or max_workers, they can do so in the cfg or in the flags
