### PR TITLE
changeup some serve defaults, align with other commands

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -26,6 +26,8 @@ import click
 import httpx
 import yaml
 
+LLAMA_CPP = "llama-cpp"
+VLLM = "vllm"
 # Local
 from . import log
 
@@ -171,8 +173,9 @@ class _serve(BaseModel):
     model_path: StrictStr
 
     # additional fields with defaults
-    host_port: StrictStr = "127.0.0.1:8000"
-    backend: str = ""  # we don't set a default value here since it's auto-detected
+    host_port: StrictStr
+
+    backend: str
 
     def api_base(self):
         """Returns server API URL, based on the configured host and port"""
@@ -249,6 +252,8 @@ def get_default_config():
         ),
         serve=_serve(
             model_path=DEFAULT_MODEL_PATH,
+            host_port="127.0.0.1:8000",
+            backend=LLAMA_CPP,
             llama_cpp=_serve_llama_cpp(
                 gpu_layers=-1,
                 max_ctx_size=4096,

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -25,8 +25,6 @@ from ...configuration import _serve as serve_config
 from ...configuration import get_api_base
 from ...utils import split_hostport
 
-LLAMA_CPP = "llama-cpp"
-VLLM = "vllm"
 SUPPORTED_BACKENDS = frozenset({LLAMA_CPP, VLLM})
 API_ROOT_WELCOME_MESSAGE = "Hello from InstructLab! Visit us at https://instructlab.ai"
 templates = [

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -222,12 +222,13 @@ def launch_server(
     # pylint: disable=import-outside-toplevel
     # First Party
     from instructlab.model.backends import backends
+    import instructlab.configuration as cfg
 
     if not ctx.obj.config.serve.backend:
-        ctx.obj.config.serve.backend = backends.VLLM
-    if ctx.obj.config.serve.backend == backends.VLLM:
+        ctx.obj.config.serve.backend = cfg.VLLM
+    if ctx.obj.config.serve.backend == cfg.VLLM:
         ctx.obj.config.serve.vllm.vllm_args.extend(["--served-model-name", model_name])
-    elif ctx.obj.config.serve.backend == backends.LLAMA_CPP:
+    elif ctx.obj.config.serve.backend == cfg.LLAMA_CPP:
         # mt_bench requires a larger context size
         ctx.obj.config.serve.llama_cpp.max_ctx_size = 5120
         # llama-cpp fails fast on too many incoming requests and returns errors to client
@@ -235,7 +236,7 @@ def launch_server(
 
     ctx.obj.config.serve.model_path = model
 
-    backend_instance = backends.select_backend(logger, ctx.obj.config.serve)
+    backend_instance = cfg.select_backend(logger, ctx.obj.config.serve)
     try:
         # http_client is handling tls params
         backend_instance.run_detached(http_client(ctx.params))

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -80,6 +80,7 @@ def serve(
     """Start a local server"""
     # First Party
     from instructlab.model.backends import backends, llama_cpp, vllm
+    import instructlab.configuration as cfg
 
     host, port = utils.split_hostport(ctx.obj.config.serve.host_port)
 
@@ -100,7 +101,7 @@ def serve(
     logger.info(f"Serving model '{model_path}' with {backend}")
 
     backend_instance = None
-    if backend == backends.LLAMA_CPP:
+    if backend == cfg.LLAMA_CPP:
         # Instantiate the llama server
         if gpu_layers is None:
             gpu_layers = ctx.obj.config.serve.llama_cpp.gpu_layers
@@ -119,7 +120,7 @@ def serve(
             num_threads=num_threads,
         )
 
-    if backend == backends.VLLM:
+    if backend == cfg.VLLM:
         # Instantiate the vllm server
         backend_instance = vllm.Server(
             logger=logger,


### PR DESCRIPTION
`get_default_config` should be the only place defaults are set, not in the class definition also, cmds like eval have shown us that we probably should just set `llama-cpp` as a default
