### PR TITLE
fix: serve log message with gpu layer and context size values

### DIFF
--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -93,6 +93,10 @@ def serve(
     # Redirect server stdout and stderr to the logger
     log.stdout_stderr_to_logger(logger, log_file)
 
+    if gpu_layers is None:
+        gpu_layers = ctx.obj.config.serve.llama_cpp.gpu_layers
+    if max_ctx_size is None:
+        max_ctx_size = ctx.obj.config.serve.llama_cpp.max_ctx_size
     logger.info(
         f"Using model '{model_path}' with {gpu_layers} gpu-layers and {max_ctx_size} max context size."
     )


### PR DESCRIPTION
Since `gpu_layers` and `max_ctx_size` have moved in their own llama_cpp section under the serve section in the config file, if the user does not pass these via flag on CLI they will be None.
The log was printing:

```
INFO 2024-07-03 11:20:38,450 serve.py:101: serve Using model
'models/merlinite-7b-lab-Q4_K_M.gguf' with None gpu-layers and None max
context size.
```

We now pick the default value from the config (which has default) if either `gpu_layers` or `max_ctx_size` are None.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
