### PR TITLE
Enable more Ruff checkers and fixers

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -48,13 +48,15 @@ fail-under=10
 #from-stdin=
 
 # Files or directories to be skipped. They should be base names, not paths.
-ignore=CVS,protobufs,train,llamacpp,mlx_explore
+ignore=CVS
 
 # Add files or directories matching the regular expressions patterns to the
 # ignore-list. The regex matches against paths and can be in Posix or Windows
 # format. Because '\\' represents the directory delimiter on Windows systems,
 # it can't be used as an escape character.
-ignore-paths=
+ignore-paths=^src/instructlab/llamacpp/.*$,
+    ^src/instructlab/mlx_explore/.*$,
+    ^src/instructlab/train/lora_mlx/.*$,
 
 # Files or directories matching the regular expression patterns are skipped.
 # The regex matches against base names, not paths. The default value ignores

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ include = [
 ignore = ["W002"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 # same as black's default line length
 line-length = 88
 
@@ -79,21 +79,30 @@ unfixable = []
 
 # Fixers will be enabled gradually.
 select = [
-  # "B",  # flake8-bugbear
-  # "E",  # pycodestyle
-  # "F",  # Pyflakes
+  "B", # flake8-bugbear
+  "E", # pycodestyle
+  "F", # Pyflakes
   "Q", # flake8-quotes
   # Ruff does not support isort's import_headings feature, yet.
-  # "I",  # isort
+  # "I",   # isort
   # "UP",  # pyupgrade
-  # "SIM",  # flake8-simplify
+  "SIM", # flake8-simplify
   "TID", # flake8-tidy-imports
 ]
 ignore = [
+  "B904", # TODO: "raise from err" or "raise from None"
   # some embedded strings are longer than 88 characters
   "E501",   # line too long
+  "SIM108", # Use ternary operator
+  "SIM102", # Use a single if instead of nested if
   "TID252", # Prefer absolute imports over relative imports from parent modules
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# vendored files, maintained externally
+"src/instructlab/llamacpp/llamacpp_convert_to_gguf.py" = ["ALL"]
+"src/instructlab/mlx_explore/**" = ["ALL"]
+"src/instructlab/train/lora_mlx/**" = ["ALL"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "yamllint".msg = "yamllint is for CLI usage only."

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -372,7 +372,7 @@ def get_api_base(host_port):
 def get_model_family(forced, model_path):
     forced = MODEL_FAMILY_MAPPINGS.get(forced, forced)
     if forced and forced.lower() not in MODEL_FAMILIES:
-        raise ConfigException("Unknown model family: %s" % forced)
+        raise ConfigException(f"Unknown model family: {forced}")
 
     # Try to guess the model family based on the model's filename
     guess = match(r"^\w*", path.basename(model_path)).group(0).lower()

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -2,7 +2,7 @@
 
 # Standard
 from time import sleep
-from typing import Optional, Tuple
+from typing import Tuple
 import abc
 import logging
 import mmap

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -523,7 +523,7 @@ def evaluate(
         m_paths = [model, base_model]
         overall_scores = []
         individual_scores_list = []
-        for i, evaluator in enumerate(evaluators):
+        for evaluator in evaluators:
             overall_score, individual_scores = evaluator.run()
             overall_scores.append(overall_score)
             individual_scores_list.append(individual_scores)

--- a/src/instructlab/model/test.py
+++ b/src/instructlab/model/test.py
@@ -47,8 +47,8 @@ def test(data_dir, model_dir, adapter_file):
     adapter_file_exists = adapter_file and os.path.exists(adapter_file)
     if adapter_file and not adapter_file_exists:
         print(
-            "NOTE: Adapter file does not exist. Testing behavior before training only. - %s"
-            % adapter_file
+            "NOTE: Adapter file does not exist. Testing behavior before "
+            f"training only. - {adapter_file}"
         )
 
     # Load the JSON Lines file

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -45,7 +45,7 @@ try:
     # pylint: disable=import-error
     # Third Party
     from habana_frameworks.torch import core as htcore
-    from habana_frameworks.torch import hpu as hpu
+    from habana_frameworks.torch import hpu
 
     # Habana implementations of SFT Trainer
     # https://huggingface.co/docs/optimum/habana/index
@@ -64,6 +64,7 @@ except ImportError:
 
 
 class StoppingCriteriaSub(StoppingCriteria):
+    # pylint: disable=unused-argument
     def __init__(self, stops=(), encounters=1, *, device: torch.device):
         super().__init__()
         self.device = device
@@ -309,11 +310,11 @@ def linux_train(
 
     print("LINUX_TRAIN.PY: GETTING THE ATTENTION LAYERS")
     # Print information about the attention modules
-    for i, layer in enumerate(attention_layers):
+    for layer in attention_layers:
         for par in list(layer.named_parameters()):
             mod = par[0]
             if isinstance(mod, str):
-                mod.split(".")[0]
+                mod = mod.split(".")[0]
         break
 
     print("LINUX_TRAIN.PY: CONFIGURING LoRA")
@@ -421,7 +422,9 @@ def linux_train(
 
     print("LINUX_TRAIN.PY: RUNNING INFERENCE ON THE OUTPUT MODEL")
 
-    for i, (d, assistant_old) in enumerate(zip(test_dataset, assistant_old_lst)):
+    for i, (d, assistant_old) in enumerate(
+        zip(test_dataset, assistant_old_lst, strict=False)
+    ):
         output = model_generate(d["user"], **generate_kwargs)
         assistant_new = output.split(response_template.strip())[-1].strip()
         assistant_expected = d["assistant"]


### PR DESCRIPTION
Ruff can not just detect and report code violations. It can automatically fix a large amount of code violations, too. This change enables most checkers and addresses their code violations:

- Update minimal Python version to 3.10
- Remove unnecesary `zip`
- Remove some unused imports
- Simplify some code
- Avoid `l`, which can be easily confused with `1`.
- Use full path regexps for pylint's `ignore-paths`

This change only contains uncontroversial and simple fixes. I will enable more fixers in the near future.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
