### PR TITLE
generate: Add `--sdg-scale-factor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 * Default log format changes to include the logger name in the logs.
 * Introduces CUDA-specific requirements in a new file `requirements-cuda.txt`. To install these
   CUDA-enabled dependencies, simply run `pip install instructlab[cuda]`.
+* `ilab data generate` now supports a new and more extensive pipeline with the
+  option `--pipeline full`. This option requires `mixtral-8x7b-instruct` as the
+  teacher model.
 
 ### Breaking Changes
 
@@ -52,6 +55,9 @@
    program cache directory.
 * `ilab model chat`: Chatlogs are now stored under the `instructlab/checkpoints` directory in the
    platform's dedicated data directory under the `instructlab` package.
+* The `--num-instructions` option to `ilab data generate` has been deprecated.
+  See `--sdg-scale-factor` for an updated option providing similar
+  functionality.
 
 ## v0.17
 

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -294,7 +294,7 @@ seed_examples:
 task_description: "simple maths"
 EOF
 
-    sed -i.bak -e 's/num_instructions:.*/num_instructions: 1/g' "${ILAB_CONFIG_FILE}"
+    sed -i.bak -e 's/sdg_scale_factor.*/sdg_scale_factor: 1/g' "${ILAB_CONFIG_FILE}"
 
     # This should be finished in a minute or so but time it out incase it goes wrong
     if ! timeout 20m ilab data generate --taxonomy-path test_taxonomy/compositional_skills/simple_math.yaml; then

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -73,10 +73,10 @@ class _InstructlabDefaults:
     # TODO: these constants should be removed, they should not leak out
     NUM_CPUS = 10
     CHUNK_WORD_COUNT = 1000
-    NUM_INSTRUCTIONS = 100
     CONNECTION_TIMEOUT = httpx.Timeout(timeout=30.0)
     # use spawn start method, fork is not thread-safe
     MULTIPROCESSING_START_METHOD = "spawn"
+    SDG_SCALE_FACTOR = 30
 
     # When otherwise unknown, ilab uses this as the default family
     MODEL_FAMILY = "merlinite"
@@ -256,7 +256,13 @@ class _generate(BaseModel):
     # additional fields with defaults
     num_cpus: PositiveInt = DEFAULTS.NUM_CPUS
     chunk_word_count: PositiveInt = DEFAULTS.CHUNK_WORD_COUNT
-    num_instructions: PositiveInt = DEFAULTS.NUM_INSTRUCTIONS
+    # DEPRECATED: see sdg_scale_factor instead
+    # Left in place so that we can still detect and give a warning if its
+    # specified in an old configuraiton file.
+    num_instructions: Optional[int] = Field(
+        default=-1, deprecated="see 'sdg_scale_factor' instead", exclude=True
+    )
+    sdg_scale_factor: Optional[PositiveInt] = DEFAULTS.SDG_SCALE_FACTOR
     output_dir: StrictStr = Field(default_factory=lambda: DEFAULTS.DATASETS_DIR)
     prompt_file: StrictStr = Field(default_factory=lambda: DEFAULTS.PROMPT_FILE)
     seed_file: StrictStr = Field(default_factory=lambda: DEFAULTS.SEED_FILE)

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -37,11 +37,17 @@ logger = logging.getLogger(__name__)
     default=DEFAULTS.CHUNK_WORD_COUNT,
     show_default=True,
 )
+# TODO - DEPRECATED - Remove in a future release
 @click.option(
     "--num-instructions",
     type=click.INT,
-    help="Number of instructions to generate.",
-    default=DEFAULTS.NUM_INSTRUCTIONS,
+    default=-1,
+    hidden=True,
+)
+@click.option(
+    "--sdg-scale-factor",
+    type=click.INT,
+    help="Number of instructions to generate for each seed example. The examples map to sample q&a pairs for new skills. For knowledge, examples are generated with both the sample q&a pairs, as well as chunks of the knowledge document(s), so the resulting data set is typically larger for a knowledge addition for the same value of `--sdg-scale-factor`.",
     show_default=True,
 )
 @click.option(
@@ -145,6 +151,7 @@ def generate(
     model,
     num_cpus,
     num_instructions,
+    sdg_scale_factor,
     taxonomy_path,
     taxonomy_base,
     output_dir,
@@ -168,7 +175,14 @@ def generate(
     from instructlab.sdg.generate_data import generate_data
     from instructlab.sdg.utils import GenerateException
 
+    if num_instructions != -1:
+        click.secho(
+            "The --num-instructions flag is deprecated. Please use --sdg-scale-factor instead.",
+            fg="yellow",
+        )
+
     prompt_file_path = DEFAULTS.PROMPT_FILE
+
     if ctx.obj is not None:
         prompt_file_path = ctx.obj.config.generate.prompt_file
 
@@ -199,7 +213,7 @@ def generate(
             model_family=model_family,
             model_name=model,
             num_cpus=num_cpus,
-            num_instructions_to_generate=num_instructions,
+            num_instructions_to_generate=sdg_scale_factor,
             taxonomy=taxonomy_path,
             taxonomy_base=taxonomy_base,
             output_dir=output_dir,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,7 +46,7 @@ class TestConfig:
         assert cfg.generate.taxonomy_path == f"{data_dir}/taxonomy"
         assert cfg.generate.taxonomy_base == "origin/main"
         assert cfg.generate.num_cpus == 10
-        assert cfg.generate.num_instructions == 100
+        assert cfg.generate.sdg_scale_factor == 30
         assert cfg.generate.chunk_word_count == 1000
         assert cfg.generate.output_dir == f"{data_dir}/datasets"
         assert cfg.generate.prompt_file == f"{data_dir}/{internal_dirname}/prompt.txt"


### PR DESCRIPTION

77371ee generate: Add `--sdg-scale-factor`

commit 77371ee3efe23c5fec8fdb3afa04c607135215fa
Author: Russell Bryant <rbryant@redhat.com>
Date:   Tue Jul 2 20:21:22 2024 -0400

    generate: Add `--sdg-scale-factor`
    
    The new implementation of data generation from the `instructlab/sdg`
    library behaves differently than before. Instead of having a tunable
    for the maximum number of generated examples, it has a tunable for the
    number of examples to generate based on each seed example, for some
    definition of "seed example". The number of seed examples expodes to
    be much more than the provided q&a pairs when working with a knowledge
    document.
    
    The new option, `--sdg-scale-factor` tries to capture this new
    behavior and make it clear that it's not a specific number of examples
    anymore, but more of a multiplication factor.
    
    We could come back and add a new option that behaves like the old one,
    like `--max-generated-examples`, but even that is slightly different
    than what was here before. Instead of implementing that now, hold off
    until a good enough use case justifies the need for it, because it
    would be harmful in some cases. For example, when working with a
    knowledge document, setting a hard cap on the number of generated
    examples will most likely halt the process before the full knowledge
    document (or documents) have been processed.
    
    The configuration file has also been updated to do the following:
    
    - Optionally allow `sdg_scale_factor` so that previous config files
      still work. Many options have been added recently without doing
      this, breaking old configs.
    
    - Allow num_instructions in the config file. This allows old config
      files to work without error, but a deprecation warning will be
      emitted.
    
    - Ensure that the deprecated field is not included when generating
      a sample configuration file.
    
    I believe this is the first example of deprecating a config file
    option in a backwards compatible way.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
