### PR TITLE
Adding test cases for eval error_rate and revert to normal tuple handling …

### DIFF
--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -477,14 +477,9 @@ def evaluate(
                     gpus,
                     backend,
                 )
-                # TODO: Change back to standard tuple handling after version bump in eval library
-                judgment = evaluator.judge_answers(api_base)
-                overall_score = judgment[0]
-                qa_pairs = judgment[1]
-                turn_scores = judgment[2]
-                error_rate = 0
-                if len(judgment) > 3:
-                    error_rate = judgment[3]
+                overall_score, qa_pairs, turn_scores, error_rate = (
+                    evaluator.judge_answers(api_base)
+                )
             finally:
                 if server is not None:
                     server.shutdown()
@@ -559,14 +554,7 @@ def evaluate(
                 for i, evaluator in enumerate(evaluators):
                     branch = branches[i]
                     print(f"Evaluating answers for branch {branch}...")
-                    judgment = evaluator.judge_answers(api_base)
-                    # TODO: Change back to standard tuple handling after version bump in eval library
-                    error_rate = 0
-                    if isinstance(judgment, tuple):
-                        qa_pairs = judgment[0]
-                        error_rate = judgment[1]
-                    else:
-                        qa_pairs = judgment
+                    qa_pairs, error_rate = evaluator.judge_answers(api_base)
                     qa_pairs_and_errors.append((qa_pairs, error_rate))
             finally:
                 if server is not None:


### PR DESCRIPTION
This PR adds unit test cases for the new error rate logic from the eval library.  There is one set of logic for a 0 error rate (which doesn't display anything new) and a separate check for when an error_rate > 0 exists.

**Issue resolved by this Pull Request:**
Resolves #1598 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
