### PR TITLE
e2e: Fix setting training epochs in CI

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -145,7 +145,7 @@ test_train() {
     task Train the model
 
     # TODO Only cuda for now
-    TRAIN_ARGS=("--legacy" "--device=cuda")
+    TRAIN_ARGS+=("--legacy" "--device=cuda")
     if [ "$FULLTRAIN" -eq 0 ]; then
         TRAIN_ARGS+=("--4-bit-quant")
     fi


### PR DESCRIPTION
The script intended to have `--num-epochs 1`, but we were overwriting
`TRAIN_ARGS` at one spot instead of appending to it. The epochs flag
was set earlier in the script.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
