### PR TITLE
Test fixtures for CliRunner, HOME, and XDG_*

### DIFF
--- a/tests/test_lab_diff.py
+++ b/tests/test_lab_diff.py
@@ -28,281 +28,259 @@ class TestLabDiff:
     def _init_taxonomy(self, taxonomy_dir):
         self.taxonomy = taxonomy_dir
 
-    def test_diff(self):
+    def test_diff(self, cli_runner: CliRunner):
         untracked_file = "compositional_skills/new/qna.yaml"
         tracked_file = "compositional_skills/tracked/qna.yaml"
         self.taxonomy.create_untracked(untracked_file)
         self.taxonomy.add_tracked(tracked_file)
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                ],
-            )
-            assert untracked_file in result.output
-            assert tracked_file not in result.output
-            assert result.exit_code == 0
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        assert untracked_file in result.output
+        assert tracked_file not in result.output
+        assert result.exit_code == 0
 
-    def test_diff_rm_tracked(self):
+    def test_diff_rm_tracked(self, cli_runner: CliRunner):
         tracked_file = "compositional_skills/tracked/qna.yaml"
         self.taxonomy.add_tracked(tracked_file)
         self.taxonomy.remove_file(tracked_file)
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                ],
-            )
-            assert tracked_file not in result.output
-            assert result.exit_code == 0
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        assert tracked_file not in result.output
+        assert result.exit_code == 0
 
-    def test_diff_invalid_ext(self):
+    def test_diff_invalid_ext(self, cli_runner: CliRunner):
         untracked_file = "compositional_skills/writing/new/qna.YAML"
         self.taxonomy.create_untracked(untracked_file)
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                ],
-            )
-            assert self.taxonomy.untracked_files == [untracked_file]
-            # Invalid extension is silently filtered out
-            assert untracked_file not in result.output
-            assert result.exit_code == 0
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        assert self.taxonomy.untracked_files == [untracked_file]
+        # Invalid extension is silently filtered out
+        assert untracked_file not in result.output
+        assert result.exit_code == 0
 
-    def test_diff_invalid_base(self):
+    def test_diff_invalid_base(self, cli_runner: CliRunner):
         taxonomy_base = "invalid"
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    taxonomy_base,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                ],
-            )
-            assert (
-                f'Couldn\'t find the taxonomy git ref "{taxonomy_base}" '
-                "from the current HEAD" in result.output
-            )
-            assert result.exit_code == 1
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                taxonomy_base,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        assert (
+            f'Couldn\'t find the taxonomy git ref "{taxonomy_base}" '
+            "from the current HEAD" in result.output
+        )
+        assert result.exit_code == 1
 
-    def test_diff_invalid_path(self):
+    def test_diff_invalid_path(self, cli_runner: CliRunner):
         taxonomy_path = "/path/to/taxonomy"
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    taxonomy_path,
-                ],
-            )
-            assert f"{taxonomy_path}" in result.output
-            assert result.exit_code == 1
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                taxonomy_path,
+            ],
+        )
+        assert f"{taxonomy_path}" in result.output
+        assert result.exit_code == 1
 
-    def test_diff_valid_yaml(self):
-        with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
-            valid_yaml_file = "compositional_skills/qna_valid.yaml"
-            self.taxonomy.create_untracked(valid_yaml_file, qnafile.read())
-            runner = CliRunner()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                ],
-            )
-            assert f"Taxonomy in {self.taxonomy.root} is valid :)" in result.output
-            assert result.exit_code == 0
+    def test_diff_valid_yaml(self, cli_runner: CliRunner, testdata_path: Path):
+        qna = testdata_path.joinpath("skill_valid_answer.yaml").read_bytes()
+        valid_yaml_file = "compositional_skills/qna_valid.yaml"
+        self.taxonomy.create_untracked(valid_yaml_file, qna)
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        assert f"Taxonomy in {self.taxonomy.root} is valid :)" in result.output
+        assert result.exit_code == 0
 
-    def test_diff_valid_yaml_file(self):
-        with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
-            valid_yaml_file = "compositional_skills/qna_valid.yaml"
-            file_path = self.taxonomy.create_untracked(valid_yaml_file, qnafile.read())
-            runner = CliRunner()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    file_path,
-                ],
-            )
-            assert f"Taxonomy in {file_path} is valid :)" in result.output
-            assert result.exit_code == 0
+    def test_diff_valid_yaml_file(self, cli_runner: CliRunner, testdata_path):
+        qna = testdata_path.joinpath("skill_valid_answer.yaml").read_bytes()
+        valid_yaml_file = "compositional_skills/qna_valid.yaml"
+        file_path = self.taxonomy.create_untracked(valid_yaml_file, qna)
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                file_path,
+            ],
+        )
+        assert f"Taxonomy in {file_path} is valid :)" in result.output
+        assert result.exit_code == 0
 
-    def test_diff_valid_yaml_quiet(self):
-        with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
-            valid_yaml_file = "compositional_skills/qna_valid.yaml"
-            self.taxonomy.create_untracked(valid_yaml_file, qnafile.read())
-            runner = CliRunner()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                    "--quiet",
-                ],
-            )
-            assert result.output == ""
-            assert result.exit_code == 0
+    def test_diff_valid_yaml_quiet(self, cli_runner: CliRunner, testdata_path):
+        qna = testdata_path.joinpath("skill_valid_answer.yaml").read_bytes()
+        valid_yaml_file = "compositional_skills/qna_valid.yaml"
+        self.taxonomy.create_untracked(valid_yaml_file, qna)
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+                "--quiet",
+            ],
+        )
+        assert result.output == ""
+        assert result.exit_code == 0
 
-    def test_diff_valid_yaml_quiet_file(self):
-        with open("tests/testdata/skill_valid_answer.yaml", "rb") as qnafile:
-            valid_yaml_file = "compositional_skills/qna_valid.yaml"
-            file_path = self.taxonomy.create_untracked(valid_yaml_file, qnafile.read())
-            runner = CliRunner()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    file_path,
-                    "--quiet",
-                ],
-            )
-            assert result.output == ""
-            assert result.exit_code == 0
+    def test_diff_valid_yaml_quiet_file(self, cli_runner: CliRunner, testdata_path):
+        qna = testdata_path.joinpath("skill_valid_answer.yaml").read_bytes()
+        valid_yaml_file = "compositional_skills/qna_valid.yaml"
+        file_path = self.taxonomy.create_untracked(valid_yaml_file, qna)
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                file_path,
+                "--quiet",
+            ],
+        )
+        assert result.output == ""
+        assert result.exit_code == 0
 
