### PR TITLE
refactor: move lama-cpp code from backends.py to llama_cpp.py

### DIFF
--- a/tests/test_lab_model_test.py
+++ b/tests/test_lab_model_test.py
@@ -8,24 +8,44 @@ import os
 
 # Third Party
 from click.testing import CliRunner
+import httpx
 import pytest
 
 # First Party
 from instructlab import lab
+from instructlab.model.backends.backends import BackendServer
 
 
 @pytest.mark.usefixtures("mock_mlx_package")
 class TestLabModelTest:
     """Test collection for `ilab model test` command."""
 
+    class ServerMock(BackendServer):
+        # py lint: disable=W0613
+        def __init__(self):
+            super().__init__("", "", "", 0)
+
+        def run_detached(
+            self, http_client: httpx.Client | None = None, background: bool = True
+        ) -> str:
+            return "api_base_mock"
+
+        def run(self):
+            pass
+
+        def shutdown(self):
+            pass
+
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=False)
-    @patch("instructlab.model.backends.backends.is_model_gguf", return_value=True)
     @patch("instructlab.model.linux_test.response", return_value="answer!")
+    @patch(
+        "instructlab.model.backends.backends.select_backend", return_value=ServerMock()
+    )
     def test_model_test_linux(
         self,
-        is_macos_with_m_chip_mock,
-        is_model_gguf_mock,
+        select_backend_mock,
         response_mock,
+        is_macos_with_m_chip_mock,
     ):
         runner = CliRunner()
         with runner.isolated_filesystem():
@@ -37,9 +57,9 @@ class TestLabModelTest:
                 lab.ilab,
                 ["--config=DEFAULT", "model", "test", "--test_file", "test_file.jsonl"],
             )
-            assert is_macos_with_m_chip_mock.call_count == 2
-            assert is_model_gguf_mock.call_count == 2
-            assert response_mock.call_count == 1
+            assert select_backend_mock.call_count
+            assert response_mock.call_count
+            assert is_macos_with_m_chip_mock.call_count
             assert "question?" in result.output
             assert "answer!" in result.output
             assert result.exit_code == 0

--- a/tests/test_lab_model_test.py
+++ b/tests/test_lab_model_test.py
@@ -23,7 +23,7 @@ class TestLabModelTest:
     class ServerMock(BackendServer):
         # py lint: disable=W0613
         def __init__(self):
-            super().__init__("", "", "", 0)
+            super().__init__("", "", "", "", "", 0)
 
         def run_detached(
             self, http_client: httpx.Client | None = None, background: bool = True


### PR DESCRIPTION
The code is moved with minimal changes.

Consolidate lama-cpp code in llama_cpp.py,
making backends.py backend implementation agnostic.

for check_api_base()  see #1596