### PR TITLE
Improve config default lookup and `--help` message

### DIFF
--- a/src/instructlab/clickext.py
+++ b/src/instructlab/clickext.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Click extensions for InstructLab"""
+
+# Standard
+import typing
+
+# Third Party
+import click
+
+
+class ConfigOption(click.Option):
+    """A click.Option with extended default lookup help
+
+    The defaults can be looked up in a subsection of the context's
+    default_map.
+
+    The help output of ConfigOption class reads defaults from the context's
+    default_map and shows the name of the config settings.
+
+    Example:
+        Options:
+        --model-path PATH           Path to the model used during generation.
+                                    [default: models/merlinite-7b-lab-Q4_K_M.gguf;
+                                    config: 'serve.model_path']
+    """
+
+    def __init__(
+        self, *args: typing.Any, config_section: str | None = None, **kwargs: typing.Any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        if self.show_default:
+            raise ValueError("show_default must be False")
+        self.config_section: str | None = config_section
+
+    def get_help_record(self, ctx: click.Context) -> tuple[str, str] | None:
+        result = super().get_help_record(ctx)
+        if result is None or ctx.default_map is None:
+            # hidden is True
+            # missing default map (clickman, sphinx)
+            return result
+
+        # get default from default_map
+        cmd = ctx.command.name
+        name = self.name
+        if typing.TYPE_CHECKING:
+            assert name is not None
+        if self.config_section is None:
+            if self.name not in ctx.default_map:
+                raise ValueError(f"{cmd}.{name} not in default_map {ctx.default_map}")
+        else:
+            section = ctx.default_map.get(self.config_section, {})
+            if self.name not in section:
+                raise ValueError(
+                    f"{cmd}.{self.config_section}.{name} not in default_map {ctx.default_map}"
+                )
+
+        # create help extra
+        default_value = self.get_default(ctx)
+        if default_value is None:
+            default_string = "<None>"
+        elif isinstance(default_value, (list, tuple)):
+            default_string = ", ".join(str(d) for d in default_value)
+        else:
+            default_string = str(default_value)
+
+        if self.config_section is None:
+            config_name = f"{cmd}.{name}"
+        else:
+            config_name = f"{cmd}.{self.config_section}.{name}"
+
+        default_msg = f"default: {default_string}; config: '{config_name}'"
+
+        # extend message
+        prefix, msg = result
+        if msg.endswith("]"):
+            msg = f"{msg[:-1]}; {default_msg}]"
+        else:
+            msg = f"{msg}  [{default_msg}]"
+        return prefix, msg
+
+    def get_default(
+        self, ctx: click.Context, call: bool = True
+    ) -> typing.Any | typing.Callable[[], typing.Any] | None:
+        """Lookup default in config subsection
+
+        Used so "serve" option "gpu_layers" looks up its default in
+        "serve.llama_cpp.gpu_layers" instead of "serve.gpu_layers".
+        """
+        if self.config_section is None:
+            # no config subsection
+            return super().get_default(ctx, call=call)
+        if ctx.default_map is not None:
+            section = ctx.default_map.get(self.config_section, {})
+            value = section.get(self.name)
+            if call and callable(value):
+                return value()
+            return value
+        return None

--- a/src/instructlab/config/config.py
+++ b/src/instructlab/config/config.py
@@ -16,6 +16,8 @@ def config(ctx):
     If this is your first time running ilab, it's best to start with `ilab config init` to create the environment.
     """
     ctx.obj = ctx.parent.obj
+    if ctx.invoked_subcommand not in {"init"}:
+        ctx.obj.ensure_config(ctx)
     ctx.default_map = ctx.parent.default_map
 
 

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -6,6 +6,7 @@ from re import match
 from typing import Optional
 import os
 import sys