-    def test_diff_invalid_yaml(self):
-        with open("tests/testdata/invalid_yaml.yaml", "rb") as qnafile:
-            self.taxonomy.create_untracked(
-                "compositional_skills/qna_invalid.yaml", qnafile.read()
-            )
-            runner = CliRunner()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                ],
-            )
-            assert "Reading taxonomy failed" in result.output
-            assert result.exit_code == 1
+    def test_diff_invalid_yaml(self, cli_runner: CliRunner, testdata_path):
+        qna = testdata_path.joinpath("invalid_yaml.yaml").read_bytes()
+        self.taxonomy.create_untracked("compositional_skills/qna_invalid.yaml", qna)
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        assert "Reading taxonomy failed" in result.output
+        assert result.exit_code == 1
 
-    def test_diff_invalid_yaml_quiet(self):
-        with open("tests/testdata/invalid_yaml.yaml", "rb") as qnafile:
-            self.taxonomy.create_untracked(
-                "compositional_skills/qna_invalid.yaml", qnafile.read()
-            )
-            runner = CliRunner()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                    "--quiet",
-                ],
-            )
-            assert result.exception is not None
-            assert result.exit_code == 1
+    def test_diff_invalid_yaml_quiet(self, cli_runner: CliRunner, testdata_path):
+        qna = testdata_path.joinpath("invalid_yaml.yaml").read_bytes()
+        self.taxonomy.create_untracked("compositional_skills/qna_invalid.yaml", qna)
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+                "--quiet",
+            ],
+        )
+        assert result.exception is not None
+        assert result.exit_code == 1
 
-    def test_diff_custom_yaml(self):
-        with open("tests/testdata/invalid_yaml.yaml", "rb") as qnafile:
-            custom_rules_file = Path("custom_rules.yaml")
-            custom_rules_file.write_bytes(TEST_CUSTOM_YAML_RULES)
-            invalid_yaml_file = "compositional_skills/qna_invalid.yaml"
-            self.taxonomy.create_untracked(invalid_yaml_file, qnafile.read())
-            runner = CliRunner()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                    "--yaml-rules",
-                    custom_rules_file,
-                    "--quiet",
-                ],
-            )
-            # custom yaml rules mean "invalid" yaml file should pass
-            assert result.output == ""
-            assert result.exit_code == 0
-            Path.unlink(custom_rules_file)
+    def test_diff_custom_yaml(self, cli_runner: CliRunner, testdata_path: Path):
+        qna = testdata_path.joinpath("invalid_yaml.yaml").read_bytes()
+        custom_rules_file = Path("custom_rules.yaml")
+        custom_rules_file.write_bytes(TEST_CUSTOM_YAML_RULES)
+        invalid_yaml_file = "compositional_skills/qna_invalid.yaml"
+        self.taxonomy.create_untracked(invalid_yaml_file, qna)
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+                "--yaml-rules",
+                str(custom_rules_file),
+                "--quiet",
+            ],
+        )
+        # custom yaml rules mean "invalid" yaml file should pass
+        assert result.output == ""
+        assert result.exit_code == 0
+        Path.unlink(custom_rules_file)
 
-    def test_diff_failing_schema_yaml(self):
-        with open("tests/testdata/skill_incomplete.yaml", "rb") as qnafile:
-            failing_yaml_file = "compositional_skills/failing/qna.yaml"
-            self.taxonomy.create_untracked(failing_yaml_file, qnafile.read())
-            runner = CliRunner()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "taxonomy",
-                    "diff",
-                    "--taxonomy-base",
-                    TAXONOMY_BASE,
-                    "--taxonomy-path",
-                    self.taxonomy.root,
-                ],
-            )
-            assert "Reading taxonomy failed" in result.output
-            assert result.exit_code == 1
+    def test_diff_failing_schema_yaml(self, cli_runner: CliRunner, testdata_path: Path):
+        qna = testdata_path.joinpath("skill_incomplete.yaml").read_bytes()
+        failing_yaml_file = "compositional_skills/failing/qna.yaml"
+        self.taxonomy.create_untracked(failing_yaml_file, qna)
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        assert "Reading taxonomy failed" in result.output
+        assert result.exit_code == 1

--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -17,38 +17,30 @@ class TestLabDownload:
     # When using `import X`, you should use `X.Y` to patch.
     # https://docs.python.org/3/library/unittest.mock.html#where-to-patch?
     @patch("instructlab.model.download.hf_hub_download")
-    def test_download(self, mock_hf_hub_download):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "model",
-                    "download",
-                ],
-            )
-            assert (
-                result.exit_code == 0
-            ), "command finished with an unexpected exit code"
-            mock_hf_hub_download.assert_called_once()
+    def test_download(self, mock_hf_hub_download, cli_runner: CliRunner):
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "download",
+            ],
+        )
+        assert result.exit_code == 0, "command finished with an unexpected exit code"
+        mock_hf_hub_download.assert_called_once()
 
     @patch(
         "instructlab.model.download.hf_hub_download",
         MagicMock(side_effect=HfHubHTTPError("Could not reach hugging face server")),
     )
-    def test_download_error(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "model",
-                    "download",
-                ],
-            )
-            assert (
-                result.exit_code == 1
-            ), "command finished with an unexpected exit code"
-            assert "Could not reach hugging face server" in result.output
+    def test_download_error(self, cli_runner: CliRunner):
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "download",
+            ],
+        )
+        assert result.exit_code == 1, "command finished with an unexpected exit code"
+        assert "Could not reach hugging face server" in result.output

