### PR TITLE
e2e: Don't upgrade OS packages on AWS runners

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x1.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x1.yml
@@ -112,7 +112,6 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf -y upgrade
           sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
 
       - name: Install ilab

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -112,7 +112,6 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf -y upgrade
           sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
 
       - name: Install ilab


### PR DESCRIPTION
The AMI we use is built to have some things pre-installed - most
notably the NVIDIA drivers and CUDA stack. I noticed that this upgrade
was now pulling in a new NVIDIA version, including a driver.

By not running an upgrade, we'll control when we apply updates to our
base image for important pre-installed dependencies.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
