### PR TITLE
e2e: Add script option to skip training

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -21,6 +21,7 @@ FULLTRAIN=0
 BACKEND="llama-cpp"
 HF_TOKEN=${HF_TOKEN:-}
 SDG_PIPELINE="simple"
+SKIP_TRAIN=${SKIP_TRAIN:-0}
 
 export GREP_COLORS='mt=1;33'
 BOLD='\033[1m'
@@ -215,6 +216,16 @@ test_exec() {
     task Stopping the ilab model serve
     step Kill ilab model serve $PID
     kill $PID
+
+    if [ "$SKIP_TRAIN" -eq 1 ]; then
+        # TODO - Drop this later.
+        # This is only a temporary measure while we bootstrap different CI workflows.
+        # There are some larger environments where it only makes sense to test the new
+        # training workflow using the training library, but that is not yet integrated
+        # here. Skip training for those environments for now.
+        task Halting prior to running training "(SKIP_TRAIN=1)"
+        return
+    fi
 
     test_train
 


### PR DESCRIPTION
I'm trying to bootstrap some test workflows using larger AWS instance
types. On these instances with multiple GPUs, it's not very useful to
test the legacy training code path, because it doesn't support using
multiple GPUs. On these instances, we want to test the new training
path using the training library. Integrating that is a work in
progress (PR #1557).

This is just a temporary measure that we can remove once the new
training code path is supported in this script.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
