### PR TITLE
Debug: Improved display params diagnostics

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -9,7 +9,7 @@ from git import GitError, Repo
 import click
 
 # First Party
-from instructlab import utils
+from instructlab import clickext, utils
 from instructlab.configuration import (
     DEFAULTS,
     ensure_storage_directories_exist,
@@ -60,6 +60,7 @@ from instructlab.configuration import (
     "using the same taxonomy repository. ",
 )
 @click.option("--train-profile", type=click.Path(), default=None)
+@clickext.display_params
 def init(
     interactive,
     model_path: str,

--- a/src/instructlab/config/show.py
+++ b/src/instructlab/config/show.py
@@ -4,15 +4,15 @@ import click
 import yaml
 
 # First Party
-from instructlab import utils
+from instructlab import clickext
 
 
 @click.command()
 @click.pass_context
-@utils.display_params
+@clickext.display_params
 def show(
-    ctx,
-):
+    ctx: click.Context,
+) -> None:
     """Displays the current config as YAML"""
     # TODO: make this use pretty colors like jq/yq
     try:
@@ -21,4 +21,5 @@ def show(
         )
     except yaml.YAMLError as e:
         click.secho(f"Error loading config as YAML: {e}", fg="red")
+        ctx.abort()
     click.echo(yaml.dump(config_yaml, indent=4))

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -7,8 +7,11 @@ import logging
 import click
 
 # First Party
-from instructlab import utils
+from instructlab import clickext
 from instructlab.configuration import DEFAULTS
+
+# Local
+from ..utils import http_client
 
 logger = logging.getLogger(__name__)
 
@@ -136,7 +139,7 @@ logger = logging.getLogger(__name__)
     help="Data generation pipeline to use. Available: simple, full. Note that 'full' requires a larger teacher model, Mixtral-8x7b.",
 )
 @click.pass_context
-@utils.display_params
+@clickext.display_params
 def generate(
     ctx,
     model,
@@ -164,9 +167,6 @@ def generate(
     # Third Party
     from instructlab.sdg.generate_data import generate_data
     from instructlab.sdg.utils import GenerateException
-
-    # Local
-    from ..utils import http_client
 
     prompt_file_path = DEFAULTS.PROMPT_FILE
     if ctx.obj is not None:

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -26,7 +26,6 @@ import openai
 from instructlab import clickext
 from instructlab import client as ilabclient
 from instructlab import configuration as cfg
-from instructlab import utils
 
 # Local
 from ..utils import get_sysprompt, http_client
@@ -151,7 +150,7 @@ PROMPT_PREFIX = ">>> "
     help="Force model family to use when picking a chat template",
 )
 @click.pass_context
-@utils.display_params
+@clickext.display_params
 def chat(
     ctx,
     question,

--- a/src/instructlab/model/convert.py
+++ b/src/instructlab/model/convert.py
@@ -13,7 +13,7 @@ from requests import exceptions as requests_exceptions
 import click
 
 # First Party
-from instructlab import utils
+from instructlab import clickext, utils
 
 logger = logging.getLogger(__name__)
 
@@ -44,9 +44,9 @@ logger = logging.getLogger(__name__)
     default=None,
     show_default=True,
 )
-@utils.macos_requirement(echo_func=click.secho, exit_exception=click.exceptions.Exit)
 @click.pass_context
-@utils.display_params
+@clickext.display_params
+@utils.macos_requirement(echo_func=click.secho, exit_exception=click.exceptions.Exit)
 def convert(
     ctx,  # pylint: disable=unused-argument
     model_dir,

--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -10,7 +10,7 @@ from huggingface_hub import snapshot_download
 import click
 
 # First Party
-from instructlab import utils
+from instructlab import clickext
 from instructlab.configuration import DEFAULTS
 
 
@@ -46,7 +46,7 @@ from instructlab.configuration import DEFAULTS
     help="User access token for connecting to the Hugging Face Hub.",
 )
 @click.pass_context
-@utils.display_params
+@clickext.display_params
 def download(ctx, repository, release, filename, model_dir, hf_token):
     """Download the model(s) to train"""
     click.echo(f"Downloading model from {repository}@{release} to {model_dir}...")

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -16,7 +16,7 @@ from instructlab import clickext
 from instructlab.model.backends import backends
 
 # Local
-from ..utils import display_params, http_client
+from ..utils import http_client
 
 if typing.TYPE_CHECKING:
     # Third Party
@@ -406,7 +406,7 @@ def launch_server(
     help="TLS client certificate password for model serving.",
 )
 @click.pass_context
-@display_params
+@clickext.display_params
 def evaluate(
     ctx,
     model,

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
     ),
 )
 @click.pass_context
