### PR TITLE
ilab init set default to "yes" for cloning down taxonomy if not existing

### DIFF
--- a/tests/test_lab_init.py
+++ b/tests/test_lab_init.py
@@ -27,10 +27,13 @@ class TestLabInit:
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         mock_clone_from.assert_called_once()
 
-    def test_init_interactive(self, cli_runner: CliRunner):
+    @patch("instructlab.config.init.Repo.clone_from")
+    def test_init_interactive(self, mock_clone_from, cli_runner: CliRunner):
         result = cli_runner.invoke(lab.ilab, ["init"], input="\nn")
         assert result.exit_code == 0
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
+        assert "taxonomy" not in os.listdir()
+        mock_clone_from.assert_not_called()
 
     @patch(
         "instructlab.config.init.Repo.clone_from",
@@ -49,14 +52,25 @@ class TestLabInit:
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         mock_clone_from.assert_called_once()
 
+    @patch("instructlab.config.init.Repo.clone_from")
+    def test_init_interactive_default_clone(
+        self, mock_clone_from, cli_runner: CliRunner
+    ):
+        result = cli_runner.invoke(lab.ilab, ["init"], input="\n")
+        assert result.exit_code == 0
+        assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
+        mock_clone_from.assert_called_once()
+
+    @patch("instructlab.config.init.Repo.clone_from")
     def test_init_interactive_with_preexisting_nonempty_taxonomy(
-        self, cli_runner: CliRunner
+        self, mock_clone_from, cli_runner: CliRunner
     ):
         os.makedirs(f"{DEFAULTS.TAXONOMY_DIR}/contents")
         result = cli_runner.invoke(lab.ilab, ["init"], input="\n")
         assert result.exit_code == 0
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         assert "taxonomy" in os.listdir(DEFAULTS._data_dir)
+        mock_clone_from.assert_not_called()
 
     def test_init_interactive_with_preexisting_config(self, cli_runner: CliRunner):
         result = cli_runner.invoke(lab.ilab, ["init"], input="non-default-taxonomy\nn")


### PR DESCRIPTION

**Issue resolved by this Pull Request:**
Resolves #1547


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
