### PR TITLE
feat: Add chat template customization to ilab serve

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -152,6 +152,7 @@ subdirectory
 tatsu
 th
 tl
+tokenizer
 tox
 triagers
 unquantized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
 * The `ilab` command now accepts a `-v` / `--verbose` option to enable debug logging.
   `ilab -vv` or `ilab --verbose --verbose` enables more verbose debug logging.
 * `ilab model test` generic support
+   evaluation (currently applicable for vLLM only).
+* Add `--chat-template` option to `ilab model serve` to support customization of the chat
+   template for both vLLM and llama.cpp backends. Options include 'auto' (current behavior, ilab
+   provides its own template), 'tokenizer' (uses the model's tokenizer config), and an external
+   file name.
 
 ### Breaking Changes
 

--- a/scripts/test-data/mock-template.txt
+++ b/scripts/test-data/mock-template.txt
@@ -1,0 +1,6 @@
+<|system|>
+You are an AI assistant using a test provided custom template
+<|user|>
+not important
+<|advisor|>
+<|endoftext|>

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -268,6 +268,7 @@ class _generate(BaseModel):
 class _serve_vllm(BaseModel):
     """Class describing configuration of vllm serving backend."""
 
+    llm_family: str = ""
     # arguments to pass into vllm process
     vllm_args: list[str] | None = None
 
@@ -294,9 +295,9 @@ class _serve(BaseModel):
 
     # required fields
     model_path: StrictStr
-
     # additional fields with defaults
     host_port: StrictStr = "127.0.0.1:8000"
+    chat_template: Optional[str] = None
     backend: Optional[str] = (
         None  # we don't set a default value here since it's auto-detected
     )
@@ -408,6 +409,7 @@ def get_default_config() -> Config:
                 llm_family="",
             ),
             vllm=_serve_vllm(
+                llm_family="",
                 vllm_args=[],
             ),
         ),

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -2,31 +2,34 @@
 
 # Standard
 from contextlib import redirect_stderr, redirect_stdout
-from typing import Optional
+from typing import Optional, cast
 import logging
 import multiprocessing
 import os
 import pathlib
 
 # Third Party
-from llama_cpp import llama_chat_format
+from llama_cpp import llama_chat_format, llama_token_get_text
 from llama_cpp.server.app import create_app
+from llama_cpp.server.model import LlamaProxy
 from llama_cpp.server.settings import Settings
 import httpx
 import llama_cpp.server.app as llama_app
 
 # Local
-from ...configuration import get_model_family
 from .backends import (
     API_ROOT_WELCOME_MESSAGE,
+    CHAT_TEMPLATE_AUTO,
+    CHAT_TEMPLATE_TOKENIZER,
     LLAMA_CPP,
     BackendServer,
     ServerException,
     UvicornServer,
     ensure_server,
+    get_model_template,
     get_uvicorn_config,
     is_temp_server_running,
-    templates,
+    verify_template_exists,
 )
 
 logger = logging.getLogger(__name__)
@@ -37,6 +40,7 @@ class Server(BackendServer):
         self,
         model_path: pathlib.Path,
         model_family: str,
+        chat_template: str,
         api_base: str,
         host: str,
         port: int,
@@ -44,8 +48,7 @@ class Server(BackendServer):
         max_ctx_size: int,
         num_threads: Optional[int],
     ):
-        super().__init__(model_path, api_base, host, port)
-        self.model_family = model_family
+        super().__init__(model_family, model_path, chat_template, api_base, host, port)
         self.gpu_layers = gpu_layers
         self.max_ctx_size = max_ctx_size
         self.num_threads = num_threads
