### PR TITLE
e2e: Add support for full SDG pipeline

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -20,6 +20,7 @@ GRANITE=0
 FULLTRAIN=0
 BACKEND="llama-cpp"
 HF_TOKEN=${HF_TOKEN:-}
+SDG_PIPELINE="simple"
 
 export GREP_COLORS='mt=1;33'
 BOLD='\033[1m'
@@ -165,6 +166,9 @@ test_generate() {
     elif [ "$BACKEND" = "vllm" ]; then
         GENERATE_ARGS+=("--model ./models/instructlab/merlinite-7b-lab")
     fi
+    if [ "$SDG_PIPELINE" = "full" ]; then
+        GENERATE_ARGS+=("--pipeline" "full")
+    fi
     ilab data generate --num-instructions ${NUM_INSTRUCTIONS} "${GENERATE_ARGS[@]}"
 }
 
@@ -254,16 +258,16 @@ usage() {
     echo "Usage: $0 [-m] [-h]"
     echo "  -m  Run minimal configuration (run quicker when you have no GPU)"
     echo "  -f  Run the fullsize training instead of --4-bit-quant"
+    echo "  -F  Use the 'full' SDG pipeline instead of the default 'simple' pipeline"
     echo "  -g  Use the granite model"
     echo "  -v  Use the vLLM backend for serving"
     echo "  -M  Use the mixtral model (4-bit quantized)"
     echo "  -h  Show this help text"
-
 }
 
 # Process command line arguments
 task "Configuring ..."
-while getopts "cmMfghv" opt; do
+while getopts "cmMfFghv" opt; do
     case $opt in
         c)
             # old option, don't fail if it's specified
@@ -279,6 +283,10 @@ while getopts "cmMfghv" opt; do
         f)
             FULLTRAIN=1
             step "Running fullsize training."
+            ;;
+        F)
+            SDG_PIPELINE="full"
+            step "Using full SDG pipeline."
             ;;
         g)
             GRANITE=1


### PR DESCRIPTION

a9d5f79 e2e: Add script support for running Mixtral
c3ccacc e2e: Add script support for testing full sdg pipeline

commit a9d5f793dfaa4d9df97ebede2a8a1a92c184df0a
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Jul 4 00:00:35 2024 -0400

    e2e: Add script support for running Mixtral
    
    Before we can test `ilab data generate --pipeline full`, we must be
    able to serve Mixtral. This commit adds that support to the e2e test
    script. It includes
    
    - downloading the 4-bit quantized version of the model
    
    - updating config.yaml to specify mixtral
    
    - updating command line parameters as appropriate for mixtral
    
    - Adjust the timeout while waiting for the model server to come up to
      be 30s instead of 10s. This model is much larger and takes longer to
      load. In my testing, 10s wasn't enough.
    
    A prerequisite for #1588
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit c3ccacc5504b3043c81b222f9c9a9635a41260b2
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Jul 5 20:49:29 2024 -0400

    e2e: Add script support for testing full sdg pipeline
    
    This script uses the default `simple` pipeline for `ilab data
    generate` by default. The `full` pipeline requires more resources and
    a larger teacher model. Add a flag to turn it on.
    
    Part of #1588
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