--- a/tests/test_lab_evaluate.py
+++ b/tests/test_lab_evaluate.py
@@ -94,50 +94,46 @@ def setup_taxonomy(taxonomy_path):
     return_value=(1.5001, [{}, {}], [1.002, 2]),
 )
 def test_evaluate_mt_bench(
-    judge_answers_mock,
-    gen_answers_mock,
-    launch_server_mock,
+    judge_answers_mock, gen_answers_mock, launch_server_mock, cli_runner
 ):
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            lab.ilab,
-            [
-                "--config=DEFAULT",
-                "model",
-                "evaluate",
-                "--benchmark",
-                "mt_bench",
-                "--model",
-                "models/instructlab/granite-7b-lab",
-                "--judge-model",
-                "models/instructlab/merlinite-7b-lab",
-            ],
-        )
-        judge_answers_mock.assert_called_once()
-        gen_answers_mock.assert_called_once()
-        assert launch_server_mock.call_count == 2
-        assert result.exit_code == 0
-        expected = textwrap.dedent(
-            """\
-            Generating answers...
-            Evaluating answers...
-            # SKILL EVALUATION REPORT
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+            "--benchmark",
+            "mt_bench",
+            "--model",
+            "models/instructlab/granite-7b-lab",
+            "--judge-model",
+            "models/instructlab/merlinite-7b-lab",
+        ],
+    )
+    judge_answers_mock.assert_called_once()
+    gen_answers_mock.assert_called_once()
+    assert launch_server_mock.call_count == 2
+    assert result.exit_code == 0
+    expected = textwrap.dedent(
+        """\
+        Generating answers...
+        Evaluating answers...
+        # SKILL EVALUATION REPORT
 
-            ## MODEL
-            models/instructlab/granite-7b-lab
+        ## MODEL
+        models/instructlab/granite-7b-lab
 
-            ### AVERAGE:
-            1.5 (across 2)
+        ### AVERAGE:
+        1.5 (across 2)
 
-            ### TURN ONE:
-            1.0
+        ### TURN ONE:
+        1.0
 
-            ### TURN TWO:
-            2
-            """
-        )
-        assert result.output == expected
+        ### TURN TWO:
+        2
+        """
+    )
+    assert result.output == expected
 
 
 @patch(
@@ -150,109 +146,101 @@ def test_evaluate_mt_bench(
     side_effect=[gen_qa_pairs(True), gen_qa_pairs(False)],
 )
 def test_evaluate_mt_bench_branch(
-    judge_answers_mock,
-    gen_answers_mock,
-    launch_server_mock,
+    judge_answers_mock, gen_answers_mock, launch_server_mock, cli_runner
 ):
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            lab.ilab,
-            [
-                "--config=DEFAULT",
-                "model",
-                "evaluate",
-                "--benchmark",
-                "mt_bench_branch",
-                "--model",
-                "models/instructlab/granite-7b-lab",
-                "--judge-model",
-                "models/instructlab/merlinite-7b-lab",
-                "--base-model",
-                "models/instructlab/granite-7b-lab",
-                "--branch",
-                "rc",
-                "--base-branch",
-                "main",
-                "--taxonomy-path",
-                "taxonomy",
-            ],
-        )
-        assert judge_answers_mock.call_count == 2
-        assert gen_answers_mock.call_count == 2
-        assert launch_server_mock.call_count == 3
-        assert result.exit_code == 0
-        expected = textwrap.dedent(
-            """\
-            Generating questions and reference answers from qna files for branch rc...
-            Generating questions and reference answers from qna files for branch main...
-            Evaluating answers for branch rc...
-            Evaluating answers for branch main...
-            # SKILL EVALUATION REPORT
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+            "--benchmark",
+            "mt_bench_branch",
+            "--model",
+            "models/instructlab/granite-7b-lab",
+            "--judge-model",
+            "models/instructlab/merlinite-7b-lab",
+            "--base-model",
+            "models/instructlab/granite-7b-lab",
+            "--branch",
+            "rc",
+            "--base-branch",
+            "main",
+            "--taxonomy-path",
+            "taxonomy",
+        ],
+    )
+    assert judge_answers_mock.call_count == 2
+    assert gen_answers_mock.call_count == 2
+    assert launch_server_mock.call_count == 3
+    assert result.exit_code == 0
+    expected = textwrap.dedent(
+        """\
+        Generating questions and reference answers from qna files for branch rc...
+        Generating questions and reference answers from qna files for branch main...
+        Evaluating answers for branch rc...
+        Evaluating answers for branch main...
+        # SKILL EVALUATION REPORT
 
-            ## BASE MODEL
-            models/instructlab/granite-7b-lab
+        ## BASE MODEL
+        models/instructlab/granite-7b-lab
 
-            ## MODEL
-            models/instructlab/granite-7b-lab
+        ## MODEL
+        models/instructlab/granite-7b-lab
 
-            ### IMPROVEMENTS:
-            1. category1/qna.yaml (+0.1)
-            2. category3/qna.yaml (+0.1)
+        ### IMPROVEMENTS:
+        1. category1/qna.yaml (+0.1)
+        2. category3/qna.yaml (+0.1)
 
-            ### REGRESSIONS:
-            1. category2/qna.yaml (-0.1)
-            2. category4/qna.yaml (-0.1)
+        ### REGRESSIONS:
+        1. category2/qna.yaml (-0.1)
+        2. category4/qna.yaml (-0.1)
 
-            ### NO CHANGE:
-            1. category5/qna.yaml
+        ### NO CHANGE:
+        1. category5/qna.yaml
 
-            ### NEW:
-            1. category6/qna.yaml
-            """
-        )
-        assert result.output == expected
+        ### NEW:
+        1. category6/qna.yaml
+        """
+    )
+    assert result.output == expected
 
 
 @patch(
     "instructlab.eval.mmlu.MMLUEvaluator.run",
     return_value=(0.5, {"task1": {"score": 0.1}, "task2": {"score": 0.9}}),
 )
-def test_evaluate_mmlu(
-    run_mock,
-):
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            lab.ilab,
-            [
-                "--config=DEFAULT",
-                "model",
-                "evaluate",
-                "--benchmark",
-                "mmlu",
-                "--model",
-                "models/instructlab/granite-7b-lab",
-            ],
-        )
-        run_mock.assert_called_once()
-        assert result.exit_code == 0
-        expected = textwrap.dedent(
-            """\
-            # KNOWLEDGE EVALUATION REPORT
+def test_evaluate_mmlu(run_mock, cli_runner: CliRunner):
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+            "--benchmark",
+            "mmlu",
+            "--model",
+            "models/instructlab/granite-7b-lab",
+        ],
+    )
+    run_mock.assert_called_once()
+    assert result.exit_code == 0
+    expected = textwrap.dedent(
+        """\
+        # KNOWLEDGE EVALUATION REPORT
 
-            ## MODEL
-            models/instructlab/granite-7b-lab
+        ## MODEL
+        models/instructlab/granite-7b-lab
 
-            ### AVERAGE:
-            0.5 (across 2)
+        ### AVERAGE:
+        0.5 (across 2)
 
-            ### SCORES:
-            task1 - 0.1
-            task2 - 0.9
-            """
-        )
-        assert result.output == expected
+        ### SCORES:
+        task1 - 0.1
+        task2 - 0.9
+        """
+    )
+    assert result.output == expected
 
 
 @patch(
@@ -262,205 +250,185 @@ def test_evaluate_mmlu(
         (0.6, gen_individual_scores(False)),
     ],
 )