+import typing
 
 # Third Party
 from instructlab.training import (
@@ -240,7 +241,7 @@ class Config(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
-def get_default_config():
+def get_default_config() -> Config:
     """Generates default configuration for CLI"""
     return Config(
         chat=_chat(model=DEFAULT_MODEL),
@@ -312,6 +313,33 @@ def get_default_config():
     )
 
 
+def get_default_map(config: Config) -> dict[str, typing.Any]:
+    """Get default map for Click"""
+    # default_map holds a dictionary with default values for each command parameters
+    config_dict = get_dict(config)
+    # since torch and train args are sep, they need to be combined into a single `train` entity for the default map
+    # this is because the flags for `ilab model train` will only be populated if the default map has a single `train` entry, not two.
+    config_dict["train"] = (
+        config_dict["train"]["train_args"]
+        | config_dict["train"]["torch_args"]
+        | config_dict["train"]["train_args"]["lora"]
+        | config_dict["train"]["train_args"]["deepspeed_options"]
+    )
+    config_dict["evaluate"] = (
+        config_dict["evaluate"]
+        | config_dict["evaluate"]["mmlu"]
+        | config_dict["evaluate"]["mmlu_branch"]
+        | config_dict["evaluate"]["mt_bench"]
+        | config_dict["evaluate"]["mt_bench_branch"]
+    )
+    # need to delete the individual sub-classes from the map
+    del config_dict["evaluate"]["mmlu"]
+    del config_dict["evaluate"]["mmlu_branch"]
+    del config_dict["evaluate"]["mt_bench"]
+    del config_dict["evaluate"]["mt_bench_branch"]
+    return config_dict
+
+
 def read_train_profile(train_file):
     try:
         with open(train_file, "r", encoding="utf-8") as yamlfile:
@@ -332,7 +360,7 @@ def read_train_profile(train_file):
         raise ConfigException(msg) from exc
 
 
-def read_config(config_file=DEFAULT_CONFIG):
+def read_config(config_file: str | os.PathLike[str] = DEFAULT_CONFIG) -> Config:
     """Reads configuration from disk."""
     try:
         with open(config_file, "r", encoding="utf-8") as yamlfile:
@@ -345,7 +373,7 @@ def read_config(config_file=DEFAULT_CONFIG):
                 "- "
                 + err.get("type", "")
                 + " "
-                + "->".join(err.get("loc", ""))
+                + "->".join(err.get("loc", ""))  # type: ignore
                 + ": "
                 + err.get("msg", "").lower()
                 + "\n"
@@ -353,12 +381,12 @@ def read_config(config_file=DEFAULT_CONFIG):
         raise ConfigException(msg) from exc
 
 
-def get_dict(cfg):
+def get_dict(cfg: Config) -> dict[str, typing.Any]:
     """Returns configuration as a dictionary"""
     return cfg.model_dump()
 
 
-def write_config(cfg, config_file=DEFAULT_CONFIG):
+def write_config(cfg: Config, config_file: str = DEFAULT_CONFIG) -> None:
     """Writes configuration to a disk"""
     with open(config_file, "w", encoding="utf-8") as yamlfile:
         d = cfg.model_dump_json()
@@ -366,7 +394,7 @@ def write_config(cfg, config_file=DEFAULT_CONFIG):
         yaml.dump(loaded, stream=yamlfile)
 
 
-def get_api_base(host_port):
+def get_api_base(host_port: str) -> str:
     """Returns server API URL, based on the provided host_port"""
     return f"http://{host_port}/v1"
 
@@ -392,9 +420,11 @@ class Lab:
 
 def init(ctx, config_file):
     if (
-        ctx.invoked_subcommand not in {"config", "init", "sysinfo"}
-        and "--help" not in sys.argv[1:]
+        ctx.invoked_subcommand in {"config", "init", "sysinfo"}
+        or "--help" in sys.argv[1:]
     ):
+        config_obj = get_default_config()
+    else:
         if config_file == "DEFAULT":
             config_obj = get_default_config()
         elif not os.path.isfile(config_file):
@@ -408,30 +438,8 @@ def init(ctx, config_file):
                 config_obj = read_config(config_file)
             except ConfigException as ex:
                 raise click.ClickException(str(ex))
-        # setup logging
-        log.configure_logging(log_level=config_obj.general.log_level.upper())
-        ctx.obj = Lab(config_obj)
-        # default_map holds a dictionary with default values for each command parameters
-        config_dict = get_dict(ctx.obj.config)
-        # since torch and train args are sep, they need to be combined into a single `train` entity for the default map
-        # this is because the flags for `ilab model train` will only be populated if the default map has a single `train` entry, not two.
-        config_dict["train"] = (
-            config_dict["train"]["train_args"]
-            | config_dict["train"]["torch_args"]
-            | config_dict["train"]["train_args"]["lora"]
-            | config_dict["train"]["train_args"]["deepspeed_options"]
-        )
-        config_dict["evaluate"] = (
-            config_dict["evaluate"]
-            | config_dict["evaluate"]["mmlu"]
-            | config_dict["evaluate"]["mmlu_branch"]
-            | config_dict["evaluate"]["mt_bench"]
-            | config_dict["evaluate"]["mt_bench_branch"]
-        )
-        # need to delete the individual sub-classes from the map
-        del config_dict["evaluate"]["mmlu"]
-        del config_dict["evaluate"]["mmlu_branch"]
-        del config_dict["evaluate"]["mt_bench"]
-        del config_dict["evaluate"]["mt_bench_branch"]
 
-        ctx.default_map = config_dict
+    # setup logging
+    log.configure_logging(log_level=config_obj.general.log_level.upper())
+    ctx.obj = Lab(config_obj)
+    ctx.default_map = get_default_map(ctx.obj.config)

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -317,26 +317,13 @@ def get_default_map(config: Config) -> dict[str, typing.Any]:
     """Get default map for Click"""
     # default_map holds a dictionary with default values for each command parameters
     config_dict = get_dict(config)
-    # since torch and train args are sep, they need to be combined into a single `train` entity for the default map
-    # this is because the flags for `ilab model train` will only be populated if the default map has a single `train` entry, not two.
-    config_dict["train"] = (
-        config_dict["train"]["train_args"]
-        | config_dict["train"]["torch_args"]
-        | config_dict["train"]["train_args"]["lora"]
-        | config_dict["train"]["train_args"]["deepspeed_options"]
-    )
     config_dict["evaluate"] = (
         config_dict["evaluate"]
-        | config_dict["evaluate"]["mmlu"]
-        | config_dict["evaluate"]["mmlu_branch"]
-        | config_dict["evaluate"]["mt_bench"]
-        | config_dict["evaluate"]["mt_bench_branch"]
+        | config_dict["evaluate"].pop("mmlu")
+        | config_dict["evaluate"].pop("mmlu_branch")
+        | config_dict["evaluate"].pop("mt_bench")
+        | config_dict["evaluate"].pop("mt_bench_branch")
     )
-    # need to delete the individual sub-classes from the map
-    del config_dict["evaluate"]["mmlu"]
-    del config_dict["evaluate"]["mmlu_branch"]
-    del config_dict["evaluate"]["mt_bench"]
-    del config_dict["evaluate"]["mt_bench_branch"]
     return config_dict
 
 

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -313,20 +313,6 @@ def get_default_config() -> Config:
     )
 
 
-def get_default_map(config: Config) -> dict[str, typing.Any]:
-    """Get default map for Click"""
-    # default_map holds a dictionary with default values for each command parameters
-    config_dict = get_dict(config)
-    config_dict["evaluate"] = (
-        config_dict["evaluate"]
-        | config_dict["evaluate"].pop("mmlu")
-        | config_dict["evaluate"].pop("mmlu_branch")
-        | config_dict["evaluate"].pop("mt_bench")
-        | config_dict["evaluate"].pop("mt_bench_branch")
-    )
-    return config_dict
-
-
 def read_train_profile(train_file):
     try:
         with open(train_file, "r", encoding="utf-8") as yamlfile:
@@ -450,7 +436,7 @@ def init(ctx: click.Context, config_file: str | os.PathLike[str]) -> None:
 
     ctx.obj = Lab(config_obj, config_file, error_msg)
     if config_obj is not None:
-        ctx.default_map = get_default_map(config_obj)
+        ctx.default_map = get_dict(config_obj)
         log.configure_logging(log_level=config_obj.general.log_level.upper())
     else:
         ctx.default_map = None

--- a/src/instructlab/data/data.py
+++ b/src/instructlab/data/data.py
@@ -16,6 +16,7 @@ def data(ctx):
     If this is your first time running ilab, it's best to start with `ilab config init` to create the environment.
     """
     ctx.obj = ctx.parent.obj
+    ctx.obj.ensure_config(ctx)
     ctx.default_map = ctx.parent.default_map
 
 

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -26,6 +26,7 @@ import openai
 from instructlab import client as ilabclient
 from instructlab import configuration as cfg
 from instructlab import utils
+from instructlab.clickext import ConfigOption
 
 # Local
 from ..utils import get_sysprompt, http_client
@@ -71,15 +72,13 @@ PROMPT_PREFIX = ">>> "
 @click.option(
     "-m",
     "--model",
-    default=cfg.DEFAULT_MODEL,
-    show_default=True,
+    cls=ConfigOption,
     help="Model name to print in chat process",
 )
 @click.option(
     "-c",
     "--context",
-    default="default",
-    show_default=True,
+    cls=ConfigOption,
     help="Name of system context in config file.",
 )
 @click.option(
@@ -97,11 +96,13 @@ PROMPT_PREFIX = ">>> "
 @click.option(
     "-gm",
     "--greedy-mode",
+    cls=ConfigOption,
     is_flag=True,
     help="Use model greedy decoding. Useful for debugging and reproducing errors.",
 )
 @click.option(
     "--max-tokens",
+    cls=ConfigOption,
     type=click.INT,
     help="Set a maximum number of tokens to request from the model endpoint.",
 )

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -23,10 +23,10 @@ import httpx
 import openai
 
 # First Party
+from instructlab import clickext
 from instructlab import client as ilabclient
 from instructlab import configuration as cfg
 from instructlab import utils
-from instructlab.clickext import ConfigOption
 
 # Local
 from ..utils import get_sysprompt, http_client
@@ -72,19 +72,22 @@ PROMPT_PREFIX = ">>> "
 @click.option(
     "-m",
     "--model",
-    cls=ConfigOption,
+    cls=clickext.ConfigOption,
+    required=True,  # default from config
     help="Model name to print in chat process",
 )
 @click.option(
     "-c",
     "--context",
-    cls=ConfigOption,
+    cls=clickext.ConfigOption,
+    required=True,  # default from config
     help="Name of system context in config file.",
 )
 @click.option(
     "-s",
     "--session",
     type=click.File("r"),
+    cls=clickext.ConfigOption,
     help="Filepath of a dialog session file.",
 )
 @click.option(
@@ -96,14 +99,15 @@ PROMPT_PREFIX = ">>> "
 @click.option(
     "-gm",
     "--greedy-mode",
-    cls=ConfigOption,
     is_flag=True,
+    cls=clickext.ConfigOption,
+    required=True,  # default from config
     help="Use model greedy decoding. Useful for debugging and reproducing errors.",
 )
 @click.option(
     "--max-tokens",
-    cls=ConfigOption,
     type=click.INT,
+    cls=clickext.ConfigOption,
     help="Set a maximum number of tokens to request from the model endpoint.",
 )
 @click.option(

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -278,21 +278,29 @@ def launch_server(
 @click.option(
     "--judge-model",
     type=click.STRING,
+    cls=clickext.ConfigOption,
+    config_sections="mt_bench",
     help="Model to be used as a judge for running mt_bench or mt_bench_branch - can be a local path or the name of a Hugging Face repository",
 )
 @click.option(
     "--output-dir",
     type=click.Path(),
+    cls=clickext.ConfigOption,
+    config_sections="mt_bench",
     help="The directory to use for evaluation output from mt_bench or mt_bench_branch",
 )
 @click.option(
     "--max-workers",
     type=click.INT,
+    cls=clickext.ConfigOption,
+    config_sections="mt_bench",
     help="Max parallel workers to run the evaluation with for mt_bench or mt_bench_branch",
 )
 @click.option(
     "--taxonomy-path",
     type=click.Path(),
+    cls=clickext.ConfigOption,
+    config_sections="mt_bench_branch",
     help="Taxonomy git repo path for running mt_bench_branch",
 )
 @click.option(
@@ -310,16 +318,22 @@ def launch_server(
 @click.option(
     "--few-shots",
     type=click.INT,
+    cls=clickext.ConfigOption,
+    config_sections="mmlu",
     help="Number of examples. Needed for running mmlu or mmlu_branch.",
 )
 @click.option(
     "--batch-size",
     type=click.INT,
+    cls=clickext.ConfigOption,
+    config_sections="mmlu",
     help="Number of GPUs. Needed for running mmlu or mmlu_branch.",
 )
 @click.option(
     "--sdg-path",
     type=click.Path(),
+    cls=clickext.ConfigOption,
+    config_sections="mmlu_branch",
     help="Path where all the MMLU Branch tasks are stored. Needed for running mmlu_branch.",
 )
 @click.option(

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -7,6 +7,9 @@ import typing
 # Third Party
 import click
 
+# First Party
+from instructlab import clickext
+
 # Local
 from ..utils import display_params, http_client
 
@@ -256,11 +259,14 @@ def launch_server(
 @click.option(
     "--model",
     type=click.STRING,
+    cls=clickext.ConfigOption,
     help="Model to be evaluated - can be a local path or the name of a Hugging Face repository",
 )
 @click.option(
     "--base-model",
     type=click.STRING,
+    cls=clickext.ConfigOption,
+    required=True,  # default from config
     help="Base model to compare with 'model' for mt_bench_branch and mmlu_branch - can be a local path or the name of a Hugging Face repository",
 )
 @click.option(
@@ -292,11 +298,13 @@ def launch_server(
 @click.option(
     "--branch",
     type=click.STRING,
+    cls=clickext.ConfigOption,
     help="Branch of taxonomy repo to eval QNAs against model",
 )
 @click.option(
     "--base-branch",
     type=click.STRING,
+    cls=clickext.ConfigOption,
     help="Base branch of taxonomy repo to eval QNAs against model for mt_bench_branch",
 )
 @click.option(

--- a/src/instructlab/model/model.py
+++ b/src/instructlab/model/model.py
@@ -22,6 +22,7 @@ def model(ctx):
 
     If this is your first time running ilab, it's best to start with `ilab config init` to create the environment.
     """
+    ctx.parent.obj.ensure_config(ctx)
     ctx.obj = ctx.parent.obj
     ctx.default_map = ctx.parent.default_map
 

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -9,8 +9,7 @@ import typing
 import click
 
 # First Party
-from instructlab import configuration as config
-from instructlab import log, utils
+from instructlab import clickext, log, utils
 from instructlab.model.backends import backends
 from instructlab.model.backends.backends import ServerException
 
@@ -20,19 +19,29 @@ logger = logging.getLogger(__name__)
 @click.command()
 @click.option(
     "--model-path",
-    type=click.Path(),
-    default=config.DEFAULT_MODEL_PATH,
-    show_default=True,
+    cls=clickext.ConfigOption,
+    type=click.Path(path_type=pathlib.Path),
+    required=True,  # default from config
     help="Path to the model used during generation.",
 )
 @click.option(
     "--gpu-layers",
+    cls=clickext.ConfigOption,
+    config_section="llama_cpp",
     type=click.INT,
-    help="The number of layers to put on the GPU. The rest will be on the CPU. Defaults to -1 to move all to GPU.",
+    required=True,  # default from config
+    help="The number of layers to put on the GPU. -1 moves all layers. The rest will be on the CPU.",
 )
-@click.option("--num-threads", type=click.INT, help="The number of CPU threads to use.")
+@click.option(
+    "--num-threads",
+    type=click.INT,
+    required=False,
+    help="The number of CPU threads to use.",
+)
 @click.option(
     "--max-ctx-size",
+    cls=clickext.ConfigOption,
+    config_section="llama_cpp",
     type=click.INT,
     help="The context size is the maximum number of tokens considered by the model, for both the prompt and response. Defaults to 4096.",
 )
@@ -43,12 +52,15 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--log-file",
-    type=click.Path(),
+    type=click.Path(path_type=pathlib.Path),
+    required=False,
     help="Log file path to write server logs to.",
 )
 @click.option(
     "--backend",
     type=click.Choice(tuple(backends.SUPPORTED_BACKENDS)),
+    cls=clickext.ConfigOption,
+    required=False,  # auto-detect
     help=(
         "The backend to use for serving the model.\n"
         "Automatically detected based on the model file properties.\n"
@@ -67,23 +79,21 @@ logger = logging.getLogger(__name__)
 @click.pass_context
 @utils.display_params
 def serve(
-    ctx,
+    ctx: click.Context,
     model_path: pathlib.Path,
-    gpu_layers,
-    num_threads,
-    max_ctx_size,
+    gpu_layers: int,
+    num_threads: int | None,
+    max_ctx_size: int,
     model_family,
-    log_file,
-    backend,
+    log_file: pathlib.Path | None,
+    backend: str | None,
     vllm_args: typing.Iterable[str],
-):
+) -> None:
     """Start a local server"""
     # First Party
     from instructlab.model.backends import llama_cpp, vllm
 
     host, port = utils.split_hostport(ctx.obj.config.serve.host_port)
-
-    model_path = pathlib.Path(model_path)
     try:
         backend = backends.get(logger, model_path, backend)
     except (ValueError, AttributeError) as e:
@@ -93,10 +103,6 @@ def serve(
     # Redirect server stdout and stderr to the logger
     log.stdout_stderr_to_logger(logger, log_file)
 
-    if gpu_layers is None:
-        gpu_layers = ctx.obj.config.serve.llama_cpp.gpu_layers
-    if max_ctx_size is None:
-        max_ctx_size = ctx.obj.config.serve.llama_cpp.max_ctx_size
     logger.info(
         f"Using model '{model_path}' with {gpu_layers} gpu-layers and {max_ctx_size} max context size."
     )

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -19,16 +19,16 @@ logger = logging.getLogger(__name__)
 @click.command()
 @click.option(
     "--model-path",
-    cls=clickext.ConfigOption,
     type=click.Path(path_type=pathlib.Path),
+    cls=clickext.ConfigOption,
     required=True,  # default from config
     help="Path to the model used during generation.",
 )
 @click.option(
     "--gpu-layers",
-    cls=clickext.ConfigOption,
-    config_section="llama_cpp",
     type=click.INT,
+    cls=clickext.ConfigOption,
+    config_sections="llama_cpp",
     required=True,  # default from config
     help="The number of layers to put on the GPU. -1 moves all layers. The rest will be on the CPU.",
 )
@@ -40,9 +40,9 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--max-ctx-size",
-    cls=clickext.ConfigOption,
-    config_section="llama_cpp",
     type=click.INT,
+    cls=clickext.ConfigOption,
+    config_sections="llama_cpp",
     help="The context size is the maximum number of tokens considered by the model, for both the prompt and response. Defaults to 4096.",
 )
 @click.option(

--- a/src/instructlab/taxonomy/taxonomy.py
+++ b/src/instructlab/taxonomy/taxonomy.py
@@ -16,6 +16,7 @@ def taxonomy(ctx):
     If this is your first time running ilab, it's best to start with `ilab config init` to create the environment.
     """
     ctx.obj = ctx.parent.obj
+    ctx.obj.ensure_config(ctx)
     ctx.default_map = ctx.parent.default_map
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,10 @@
 # Standard
 from unittest import mock
 import sys
+import typing
 
 # Third Party
+from click.testing import CliRunner
 import pytest
 
 # Local
@@ -31,3 +33,11 @@ def mock_mlx_package():
     }
     with mock.patch.dict(sys.modules, mlx_modules):
         yield
+
+
+@pytest.fixture
+def cli_runner() -> typing.Generator[CliRunner, None, None]:
+    """Click CLI runner"""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        yield runner

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -56,3 +56,36 @@ def test_ilab_cli_imports():
     code.append("import instructlab.lab")
 
     subprocess.check_call([sys.executable, "-c", "; ".join(code)], text=True)
+
+
+@pytest.mark.parametrize(
+    "first,second",
+    [
+        # split first and second level for nicer pytest output
+        (None, None),
+        ("config", None),
+        ("config", "init"),
+        ("model", None),
+        ("model", "chat"),
+        ("model", "convert"),
+        ("model", "download"),
+        ("model", "evaluate"),
+        ("model", "serve"),
+        ("model", "test"),
+        ("model", "train"),
+        ("data", None),
+        ("data", "generate"),
+        ("sysinfo", None),
+        ("taxonomy", None),
+        ("taxonomy", "diff"),
+    ],
+)
+def test_ilab_cli_help(first: str | None, second: str | None, cli_runner):
+    cmd = ["--config", "DEFAULT"]
+    if first is not None:
+        cmd.append(first)
+    if second is not None:
+        cmd.append(second)
+    cmd.append("--help")
+    result = cli_runner.invoke(lab.ilab, cmd)
+    assert result.exit_code == 0, result.stdout


### PR DESCRIPTION
Introduce a `click.Option` subclass that renders help messages with defaults from the context's `default_map` and shows a hint to the config setting name. This simplifies the code and avoids code duplication.

The implementation can later be extended to show dynamic defaults from the user's config file instead of static defaults from the default config. The new `ConfigOption` can lookup defaults from nested settings. There is no need to flatten the configuration any more.

## Simple example `ilab model serve`


Code:
```python
@click.option(
    "--model-path",
    type=click.Path(),
    cls=ConfigOption,
    help="Path to the model used during generation.",
)
```

Output:
```
Options:
  --model-path PATH           Path to the model used during generation.
                              [default: models/merlinite-7b-lab-Q4_K_M.gguf;
                              config: 'serve.model_path']
```

## Complex example with nested lookup in `ilab model evaluate`

```python
@click.option(
    "--judge-model",
    type=click.STRING,
    cls=clickext.ConfigOption,
    config_sections="mt_bench",
    help="Model to be used as a judge for running mt_bench or mt_bench_branch - can be a local path or the name of a Hugging Face repository",
)
```

Output:
```
$ ilab model evaluate --help
Options:
...
  --judge-model TEXT              Model to be used as a judge for running
                                  mt_bench or mt_bench_branch - can be a local
                                  path or the name of a Hugging Face
                                  repository  [default: prometheus-
                                  eval/prometheus-8x7b-v2.0; config:
                                  'evaluate.mt_bench.judge_model']
...
```


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

**TODO:**
- [x] Add `ConfigOption` to all subcommands
- [x] Extend `ConfigOption` to support nested defaults, e.g. `llama_cpp.gpu_layers`

