### PR TITLE
Require setuptools >= 70.1.0 to build wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
+requires = ["setuptools>=70.1.0", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
setuptools < 70.0 have a bug in the schema definition for dynamic optional dependencies. The issue was fixed in validate-pyproject 0.17 and setuptools 70.0.0.

70.1.0 has another fix that might be relevant for Python 3.10.

This fixes the following error message:

```
ValueError: invalid pyproject.toml config: `tool.setuptools.dynamic.optional-dependencies`.
configuration error: `tool.setuptools.dynamic.optional-dependencies` keys must be named by:

    {format: 'python-identifier'}
```

See: https://github.com/abravalheri/validate-pyproject/pull/170

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