-def test_evaluate_mmlu_branch(
-    run_mock,
-):
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            lab.ilab,
-            [
-                "--config=DEFAULT",
-                "model",
-                "evaluate",
-                "--benchmark",
-                "mmlu_branch",
-                "--model",
-                "models/instructlab/granite-7b-lab",
-                "--base-model",
-                "models/instructlab/granite-7b-lab",
-                "--sdg-path",
-                "generated",
-            ],
-        )
-        assert run_mock.call_count == 2
-        assert result.exit_code == 0
-        expected = textwrap.dedent(
-            """\
-            # KNOWLEDGE EVALUATION REPORT
+def test_evaluate_mmlu_branch(run_mock, cli_runner: CliRunner):
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+            "--benchmark",
+            "mmlu_branch",
+            "--model",
+            "models/instructlab/granite-7b-lab",
+            "--base-model",
+            "models/instructlab/granite-7b-lab",
+            "--sdg-path",
+            "generated",
+        ],
+    )
+    assert run_mock.call_count == 2
+    assert result.exit_code == 0
+    expected = textwrap.dedent(
+        """\
+        # KNOWLEDGE EVALUATION REPORT
 
-            ## BASE MODEL
-            models/instructlab/granite-7b-lab
+        ## BASE MODEL
+        models/instructlab/granite-7b-lab
 
-            ## MODEL
-            models/instructlab/granite-7b-lab
+        ## MODEL
+        models/instructlab/granite-7b-lab
 
-            ### AVERAGE:
-            -0.1 (across 5)
+        ### AVERAGE:
+        -0.1 (across 5)
 
-            ### IMPROVEMENTS:
-            1. task1 (+0.1)
-            2. task3 (+0.1)
+        ### IMPROVEMENTS:
+        1. task1 (+0.1)
+        2. task3 (+0.1)
 
-            ### REGRESSIONS:
-            1. task2 (-0.1)
-            2. task4 (-0.1)
+        ### REGRESSIONS:
+        1. task2 (-0.1)
+        2. task4 (-0.1)
 
-            ### NO CHANGE:
-            1. task5
-            """
-        )
-        assert result.output == expected
+        ### NO CHANGE:
+        1. task5
+        """
+    )
+    assert result.output == expected
 
 
-def test_no_model_mt_bench():
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            lab.ilab,
-            [
-                "--config=DEFAULT",
-                "model",
-                "evaluate",
-                "--benchmark",
-                "mt_bench",
-            ],
-        )
-        assert (
-            result.output
-            == "Benchmark mt_bench requires the following args to be set: ['model', 'judge-model']\n"
-        )
-        assert result.exit_code != 0
+def test_no_model_mt_bench(cli_runner: CliRunner):
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+            "--benchmark",
+            "mt_bench",
+        ],
+    )
+    assert (
+        result.output
+        == "Benchmark mt_bench requires the following args to be set: ['model', 'judge-model']\n"
+    )
+    assert result.exit_code != 0
 
 
-def test_missing_benchmark():
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            lab.ilab,
-            [
-                "--config=DEFAULT",
-                "model",
-                "evaluate",
-            ],
-        )
-        assert "Missing option '--benchmark'" in result.output
-        assert result.exit_code != 0
+def test_missing_benchmark(cli_runner: CliRunner):
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+        ],
+    )
+    assert "Missing option '--benchmark'" in result.output
+    assert result.exit_code != 0
 
 
-def test_invalid_model_mt_bench():
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            lab.ilab,
-            [
-                "--config=DEFAULT",
-                "model",
-                "evaluate",
-                "--benchmark",
-                "mt_bench",
-                "--model",
-                "invalid",
-                "--judge-model",
-                "models/instructlab/merlinite-7b-lab",
-            ],
-        )
-        assert "Failed to determine backend:" in result.output
-        assert result.exit_code != 0
+def test_invalid_model_mt_bench(cli_runner: CliRunner):
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+            "--benchmark",
+            "mt_bench",
+            "--model",
+            "invalid",
+            "--judge-model",
+            "models/instructlab/merlinite-7b-lab",
+        ],
+    )
+    assert "Failed to determine backend:" in result.output
+    assert result.exit_code != 0
 
 
-def test_invalid_model_mmlu():
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            lab.ilab,
-            [
-                "--config=DEFAULT",
-                "model",
-                "evaluate",
-                "--benchmark",
-                "mmlu",
-                "--model",
-                "invalid",
-            ],
-        )
-        # TODO: This error could use some work
-        # assert "is not a valid model" in str(result.exception)
-        assert result.exit_code != 0
+def test_invalid_model_mmlu(cli_runner: CliRunner):
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+            "--benchmark",
+            "mmlu",
+            "--model",
+            "invalid",
+        ],
+    )
+    # TODO: This error could use some work
+    # assert "is not a valid model" in str(result.exception)
+    assert result.exit_code != 0
 
 
 @patch(
     "instructlab.model.evaluate.launch_server",
     return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1"),
 )
-def test_invalid_taxonomy_mt_bench_branch(
-    launch_server_mock,
-):
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(
-            lab.ilab,
-            [
-                "--config=DEFAULT",
-                "model",
-                "evaluate",
-                "--benchmark",
-                "mt_bench_branch",
-                "--model",
-                "models/instructlab/granite-7b-lab",
-                "--judge-model",
-                "models/instructlab/merlinite-7b-lab",
-                "--base-model",
-                "models/instructlab/granite-7b-lab",
-                "--branch",
-                "rc",
-                "--base-branch",
-                "main",
-                "--taxonomy-path",
-                "invalid_taxonomy",
-            ],
-        )
-        launch_server_mock.assert_called_once()
-        # TODO: This error could use some work
-        # assert "/invalid_taxonomy" in str(result.exception)
-        assert result.exit_code != 0
+def test_invalid_taxonomy_mt_bench_branch(launch_server_mock, cli_runner: CliRunner):
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+            "--benchmark",
+            "mt_bench_branch",
+            "--model",
+            "models/instructlab/granite-7b-lab",
+            "--judge-model",
+            "models/instructlab/merlinite-7b-lab",
+            "--base-model",
+            "models/instructlab/granite-7b-lab",
+            "--branch",
+            "rc",
+            "--base-branch",
+            "main",
+            "--taxonomy-path",
+            "invalid_taxonomy",
+        ],
+    )
+    launch_server_mock.assert_called_once()
+    # TODO: This error could use some work
+    # assert "/invalid_taxonomy" in str(result.exception)
+    assert result.exit_code != 0
 
 
 @patch(
     "instructlab.model.evaluate.launch_server",
     return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1"),
 )