@@ -57,6 +60,7 @@ class Server(BackendServer):
         try:
             server(
                 model_path=self.model_path,
+                chat_template=self.chat_template,
                 gpu_layers=self.gpu_layers,
                 max_ctx_size=self.max_ctx_size,
                 model_family=self.model_family,
@@ -75,6 +79,7 @@ class Server(BackendServer):
             target=server,
             kwargs={
                 "model_path": self.model_path,
+                "chat_template": self.chat_template,
                 "gpu_layers": self.gpu_layers,
                 "max_ctx_size": self.max_ctx_size,
                 "model_family": self.model_family,
@@ -107,6 +112,9 @@ class Server(BackendServer):
 
     def shutdown(self):
         """Stop the server process and close the queue."""
+
+        super().shutdown()
+
         if self.process and self.queue:
             self.process.terminate()
             self.process.join(timeout=30)
@@ -116,13 +124,14 @@ class Server(BackendServer):
 
 def server(
     model_path: pathlib.Path,
+    chat_template: str,
     gpu_layers: int,
     max_ctx_size: int,
     model_family: str,
     threads=None,
     host: str = "localhost",
     port: int = 8000,
-    queue=None,
+    queue: Optional[multiprocessing.Queue] = None,
 ):
     """Start OpenAI-compatible server"""
     settings = Settings(
@@ -149,30 +158,8 @@ def server(
             return
         raise ServerException(f"failed creating the server application: {exc}") from exc
 
-    template = ""
-    eos_token = "<|endoftext|>"
-    bos_token = ""
-    for template_dict in templates:
-        if template_dict["model"] == get_model_family(model_family, model_path):
-            template = template_dict["template"]
-            if template_dict["model"] == "mixtral":
-                eos_token = "</s>"
-                bos_token = "<s>"
-    try:
-        for proxy in llama_app.get_llama_proxy():
-            proxy().chat_handler = llama_chat_format.Jinja2ChatFormatter(
-                template=template,
-                eos_token=eos_token,
-                bos_token=bos_token,
-            ).to_chat_handler()
-    # pylint: disable=broad-exception-caught
-    except Exception as exc:
-        if queue:
-            queue.put(exc)
-            queue.close()
-            queue.join_thread()
-            return
-        raise ServerException(f"failed creating the server application: {exc}") from exc
+    # Update chat template if necessary
+    augment_chat_template(chat_template, model_family, model_path, queue)
 
     logger.info("Starting server process, press CTRL+C to shutdown server...")
     logger.info(
@@ -205,3 +192,76 @@ def server(
     if queue:
         queue.close()
         queue.join_thread()
+
+
+def augment_chat_template(
+    chat_template: str,
+    model_family: str,
+    model_path: pathlib.Path,
+    queue: Optional[multiprocessing.Queue],
+):
+    # chat template takes the format ('auto' | 'tokenizer' | a filesystem path to a file)
+    if chat_template == CHAT_TEMPLATE_TOKENIZER:
+        # llama_cpp_python calculates from the tokenizer config on load, so
+        # nothing to do
+        return
+
+    try:
+        if chat_template == CHAT_TEMPLATE_AUTO:
+            # Currently "auto" maps to replacing with ilab stored templates
+            template, eos_token, bos_token = get_model_template(
+                model_family, model_path
+            )
+        else:
+            # In this case, the template is a path to a file; attempt to load it
+            template = load_template(chat_template)
+            eos_token = None
+            bos_token = None
+
+        logger.info("Replacing chat template:\n %s", template)
+
+        for proxy in llama_app.get_llama_proxy():
+            proxy().chat_handler = llama_chat_format.Jinja2ChatFormatter(
+                template=template,
+                # Use the model defined eos and bos if either is not
+                # defined (when a custom template is used)
+                eos_token=resolve_token_eos(eos_token, proxy),
+                bos_token=resolve_token_bos(bos_token, proxy),
+            ).to_chat_handler()
+    # pylint: disable=broad-exception-caught
+    except Exception as exc:
+        if queue:
+            queue.put(exc)
+            queue.close()
+            queue.join_thread()
+            return
+        raise ServerException(f"failed creating the server application: {exc}") from exc
+
+
+def resolve_token_eos(eos_token: Optional[str], proxy: LlamaProxy) -> str:
+    if eos_token is not None:
+        return eos_token
+
+    return resolve_token(proxy, proxy().token_eos())
+
+
+def resolve_token_bos(bos_token: Optional[str], proxy: LlamaProxy) -> str:
+    if bos_token is not None:
+        return bos_token
+
+    return resolve_token(proxy, proxy().token_bos())
+
+
+def resolve_token(proxy: LlamaProxy, token: int) -> str:
+    result = llama_token_get_text(proxy().model, token).decode("utf-8")
+    return cast(str, result)
+
+
+def load_template(template_path: str) -> str:
+    path = pathlib.Path(template_path)
+    verify_template_exists(path)
+
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception as e:
+        raise IOError("Error reading chat template file contents: {}".format(e)) from e

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -58,6 +58,16 @@ logger = logging.getLogger(__name__)
     help="Log file path to write server logs to.",
 )
 @click.option(
+    "--chat-template",
+    type=str,
+    help=(
+        "Which chat template to use in serving the model, either 'auto', "
+        "'tokenizer', or a path to a jinja formatted template file. \n"
+        " 'auto' (the default) indicates serve will decide which template to use.\n"
+        " 'tokenizer' indicates the model's tokenizer config will be preferred"
+    ),
+)
+@click.option(
     "--backend",
     type=click.Choice(tuple(backends.SUPPORTED_BACKENDS)),
     cls=clickext.ConfigOption,
@@ -78,6 +88,7 @@ def serve(
     model_family,
     log_file: pathlib.Path | None,
     backend: str | None,
+    chat_template: str | None,
 ) -> None:
     """Start a local server
 
@@ -102,6 +113,9 @@ def serve(
     # Redirect server stdout and stderr to the logger
     log.stdout_stderr_to_logger(logger, log_file)
 
+    if chat_template is None:
+        chat_template = ctx.obj.config.serve.chat_template
+
     logger.info(
         f"Using model '{model_path}' with {gpu_layers} gpu-layers and {max_ctx_size} max context size."
     )
@@ -116,6 +130,7 @@ def serve(
             api_base=ctx.obj.config.serve.api_base(),
             model_path=model_path,
             model_family=model_family,
+            chat_template=chat_template,
             host=host,
             port=port,
             gpu_layers=gpu_layers,
@@ -134,7 +149,9 @@ def serve(
 
         backend_instance = vllm.Server(
             api_base=ctx.obj.config.serve.api_base(),
+            model_family=model_family,
             model_path=model_path,
+            chat_template=chat_template,
             vllm_args=vllm_args,
             host=host,
             port=port,

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -113,6 +113,8 @@ def test_ilab_vllm_args(
     m_backends_get.assert_called_once_with(tmp_path, backends.VLLM)
     m_server.assert_called_once_with(
         api_base="http://127.0.0.1:8000/v1",
+        chat_template=None,
+        model_family=None,
         model_path=tmp_path,
         vllm_args=["--enable_lora"],
         host="127.0.0.1",
@@ -148,4 +150,5 @@ def test_ilab_llama_cpp_args(
         gpu_layers=-1,
         max_ctx_size=4096,
         num_threads=None,
+        chat_template=None,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,7 @@ class TestConfig:
         assert cfg.serve.vllm.vllm_args == []
         assert cfg.serve.host_port == "127.0.0.1:8000"
         assert cfg.serve.backend is None
+        assert cfg.serve.chat_template is None
 
     def _assert_model_defaults(self, cfg):
         package_name = "instructlab"
@@ -184,6 +185,7 @@ generate:
   taxonomy_path: mytaxonomy
 serve:
   model_path: models/granite-7b-lab-Q4_K_M.gguf
+  chat_template: tokenizer
   llama_cpp:
     gpu_layers: 1
     max_ctx_size: 2048
@@ -216,6 +218,7 @@ general:
         assert cfg.generate.model == "models/granite-7b-lab-Q4_K_M.gguf"
         assert cfg.serve.llama_cpp.gpu_layers == 1
         assert cfg.serve.llama_cpp.max_ctx_size == 2048
+        assert cfg.serve.chat_template == "tokenizer"
         assert cfg.serve.vllm.vllm_args == [
             "--dtype=auto",
             "--enable-lora",

--- a/tests/test_lab_serve.py
+++ b/tests/test_lab_serve.py
@@ -1,0 +1,105 @@
+# Standard
+from unittest import mock
+from unittest.mock import patch
+import pathlib
+
+# Third Party
+from click.testing import CliRunner
+
+# First Party
+from instructlab import lab
+
+
+def vllm_setup_test(mock_popen, mock_determine, runner, args):
+    mock_process = mock.MagicMock()
+    mock_popen.return_value = mock_process
+
+    mock_process.communicate.return_value = ("out", "err")
+    mock_process.returncode = 0
+    mock_determine.return_value = ("vllm", "testing")
+
+    runner.invoke(lab.ilab, args)
+
+    assert len(mock_popen.call_args_list) == 1
+    return mock_popen.call_args_list[0][1]["args"]
+
+
+def assert_vllm_args(args):
+    assert "python" in args[0]
+    assert args[1] == "-m"
+    assert args[2] == "vllm.entrypoints.openai.api_server"
+
+
+def assert_template(args, expect_chat, path_chat, chat_value):
+    hit_chat = False
+    template_exists = False
+    template = ""
+    for s in args:
+        if hit_chat:
+            template = s
+            template_exists = pathlib.Path(s).exists()
+        if s == "--chat-template":
+            hit_chat = True
+
+    assert hit_chat == expect_chat
+    if path_chat:
+        assert template_exists
+        assert template == chat_value
+
+
+@patch("time.sleep", side_effect=Exception("Intended Abort"))
+@patch("instructlab.model.backends.backends.determine_backend")
+@patch("subprocess.Popen")
+def test_chat_auto(mock_popen, mock_determine, _, cli_runner: CliRunner):
+    args = vllm_setup_test(
+        mock_popen,
+        mock_determine,
+        cli_runner,
+        ["--config=DEFAULT", "model", "serve", "--model-path=foo"],
+    )
+    assert_vllm_args(args)
+    assert_template(args=args, expect_chat=True, path_chat=False, chat_value="")
+
+
+@patch("time.sleep", side_effect=Exception("Intended Abort"))
+@patch("instructlab.model.backends.backends.determine_backend")
+@patch("subprocess.Popen")
+def test_chat_custom(
+    mock_popen, mock_determine, _, cli_runner: CliRunner, tmp_path: pathlib.Path
+):
+    file = tmp_path / "chat_template.jinja2"
+    file.touch()
+    args = vllm_setup_test(
+        mock_popen,
+        mock_determine,
+        cli_runner,
+        [
+            "--config=DEFAULT",
+            "model",
+            "serve",
+            "--model-path=foo",
+            "--chat-template={}".format(str(file)),
+        ],
+    )
+    assert_vllm_args(args)
+    assert_template(args=args, expect_chat=True, path_chat=True, chat_value=str(file))
+
+
+@patch("time.sleep", side_effect=Exception("Intended Abort"))
+@patch("instructlab.model.backends.backends.determine_backend")
+@patch("subprocess.Popen")
+def test_chat_manual(mock_popen, mock_determine, _, cli_runner: CliRunner):
+    args = vllm_setup_test(
+        mock_popen,
+        mock_determine,
+        cli_runner,
+        [
+            "--config=DEFAULT",
+            "model",
+            "serve",
+            "--model-path=foo",
+            "--chat-template=tokenizer",
+        ],
+    )
+    assert_vllm_args(args)
+    assert_template(args=args, expect_chat=False, path_chat=False, chat_value="")


### PR DESCRIPTION
Introduces a `--chat-template` option, covering both vllm and llama.cpp backends. This addresses compatibility problems with ilab chat clients and the vllm backend, and brings closer consitency between llama.cpp and vllm for out of the box usage. This is also a prerequisite for e2e testing using vLLM.

The option has three possible values:

1. 'auto' (default) - instructlab overrides the model template with a new template based on hard coded model knowledege. This is the current behavior before this commit. However, in the future this could be changed to a different dynamic policy, as the name simply implies instructlab decides

2. 'tokenizer' - uses the template expressed in the model's tokenizer_config.json file (or internal gguf settings). This is the ideal long term direction, although 'auto' allows for better compatibility with legacy behvior.

3. A filesystem path expressing the location of a custom template (e.g. /foo/bar/template.jinja)

Notes:

- On vLLM, Temporary files are held in globals with an atexit cleanup since we currently lack a well defined scope with a long enough period to cover vLLM opening the file. A future change could address this by introducing a scope, or shift startup wait code into start.
- Even though the effective default of --chat-template is "auto" internally None is used to allow for the usage of context overrides.
- Fixes leftover instance logger in exception handling
- Testing is mostly a follow-up with the e2e fixes
- Will link dev doc update soon

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] functional tests have been added, if necessary.
