### PR TITLE
Introduce check_api_base

### DIFF
--- a/src/instructlab/client.py
+++ b/src/instructlab/client.py
@@ -1,11 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=duplicate-code
 
+# Standard
+import logging
+
 # Third Party
 from openai import OpenAI, OpenAIError
+import httpx
 
 # Local
 from .configuration import DEFAULTS
+
+logger = logging.getLogger(__name__)
 
 
 class ClientException(Exception):
@@ -28,3 +34,12 @@ def list_models(
         return client.models.list()
     except OpenAIError as exc:
         raise ClientException(f"Connection Error {exc}") from exc
+
+
+def check_api_base(api_base: str, http_client: httpx.Client | None = None) -> bool:
+    try:
+        logger.info(f"Trying to connect to model server at {api_base}")
+        list_models(api_base=api_base, http_client=http_client)
+        return True
+    except ClientException:
+        return False

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -23,7 +23,7 @@ import httpx
 import uvicorn
 
 # Local
-from ...client import ClientException, list_models
+from ...client import ClientException, check_api_base, list_models
 from ...configuration import _serve as serve_config
 from ...configuration import get_api_base
 from ...utils import split_hostport
@@ -234,16 +234,10 @@ def ensure_server(
     """Checks if server is running, if not starts one as a subprocess. Returns the server process
     and the URL where it's available."""
 
-    try:
-        logger.info(f"Trying to connect to model server at {api_base}")
-        # pylint: disable=duplicate-code
-        list_models(
-            api_base=api_base,
-            http_client=http_client,
-        )
+    # pylint: disable=no-else-return
+    if check_api_base(api_base, http_client):
         return (None, None, api_base)
-        # pylint: enable=duplicate-code
-    except ClientException:
+    else:
         port = free_tcp_ipv4_port(host)
         logger.debug(f"Using available port {port} for temporary model serving.")
 


### PR DESCRIPTION
ensure_server() became technological debt.
Historically, it has aggregated a mix of functionally different code, and its name does not accurately describe the content. Also usage of this function is confusing.

The plan is to split the function and reorder the code accordingly guidelines:
- clean backend agnostic code
- clean llama-cpp related code
- clean vllm related code
- no code duplication
- modularity

In order to refactoring, offshoot check_api_base() from ensure_server().