-def test_invalid_branch_mt_bench_branch(
-    launch_server_mock,
-):
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        setup_taxonomy("taxonomy")
-        result = runner.invoke(
-            lab.ilab,
-            [
-                "--config=DEFAULT",
-                "model",
-                "evaluate",
-                "--benchmark",
-                "mt_bench_branch",
-                "--model",
-                "models/instructlab/granite-7b-lab",
-                "--judge-model",
-                "models/instructlab/merlinite-7b-lab",
-                "--base-model",
-                "models/instructlab/granite-7b-lab",
-                "--branch",
-                "invalid",
-                "--base-branch",
-                "main",
-                "--taxonomy-path",
-                "taxonomy",
-            ],
-        )
-        launch_server_mock.assert_called_once()
-        # TODO: This error could use some work
-        # assert "pathspec 'invalid' did not match any file(s) known to git" in str(
-        #    result.exception
-        # )
-        assert result.exit_code != 0
+def test_invalid_branch_mt_bench_branch(launch_server_mock, cli_runner: CliRunner):
+    setup_taxonomy("taxonomy")
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+            "--benchmark",
+            "mt_bench_branch",
+            "--model",
+            "models/instructlab/granite-7b-lab",
+            "--judge-model",
+            "models/instructlab/merlinite-7b-lab",
+            "--base-model",
+            "models/instructlab/granite-7b-lab",
+            "--branch",
+            "invalid",
+            "--base-branch",
+            "main",
+            "--taxonomy-path",
+            "taxonomy",
+        ],
+    )
+    launch_server_mock.assert_called_once()
+    # TODO: This error could use some work
+    # assert "pathspec 'invalid' did not match any file(s) known to git" in str(
+    #    result.exception
+    # )
+    assert result.exit_code != 0

--- a/tests/test_lab_init.py
+++ b/tests/test_lab_init.py
@@ -20,75 +20,61 @@ class TestLabInit:
     # When using `import X`, you should use `X.Y` to patch.
     # https://docs.python.org/3/library/unittest.mock.html#where-to-patch?
     @patch("instructlab.config.init.Repo.clone_from")
-    def test_init_noninteractive(self, mock_clone_from):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(lab.ilab, ["init", "--non-interactive"])
-            assert result.exit_code == 0
-            assert "config.yaml" in os.listdir()
-            mock_clone_from.assert_called_once()
+    def test_init_noninteractive(self, mock_clone_from, cli_runner: CliRunner):
+        result = cli_runner.invoke(lab.ilab, ["init", "--non-interactive"])
+        assert result.exit_code == 0
+        assert "config.yaml" in os.listdir()
+        mock_clone_from.assert_called_once()
 
