### PR TITLE
e2e: Fix reference to invalid variable

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -243,7 +243,7 @@ while getopts "cmfgh" opt; do
             exit 0
             ;;
         \?)
-            echo "Invalid option: -$OPTARG" >&2
+            echo "Invalid option: -$opt" >&2
             usage
             exit 1
             ;;


### PR DESCRIPTION
When handling an invalid argument to the script, the `$OPTARG`
variable was referenced as the invalid argument. The variable is
actually `$opt`. I noticed this when I ran the script with an invalid
arg by accident.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
