### PR TITLE
fix: Updating Nvidia GPU setup on RH systems in cloud-instance

### DIFF
--- a/scripts/infra/README.md
+++ b/scripts/infra/README.md
@@ -44,35 +44,35 @@ Either way, you'll need to edit the config to reference your cloud environment(s
 
 ## Usage
 
-`./cloud-instance.sh <cloud-type> <command> [options]`
+`scripts/infra/cloud-instance.sh <cloud-type> <command> [options]`
 
 Example:
 
 ```bash
 # Launch a new instance with your `EC2_INSTANCE_NAME` and `EC2_INSTANCE_TYPE` specified
 # in config with the instance type including Nvidia GPU(s)
-./cloud-instance.sh ec2 launch
+scripts/infra/cloud-instance.sh ec2 launch
 # Clone instructlab onto the instance and setup the development environment
-./cloud-instance.sh ec2 setup-rh-devenv
+scripts/infra/cloud-instance.sh ec2 setup-rh-devenv
 # Install nvidia drivers and reboot
-./cloud-instance.sh ec2 install-rh-nvidia-drivers
-./cloud-instance.sh ec2 ssh sudo reboot
+scripts/infra/cloud-instance.sh ec2 install-rh-nvidia-drivers
+scripts/infra/cloud-instance.sh ec2 ssh sudo reboot
 # Install instructlab
-./cloud-instance.sh ec2 pip-install-with-nvidia
+scripts/infra/cloud-instance.sh ec2 pip-install-with-nvidia
 # ssh to the instance
-./cloud-instance.sh ec2 ssh
+scripts/infra/cloud-instance.sh ec2 ssh
 # Run commands on the instance through ssh
-./cloud-instance.sh ec2 ssh ls -la
-./cloud-instance.sh ec2 ssh "source instructlab/venv/bin/activate && ilab sysinfo"
+scripts/infra/cloud-instance.sh ec2 ssh ls -la
+scripts/infra/cloud-instance.sh ec2 ssh "source instructlab/venv/bin/activate && ilab sysinfo"
 # Sync your local git repo to the repo on the instance
-./cloud-instance.sh ec2 sync
+scripts/infra/cloud-instance.sh ec2 sync
 # Make changes in your local git without committing
 # Sync your changes to the remote instance with a temporary commit
-./cloud-instance.sh ec2 sync -c
+scripts/infra/cloud-instance.sh ec2 sync -c
 # When you're done, stop the instance
-./cloud-instance.sh ec2 stop
+scripts/infra/cloud-instance.sh ec2 stop
 # While stopped and not yet pruned from your account, you can restart it if needed
-./cloud-instance.sh ec2 start
+scripts/infra/cloud-instance.sh ec2 start
 # When you are done, you can delete the instance
-./cloud-instance.sh ec2 terminate
+scripts/infra/cloud-instance.sh ec2 terminate
 ```


### PR DESCRIPTION
The fix requires version locking cuda and nccl.

Includes minor change to reference cloud-instance from root of instructlab consistently.  This helps users not need to cd so many times to follow the README verbatim.

Related to: #1566 

**Checklist:**

- [*] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
