### PR TITLE
Temporarily removing assertions to allow to cross repo change

### DIFF
--- a/tests/test_lab_evaluate.py
+++ b/tests/test_lab_evaluate.py
@@ -385,7 +385,7 @@ def test_invalid_model_mmlu():
             ],
         )
         # TODO: This error could use some work
-        assert "is not a valid model" in str(result.exception)
+        # assert "is not a valid model" in str(result.exception)
         assert result.exit_code != 0
 
 
@@ -422,7 +422,7 @@ def test_invalid_taxonomy_mt_bench_branch(
         )
         launch_server_mock.assert_called_once()
         # TODO: This error could use some work
-        assert "/invalid_taxonomy" in str(result.exception)
+        # assert "/invalid_taxonomy" in str(result.exception)
         assert result.exit_code != 0
 
 
@@ -460,7 +460,7 @@ def test_invalid_branch_mt_bench_branch(
         )
         launch_server_mock.assert_called_once()
         # TODO: This error could use some work
-        assert "pathspec 'invalid' did not match any file(s) known to git" in str(
-            result.exception
-        )
+        # assert "pathspec 'invalid' did not match any file(s) known to git" in str(
+        #    result.exception
+        # )
         assert result.exit_code != 0


### PR DESCRIPTION
In order to deliver:
https://github.com/instructlab/eval/pull/52
and
https://github.com/instructlab/instructlab/pull/1616

We need to merge and release 52 and merge 1616 at the same time.

To avoid any time delay, I am putting out this PR to merge first.  That will enable us to merge and release https://github.com/instructlab/eval/pull/52, then get the tests to pass on 1616 before merging.  Otherwise CI will be broken for the time period between the release and merge.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
