### PR TITLE
fix: warn if vLLM is set and OS is not Linux

### DIFF
--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,4 +1,6 @@
 # Standard
+from unittest.mock import patch
+import pathlib
 import socket
 
 # Third Party
@@ -7,15 +9,6 @@ import pytest
 # First Party
 from instructlab.model.backends import backends
 
-supported_backends = ["llama-cpp", "vllm"]  # Example supported backends
-
-
-@pytest.fixture
-def mock_supported_backends(monkeypatch):
-    monkeypatch.setattr(
-        "instructlab.model.backends.backends.SUPPORTED_BACKENDS", supported_backends
-    )
-
 
 def test_free_port():
     host = "localhost"
@@ -23,3 +16,70 @@ def test_free_port():
     # check that port is bindable
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind((host, port))
+
+
+# the test fails because the model_path is not a valid GGUF file
+def test_get_backend_auto_detection_fail_not_gguf(tmp_path: pathlib.Path):
+    tmp_gguf = tmp_path / "test.gguf"
+    # Write a known invalid header
+    invalid_header = (
+        b"\x00\x00\x00\x00"  # Use a header that will definitely not match "GGUF_MAGIC"
+    )
+    tmp_gguf.write_bytes(
+        invalid_header + bytes([0] * 4093)
+    )  # Fill the rest of the file with zeros
+    with pytest.raises(ValueError) as exc_info:
+        backends.get(tmp_gguf, None)
+    assert "is not a GGUF format" in str(exc_info.value)
+
+
+# this test succeeds because the model_path is a valid GGUF file (is_model_gguf mocked to returns True)
+@patch("instructlab.model.backends.backends.is_model_gguf", return_value=True)
+def test_get_backend_auto_detection_success_gguf(
+    m_is_model_gguf, tmp_path: pathlib.Path
+):
+    tmp_gguf = tmp_path / "test.gguf"
+    backend = backends.get(tmp_gguf, None)
+    assert backend == "llama-cpp"
+    m_is_model_gguf.assert_called_once_with(tmp_gguf)
+
+
+# this test fails because the model_path is a directory but the platform is not linux
+@patch("sys.platform", "darwin")
+def test_get_backend_auto_detection_failure_vllm_dir_but_not_linux(
+    tmp_path: pathlib.Path,
+):
+    with pytest.raises(ValueError) as exc_info:
+        backends.get(tmp_path, None)
+    assert "Cannot determine which backend to use" in str(exc_info.value)
+
+
+# this test succeeds because the model_path is a directory and the platform is linux so vllm is
+# picked
+@patch("sys.platform", "linux")
+def test_get_backend_auto_detection_success_vllm_dir(tmp_path: pathlib.Path):
+    backend = backends.get(tmp_path, None)
+    assert backend == "vllm"
+
+
+# this test fails because the OS is darwin and a directory is passed, only works on Linux
+@patch("sys.platform", "darwin")
+def test_get_backend_auto_detection_failed_vllm_dir_darwin(tmp_path: pathlib.Path):
+    with pytest.raises(ValueError) as exc_info:
+        backends.get(tmp_path, None)
+    assert (
+        "Model is a directory containing huggingface safetensors files but the system is not Linux."
+        in str(exc_info.value)
+    )
+
+
+# this test succeeds even if the auto-detection picked a different backend, we continue with what
+# the user requested
+@patch(
+    "instructlab.model.backends.backends.determine_backend",
+    return_value=("vllm", "reason for selection"),
+)
+def test_get_forced_backend_fails_autodetection(m_determine_backend):
+    backend = backends.get("", "llama-cpp")
+    assert backend == "llama-cpp"
+    m_determine_backend.assert_called_once()


### PR DESCRIPTION
Running `ilab model serve --backend vllm` on macOS will never work since
vLLM is only supported on Linux.

The CLI now warns with:

```
$ ilab model serve --backend vllm
...
WARNING 2024-07-11 09:30:34,816 backends.py:195: get The serving backend 'vllm' was configured explicitly, but the provided model is not compatible with it. The model was detected as 'llama-cpp, reason: model is a GGUF file.'.
The backend startup sequence will continue with the configured backend but might fail.
```

And the backend initialization will fail later on.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