-    def test_init_interactive(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(lab.ilab, ["init"], input="\nn")
-            assert result.exit_code == 0
-            assert "config.yaml" in os.listdir()
+    def test_init_interactive(self, cli_runner: CliRunner):
+        result = cli_runner.invoke(lab.ilab, ["init"], input="\nn")
+        assert result.exit_code == 0
+        assert "config.yaml" in os.listdir()
 
     @patch(
         "instructlab.config.init.Repo.clone_from",
         MagicMock(side_effect=GitError("Authentication failed")),
     )
-    def test_init_interactive_git_error(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(lab.ilab, ["init"], input="\ny")
-            assert (
-                result.exit_code == 1
-            ), "command finished with an unexpected exit code"
-            assert (
-                "Failed to clone taxonomy repo: Authentication failed" in result.output
-            )
-            assert "manually run" in result.output
+    def test_init_interactive_git_error(self, cli_runner: CliRunner):
+        result = cli_runner.invoke(lab.ilab, ["init"], input="\ny")
+        assert result.exit_code == 1, "command finished with an unexpected exit code"
+        assert "Failed to clone taxonomy repo: Authentication failed" in result.output
+        assert "manually run" in result.output
 
     @patch("instructlab.config.init.Repo.clone_from")
-    def test_init_interactive_clone(self, mock_clone_from):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(lab.ilab, ["init"], input="\ny")
-            assert result.exit_code == 0
-            assert "config.yaml" in os.listdir()
-            mock_clone_from.assert_called_once()
+    def test_init_interactive_clone(self, mock_clone_from, cli_runner: CliRunner):
+        result = cli_runner.invoke(lab.ilab, ["init"], input="\ny")
+        assert result.exit_code == 0
+        assert "config.yaml" in os.listdir()
+        mock_clone_from.assert_called_once()
 
-    def test_init_interactive_with_preexisting_nonempty_taxonomy(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            os.makedirs("taxonomy/contents")
-            result = runner.invoke(lab.ilab, ["init"], input="\n")
-            assert result.exit_code == 0
-            assert "config.yaml" in os.listdir()
-            assert "taxonomy" in os.listdir()
+    def test_init_interactive_with_preexisting_nonempty_taxonomy(
+        self, cli_runner: CliRunner
+    ):
+        os.makedirs("taxonomy/contents")
+        result = cli_runner.invoke(lab.ilab, ["init"], input="\n")
+        assert result.exit_code == 0
+        assert "config.yaml" in os.listdir()
+        assert "taxonomy" in os.listdir()
 
-    def test_init_interactive_with_preexisting_config(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            # first run to prime the config.yaml in current directory
-            result = runner.invoke(lab.ilab, ["init"], input="non-default-taxonomy\nn")
-            assert result.exit_code == 0
-            assert "config.yaml" in os.listdir()
-            config = read_config("config.yaml")
-            assert config.generate.taxonomy_path == "non-default-taxonomy"
+    def test_init_interactive_with_preexisting_config(self, cli_runner: CliRunner):
+        # first run to prime the config.yaml in current directory
+        result = cli_runner.invoke(lab.ilab, ["init"], input="non-default-taxonomy\nn")
+        assert result.exit_code == 0
+        assert "config.yaml" in os.listdir()
+        config = read_config("config.yaml")
+        assert config.generate.taxonomy_path == "non-default-taxonomy"
 
-            # second invocation should ask if we want to overwrite - yes, and change taxonomy path
-            result = runner.invoke(lab.ilab, ["init"], input="y\ndifferent-taxonomy\nn")
-            assert result.exit_code == 0
-            assert "config.yaml" in os.listdir()
-            config = read_config("config.yaml")
-            assert config.generate.taxonomy_path == "different-taxonomy"
+        # second invocation should ask if we want to overwrite - yes, and change taxonomy path
+        result = cli_runner.invoke(lab.ilab, ["init"], input="y\ndifferent-taxonomy\nn")
+        assert result.exit_code == 0
+        assert "config.yaml" in os.listdir()
+        config = read_config("config.yaml")
+        assert config.generate.taxonomy_path == "different-taxonomy"
 
-            # third invocation should again ask, but this time don't overwrite
-            result = runner.invoke(lab.ilab, ["init"], input="n")
-            assert result.exit_code == 0
-            assert "config.yaml" in os.listdir()
-            config = read_config("config.yaml")
-            assert config.generate.taxonomy_path == "different-taxonomy"
+        # third invocation should again ask, but this time don't overwrite
+        result = cli_runner.invoke(lab.ilab, ["init"], input="n")
+        assert result.exit_code == 0
+        assert "config.yaml" in os.listdir()
+        config = read_config("config.yaml")
+        assert config.generate.taxonomy_path == "different-taxonomy"

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -83,40 +83,34 @@ class TestLabTrain:
         make_data_mock,
         load_mock,
         is_macos_with_m_chip_mock,
+        cli_runner: CliRunner,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            result = runner.invoke(
-                lab.ilab,
-                ["--config=DEFAULT", "model", "train", "--input-dir", INPUT_DIR],
-            )
-            assert result.exit_code == 0
-            load_mock.assert_not_called()
-            load_and_train_mock.assert_called_once()
-            assert load_and_train_mock.call_args[1]["model"] is not None
-            assert load_and_train_mock.call_args[1]["train"]
-            assert load_and_train_mock.call_args[1]["data"] == Path("taxonomy_data")
-            assert load_and_train_mock.call_args[1]["adapter_file"] is not None
-            assert load_and_train_mock.call_args[1]["iters"] == 100
-            assert load_and_train_mock.call_args[1]["save_every"] == 10
-            assert load_and_train_mock.call_args[1]["steps_per_eval"] == 10
-            assert len(load_and_train_mock.call_args[1]) == 7
-            convert_between_mlx_and_pytorch_mock.assert_called_once()
-            assert (
-                convert_between_mlx_and_pytorch_mock.call_args[1]["hf_path"] is not None
-            )
-            assert (
-                convert_between_mlx_and_pytorch_mock.call_args[1]["mlx_path"]
-                is not None
-            )
-            assert convert_between_mlx_and_pytorch_mock.call_args[1]["quantize"]
-            assert not convert_between_mlx_and_pytorch_mock.call_args[1]["local"]
-            assert len(convert_between_mlx_and_pytorch_mock.call_args[1]) == 4
-            make_data_mock.assert_called_once()
-            assert make_data_mock.call_args[1]["data_dir"] == Path("taxonomy_data")
-            assert len(make_data_mock.call_args[1]) == 1
-            is_macos_with_m_chip_mock.assert_called_once()
+        setup_input_dir()
+        result = cli_runner.invoke(
+            lab.ilab,
+            ["--config=DEFAULT", "model", "train", "--input-dir", INPUT_DIR],
+        )
+        assert result.exit_code == 0
+        load_mock.assert_not_called()
+        load_and_train_mock.assert_called_once()
+        assert load_and_train_mock.call_args[1]["model"] is not None
+        assert load_and_train_mock.call_args[1]["train"]
+        assert load_and_train_mock.call_args[1]["data"] == Path("taxonomy_data")
+        assert load_and_train_mock.call_args[1]["adapter_file"] is not None
+        assert load_and_train_mock.call_args[1]["iters"] == 100
+        assert load_and_train_mock.call_args[1]["save_every"] == 10
+        assert load_and_train_mock.call_args[1]["steps_per_eval"] == 10
+        assert len(load_and_train_mock.call_args[1]) == 7
+        convert_between_mlx_and_pytorch_mock.assert_called_once()
+        assert convert_between_mlx_and_pytorch_mock.call_args[1]["hf_path"] is not None
+        assert convert_between_mlx_and_pytorch_mock.call_args[1]["mlx_path"] is not None
+        assert convert_between_mlx_and_pytorch_mock.call_args[1]["quantize"]
+        assert not convert_between_mlx_and_pytorch_mock.call_args[1]["local"]
+        assert len(convert_between_mlx_and_pytorch_mock.call_args[1]) == 4
+        make_data_mock.assert_called_once()
+        assert make_data_mock.call_args[1]["data_dir"] == Path("taxonomy_data")
+        assert len(make_data_mock.call_args[1]) == 1
+        is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=True)
     @patch("instructlab.mlx_explore.gguf_convert_to_mlx.load")
@@ -130,106 +124,69 @@ class TestLabTrain:
         make_data_mock,
         load_mock,
         is_macos_with_m_chip_mock,
+        cli_runner: CliRunner,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "model",
-                    "train",
-                    "--input-dir",
-                    INPUT_DIR,
-                    "--skip-quantize",
-                ],
-            )
-            assert result.exit_code == 0
-            load_mock.assert_not_called()
-            load_and_train_mock.assert_called_once()
-            convert_between_mlx_and_pytorch_mock.assert_called_once()
-            assert (
-                convert_between_mlx_and_pytorch_mock.call_args[1]["quantize"] is False
-            )
-            make_data_mock.assert_called_once()
-            is_macos_with_m_chip_mock.assert_called_once()
+        setup_input_dir()
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "train",
+                "--input-dir",
+                INPUT_DIR,
+                "--skip-quantize",
+            ],
+        )
+        assert result.exit_code == 0
+        load_mock.assert_not_called()
+        load_and_train_mock.assert_called_once()
+        convert_between_mlx_and_pytorch_mock.assert_called_once()
+        assert convert_between_mlx_and_pytorch_mock.call_args[1]["quantize"] is False
+        make_data_mock.assert_called_once()
+        is_macos_with_m_chip_mock.assert_called_once()
 
-    def test_input_error(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "model",
-                    "train",
-                    "--legacy",
-                    "--input-dir",
-                    "invalid",
-                ],
-            )
-            assert result.exception is not None
-            assert "Could not read directory: invalid" in result.output
-            assert result.exit_code == 1
+    def test_input_error(self, cli_runner: CliRunner):
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "train",
+                "--legacy",
+                "--input-dir",
+                "invalid",
+            ],
+        )
+        assert result.exception is not None
+        assert "Could not read directory: invalid" in result.output
+        assert result.exit_code == 1
 
-    def test_invalid_taxonomy(self):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            os.mkdir(INPUT_DIR)  # Leave out the test and train files
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "model",
-                    "train",
-                    "--legacy",
-                    "--input-dir",
-                    INPUT_DIR,
-                ],
-            )
-            assert result.exception is not None
-            assert (
-                f"{INPUT_DIR} does not contain training or test files, did you run `ilab data generate`?"
-                in result.output
-            )
-            assert result.exit_code == 1
+    def test_invalid_taxonomy(self, cli_runner: CliRunner):
+        os.mkdir(INPUT_DIR)  # Leave out the test and train files
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "train",
+                "--legacy",
+                "--input-dir",
+                INPUT_DIR,
+            ],
+        )
+        assert result.exception is not None
+        assert (
+            f"{INPUT_DIR} does not contain training or test files, did you run `ilab data generate`?"
+            in result.output
+        )
+        assert result.exit_code == 1
 
-    def test_invalid_data_dir(self):
+    def test_invalid_data_dir(self, cli_runner: CliRunner):
         # The error comes from make_data itself so it's only really useful to test on a mac
         if is_arm_mac():