-@utils.display_params
+@clickext.display_params
 def serve(
     ctx: click.Context,
     model_path: pathlib.Path,

--- a/src/instructlab/model/test.py
+++ b/src/instructlab/model/test.py
@@ -10,7 +10,7 @@ import os
 import click
 
 # First Party
-from instructlab import utils
+from instructlab import clickext, utils
 from instructlab.configuration import DEFAULTS
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
     help="Force model family to use when picking a generation template",
 )
 @click.pass_context
-@utils.display_params
+@clickext.display_params
 # pylint: disable=function-redefined
 def test(
     ctx,

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -308,7 +308,7 @@ DS_OPTIONS = "train_args.deepspeed_options"
     help="if true, enables the legacy linux training codepath from release 0.17.0 and prior.",
 )
 @click.pass_context
-@utils.display_params
+@clickext.display_params
 def train(
     ctx,
     data_path: str,

--- a/src/instructlab/system/info.py
+++ b/src/instructlab/system/info.py
@@ -9,6 +9,9 @@ import typing
 # Third Party
 import click
 
+# First Party
+from instructlab import clickext
+
 
 def _platform_info() -> typing.Dict[str, typing.Any]:
     """Platform and machine information"""
@@ -140,6 +143,7 @@ def get_sysinfo() -> typing.Dict[str, typing.Any]:
 
 
 @click.command()
+@clickext.display_params
 def info():
     """Print system information"""
     for key, value in get_sysinfo().items():

--- a/src/instructlab/taxonomy/diff.py
+++ b/src/instructlab/taxonomy/diff.py
@@ -10,7 +10,7 @@ import click
 import yaml
 
 # First Party
-from instructlab import utils
+from instructlab import clickext
 from instructlab.configuration import DEFAULTS
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
     help="Suppress all output. Call returns 0 if check passes, 1 otherwise.",
 )
 @click.pass_context
-@utils.display_params
+@clickext.display_params
 def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
     """
     Lists taxonomy files that have changed since <taxonomy-base>

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -530,29 +530,6 @@ def http_client(params):
     )
 
 
-def display_params(func):
-    """Display command parameters."""
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            if (logger.isEnabledFor(logging.DEBUG)) and (
-                ("quiet" not in kwargs) or (not kwargs["quiet"])
-            ):
-                print("===================using parameters ========================")
-                max_param_length = max(len(param) for param in kwargs)
-                for param_name, param_value in kwargs.items():
-                    print(
-                        f"{param_name}{' ' * (max_param_length - len(param_name)):s}: {param_value}"
-                    )
-                print("============================================================")
-        except Exception:
-            pass
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
 def split_hostport(hostport: str) -> tuple[str, int]:
     """Split server:port into server and port (IPv6 safe)"""
     if "//" not in hostport:


### PR DESCRIPTION
The `display_params` decorator now adds two hidden diagnostic flags `--debug-params` and `--debug-params-json` to the list of options. When a flag is passed to a subcommand, it displays all parameters with additional options and then exits with error code 0. The JSON output is designed to be used in tests.

The function now displays more information, too. Besides name and value, it reveals the type of the value and the origin (command line, env vars, default, default, map).

```console
$ ilab model chat --debug-params
Parameters:
  question: ()         [type: tuple, src: commandline]
     model: 'models/merlinite-7b-lab-Q4_K_M.gguf'      [type: str, src: default_map]
   context: 'default'  [type: str, src: default_map]
   session: None       [type: None, src: default]
   ...
```

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
