### PR TITLE
Provide a conversion utility to ensure that the datasets being provided to legacy train are compatible

### DIFF
--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -228,8 +228,8 @@ def linux_train(
     try:
         train_dataset = ensure_legacy_dataset(train_dataset)
         test_dataset = ensure_legacy_dataset(test_dataset)
-    except ValueError:
-        ctx.fail("failed to run training, dataset appears to be empty")
+    except ValueError as e:
+        ctx.fail(f"Failed to parse dataset: {e}")
 
     train_dataset.to_pandas().head()
 

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -33,6 +33,9 @@ from trl import DataCollatorForCompletionOnlyLM, SFTTrainer
 import click
 import torch
 
+# First Party
+from instructlab.utils import ensure_legacy_dataset
+
 # Local
 from ..model.chat import CONTEXTS
 
@@ -222,6 +225,12 @@ def linux_train(
     )
 
     test_dataset = load_dataset("json", data_files=os.fspath(test_file), split="train")
+    try:
+        train_dataset = ensure_legacy_dataset(train_dataset)
+        test_dataset = ensure_legacy_dataset(test_dataset)
+    except ValueError:
+        ctx.fail("failed to run training, dataset appears to be empty")
+
     train_dataset.to_pandas().head()
 
     # https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoTokenizer.from_pretrained

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+from enum import Enum
 from functools import cache, wraps
 from importlib import resources
 from importlib.abc import Traversable
@@ -44,13 +45,23 @@ class TaxonomyReadingException(Exception):
     """An exception raised during reading of the taxonomy."""
 
 
+class MessageRole(Enum):
+    """
+    Defines the known roles used in message samples.
+    """
+
+    SYSTEM = "system"
+    USER = "user"
+    ASSISTANT = "assistant"
+
+
 class Message(TypedDict):
     """
     Represents a message within an AI conversation.
     """
 
     content: str
-    role: str  # one of: 'user', 'assistant', or 'system'
+    role: MessageRole
 
 
 class MessageSample(TypedDict):

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -18,7 +18,7 @@ import pytest
 from instructlab import lab
 from instructlab.configuration import DEFAULTS
 from instructlab.train import linux_train
-from instructlab.utils import MessageRole, MessageSample
+from instructlab.utils import MessageSample
 
 INPUT_DIR = "test_generated"
 TRAINING_RESULTS_DIR = "training_results"
@@ -230,11 +230,11 @@ class TestLabTrain:
             {
                 "messages": [
                     {
-                        "role": MessageRole.SYSTEM.value,
+                        "role": "system",
                         "content": "You are a friendly assistant",
                     },
-                    {"role": MessageRole.USER.value, "content": "What is 2 + 2?"},
-                    {"role": MessageRole.ASSISTANT.value, "content": "2 + 2 = 4"},
+                    {"role": "user", "content": "What is 2 + 2?"},
+                    {"role": "assistant", "content": "2 + 2 = 4"},
                 ],
                 "group": " test",
                 "dataset": "test-dataset",
@@ -277,7 +277,6 @@ class TestLabTrain:
         assert convert_llama_to_gguf_mock.call_args[1]["pad_vocab"] is True
         assert len(convert_llama_to_gguf_mock.call_args[1]) == 2
         linux_train_mock.assert_called_once()
-        print(linux_train_mock.call_args[1])
         assert linux_train_mock.call_args[1]["train_file"] == Path(
             os.path.join(DEFAULTS.DATASETS_DIR, "train_gen.jsonl")
         )


### PR DESCRIPTION
Due to differences in the design of the training & generate in the original ilab implementation and 
what we had in the dedicated SDG and full model fine-tuning pipelines, the datasets that we are generating are incompatibile.

Specifically, instructlab/sdg currently outputs datasets in the HuggingFace messages format, while ilab expects a dataset in the format of:

```py
dataset = [
	{
		"system": "You are a friendly assistant",
		"user": "What is 2+2?",
		"assistant": "2+2=4"
	}
]
```

This PR introduces a shim which detects whether the provided dataset is using the legacy format or the messages format, and provides a conversion if necessary.

**Note**: This conversion can only go in one direction, as the messages format includes additional metadata. Here is a sample in the messages format:
```json
{
    "messages": [
        {
            "content": "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior.",
            "role": "system"
        },
        {
            "content": "Using the word \"grace\", come up with a word that rhymes and has the same number of syllables\n<nopace>",
            "role": "user"
        },
        {
            "content": "Certainly! Here's a word that rhymes with \"grace\" and has the same number of syllables:\n1\\. Space",
            "role": "assistant"
        }
    ],
    "group": "lab_extension",
    "dataset": "base/full-extension",
    "metadata": "{\"num_turns\": 1}"
}
```

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