-            runner = CliRunner()
-            with runner.isolated_filesystem():
-                os.mkdir(INPUT_DIR)  # Leave out the test and train files
-                result = runner.invoke(
-                    lab.ilab,
-                    [
-                        "--config=DEFAULT",
-                        "model",
-                        "train",
-                        "--legacy",
-                        "--data-path",
-                        "invalid",
-                        "--input-dir",
-                        INPUT_DIR,
-                    ],
-                )
-                assert result.exception is not None
-                assert "Could not read from data directory" in result.output
-                assert result.exit_code == 1
-
-    @patch("instructlab.utils.is_macos_with_m_chip", return_value=True)
-    @patch(
-        "instructlab.train.lora_mlx.make_data.make_data",
-        side_effect=FileNotFoundError(),
-    )
-    def test_invalid_data_dir_synthetic(
-        self, make_data_mock, is_macos_with_m_chip_mock
-    ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
             os.mkdir(INPUT_DIR)  # Leave out the test and train files
-            result = runner.invoke(
+            result = cli_runner.invoke(
                 lab.ilab,
                 [
                     "--config=DEFAULT",
@@ -242,11 +199,37 @@ class TestLabTrain:
                     INPUT_DIR,
                 ],
             )
-            make_data_mock.assert_called_once()
             assert result.exception is not None
             assert "Could not read from data directory" in result.output
             assert result.exit_code == 1
-            is_macos_with_m_chip_mock.assert_called_once()
+
+    @patch("instructlab.utils.is_macos_with_m_chip", return_value=True)
+    @patch(
+        "instructlab.train.lora_mlx.make_data.make_data",
+        side_effect=FileNotFoundError(),
+    )
+    def test_invalid_data_dir_synthetic(
+        self, make_data_mock, is_macos_with_m_chip_mock, cli_runner
+    ):
+        os.mkdir(INPUT_DIR)  # Leave out the test and train files
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "train",
+                "--legacy",
+                "--data-path",
+                "invalid",
+                "--input-dir",
+                INPUT_DIR,
+            ],
+        )
+        make_data_mock.assert_called_once()
+        assert result.exception is not None
+        assert "Could not read from data directory" in result.output
+        assert result.exit_code == 1
+        is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=True)
     @patch("instructlab.mlx_explore.gguf_convert_to_mlx.load")
@@ -260,27 +243,26 @@ class TestLabTrain:
         make_data_mock,
         load_mock,
         is_macos_with_m_chip_mock,
+        cli_runner: CliRunner,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "model",
-                    "train",
-                    "--input-dir",
-                    INPUT_DIR,
-                    "--skip-preprocessing",
-                ],
-            )
-            assert result.exit_code == 0
-            load_mock.assert_not_called()
-            load_and_train_mock.assert_called_once()
-            convert_between_mlx_and_pytorch_mock.assert_called_once()
-            make_data_mock.assert_not_called()
-            is_macos_with_m_chip_mock.assert_called_once()
+        setup_input_dir()
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "train",
+                "--input-dir",
+                INPUT_DIR,
+                "--skip-preprocessing",
+            ],
+        )
+        assert result.exit_code == 0
+        load_mock.assert_not_called()
+        load_and_train_mock.assert_called_once()
+        convert_between_mlx_and_pytorch_mock.assert_called_once()
+        make_data_mock.assert_not_called()
+        is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=True)
     @patch("instructlab.mlx_explore.utils.fetch_tokenizer_from_hub")
@@ -296,38 +278,37 @@ class TestLabTrain:
         load_mock,
         fetch_tokenizer_from_hub_mock,
         is_macos_with_m_chip_mock,
+        cli_runner: CliRunner,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            setup_load()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "model",
-                    "train",
-                    "--legacy",
-                    "--input-dir",
-                    INPUT_DIR,
-                    "--tokenizer-dir",
-                    "tokenizer",
-                    "--gguf-model-path",
-                    "gguf_model",
-                    "--model-path",
-                    MODEL_DIR,
-                ],
-            )
-            assert result.exit_code == 0
-            load_mock.assert_called_once()
-            load_and_train_mock.assert_called_once()
-            convert_between_mlx_and_pytorch_mock.assert_not_called()
-            make_data_mock.assert_called_once()
-            fetch_tokenizer_from_hub_mock.assert_called_once()
-            assert fetch_tokenizer_from_hub_mock.call_args[0][0] == "tokenizer"
-            assert fetch_tokenizer_from_hub_mock.call_args[0][1] == "tokenizer"
-            assert len(fetch_tokenizer_from_hub_mock.call_args[0]) == 2
-            is_macos_with_m_chip_mock.assert_called_once()
+        setup_input_dir()
+        setup_load()
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "train",
+                "--legacy",
+                "--input-dir",
+                INPUT_DIR,
+                "--tokenizer-dir",
+                "tokenizer",
+                "--gguf-model-path",
+                "gguf_model",
+                "--model-path",
+                MODEL_DIR,
+            ],
+        )
+        assert result.exit_code == 0
+        load_mock.assert_called_once()
+        load_and_train_mock.assert_called_once()
+        convert_between_mlx_and_pytorch_mock.assert_not_called()
+        make_data_mock.assert_called_once()
+        fetch_tokenizer_from_hub_mock.assert_called_once()
+        assert fetch_tokenizer_from_hub_mock.call_args[0][0] == "tokenizer"
+        assert fetch_tokenizer_from_hub_mock.call_args[0][1] == "tokenizer"
+        assert len(fetch_tokenizer_from_hub_mock.call_args[0]) == 2
+        is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=True)
     @patch("instructlab.mlx_explore.utils.fetch_tokenizer_from_hub")
@@ -343,36 +324,35 @@ class TestLabTrain:
         load_mock,
         fetch_tokenizer_from_hub_mock,
         is_macos_with_m_chip_mock,
+        cli_runner: CliRunner,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            setup_load()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "model",
-                    "train",
-                    "--legacy",
-                    "--input-dir",
-                    INPUT_DIR,
-                    "--tokenizer-dir",
-                    "tokenizer",
-                    "--gguf-model-path",
-                    "gguf_model",
-                    "--model-path",
-                    MODEL_DIR,
-                    "--local",
-                ],
-            )
-            assert result.exit_code == 0
-            load_mock.assert_called_once()
-            load_and_train_mock.assert_called_once()
-            convert_between_mlx_and_pytorch_mock.assert_not_called()
-            make_data_mock.assert_called_once()
-            fetch_tokenizer_from_hub_mock.assert_not_called()
-            is_macos_with_m_chip_mock.assert_called_once()
+        setup_input_dir()
+        setup_load()
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "train",
+                "--legacy",
+                "--input-dir",
+                INPUT_DIR,
+                "--tokenizer-dir",
+                "tokenizer",
+                "--gguf-model-path",
+                "gguf_model",
+                "--model-path",
+                MODEL_DIR,
+                "--local",
+            ],
+        )
+        assert result.exit_code == 0
+        load_mock.assert_called_once()
+        load_and_train_mock.assert_called_once()
+        convert_between_mlx_and_pytorch_mock.assert_not_called()
+        make_data_mock.assert_called_once()
+        fetch_tokenizer_from_hub_mock.assert_not_called()
+        is_macos_with_m_chip_mock.assert_called_once()
 
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=False)
     @patch.object(linux_train, "linux_train", return_value=Path("training_results"))
@@ -385,43 +365,42 @@ class TestLabTrain:
         convert_llama_to_gguf_mock,
         linux_train_mock,
         is_macos_with_m_chip_mock,
+        cli_runner: CliRunner,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            setup_linux_dir()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "model",
-                    "train",
-                    "--legacy",
-                    "--input-dir",
-                    INPUT_DIR,
-                ],
-            )
-            assert result.exit_code == 0
-            convert_llama_to_gguf_mock.assert_called_once()
-            assert convert_llama_to_gguf_mock.call_args[1]["model"] == Path(
-                "training_results/final"
-            )
-            assert convert_llama_to_gguf_mock.call_args[1]["pad_vocab"] is True
-            assert len(convert_llama_to_gguf_mock.call_args[1]) == 2
-            linux_train_mock.assert_called_once()
-            print(linux_train_mock.call_args[1])
-            assert linux_train_mock.call_args[1]["train_file"] == Path(
-                "taxonomy_data/train_gen.jsonl"
-            )
-            assert linux_train_mock.call_args[1]["test_file"] == Path(
-                "taxonomy_data/test_gen.jsonl"
-            )
-            assert linux_train_mock.call_args[1]["num_epochs"] == 10
-            assert linux_train_mock.call_args[1]["train_device"] is not None
-            assert not linux_train_mock.call_args[1]["four_bit_quant"]
-            assert len(linux_train_mock.call_args[1]) == 7
-            is_macos_with_m_chip_mock.assert_called_once()
-            assert not os.path.isfile(LINUX_GGUF_FILE)
+        setup_input_dir()
+        setup_linux_dir()
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "train",
+                "--legacy",
+                "--input-dir",
+                INPUT_DIR,
+            ],
+        )
+        assert result.exit_code == 0
+        convert_llama_to_gguf_mock.assert_called_once()
+        assert convert_llama_to_gguf_mock.call_args[1]["model"] == Path(
+            "training_results/final"
+        )
+        assert convert_llama_to_gguf_mock.call_args[1]["pad_vocab"] is True
+        assert len(convert_llama_to_gguf_mock.call_args[1]) == 2
+        linux_train_mock.assert_called_once()
+        print(linux_train_mock.call_args[1])
+        assert linux_train_mock.call_args[1]["train_file"] == Path(
+            "taxonomy_data/train_gen.jsonl"
+        )
+        assert linux_train_mock.call_args[1]["test_file"] == Path(
+            "taxonomy_data/test_gen.jsonl"
+        )
+        assert linux_train_mock.call_args[1]["num_epochs"] == 10
+        assert linux_train_mock.call_args[1]["train_device"] is not None
+        assert not linux_train_mock.call_args[1]["four_bit_quant"]
+        assert len(linux_train_mock.call_args[1]) == 7
+        is_macos_with_m_chip_mock.assert_called_once()
+        assert not os.path.isfile(LINUX_GGUF_FILE)
 
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=False)
     @patch(
@@ -433,45 +412,47 @@ class TestLabTrain:
         side_effect=mock_convert_llama_to_gguf,
     )
     def test_num_epochs(
-        self, convert_llama_to_gguf_mock, linux_train_mock, is_macos_with_m_chip_mock
+        self,
+        convert_llama_to_gguf_mock,
+        linux_train_mock,
+        is_macos_with_m_chip_mock,
+        cli_runner: CliRunner,
     ):
-        runner = CliRunner()
-        with runner.isolated_filesystem():
-            setup_input_dir()
-            setup_linux_dir()
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "model",
-                    "train",
-                    "--legacy",
-                    "--input-dir",
-                    INPUT_DIR,
-                    "--num-epochs",
-                    "2",
-                ],
-            )
-            assert result.exit_code == 0
-            convert_llama_to_gguf_mock.assert_called_once()
-            linux_train_mock.assert_called_once()
-            assert linux_train_mock.call_args[1]["num_epochs"] == 2
-            is_macos_with_m_chip_mock.assert_called_once()
-            assert not os.path.isfile(LINUX_GGUF_FILE)
+        setup_input_dir()
+        setup_linux_dir()
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "train",
+                "--legacy",
+                "--input-dir",
+                INPUT_DIR,
+                "--num-epochs",
+                "2",
+            ],
+        )
+        assert result.exit_code == 0
+        convert_llama_to_gguf_mock.assert_called_once()
+        linux_train_mock.assert_called_once()
+        assert linux_train_mock.call_args[1]["num_epochs"] == 2
+        is_macos_with_m_chip_mock.assert_called_once()
+        assert not os.path.isfile(LINUX_GGUF_FILE)
 
-            # Test with invalid num_epochs
-            result = runner.invoke(
-                lab.ilab,
-                [
-                    "--config=DEFAULT",
-                    "model",
-                    "train",
-                    "--input-dir",
-                    INPUT_DIR,
-                    "--num-epochs",
-                    "two",
-                ],
-            )
-            assert result.exception is not None
-            assert result.exit_code == 2
-            assert "'two' is not a valid integer" in result.output
+        # Test with invalid num_epochs
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "train",
+                "--input-dir",
+                INPUT_DIR,
+                "--num-epochs",
+                "two",
+            ],
+        )
+        assert result.exception is not None
+        assert result.exit_code == 2
+        assert "'two' is not a valid integer" in result.output


### PR DESCRIPTION
Introduce pytest fixtures for click's `CliRunner`, to reset `HOME` and `XDG_*` env variables, and access to test data.

`tmp_path_home` fixture sets `os.environ` variable `HOME` to pytest's current `tmp_path` and removes all `XDG_*` variables.

`cli_runner` uses `tmp_path_home` and creates a new click `CliRunner` with file system isolation inside pytest's `tmp_path`.

`testdata_path` returns the local test data directory as absolute `pathlib.Path` object.

All tests have been refactored to use the new `cli_runner` fixture. The change is inspired by a previous PR by Ihar Hrachyshka.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
