### PR TITLE
e2e: Fix config update to use Mixtral

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -74,7 +74,7 @@ test_init() {
 
     step Checking config.yaml
     if [ "${MIXTRAL}" -eq 1 ]; then
-        sed -i -e 's/models\/merlinite.*/models\/mixtral-8x7b-instruct-v0\.1\.Q4_K_M\.gguf/' config.yaml
+        sed -i -e 's/models\/merlinite.*/models\/mixtral-8x7b-instruct-v0\.1\.Q4_K_M\.gguf/' "${CONFIG_HOME}/config.yaml"
     fi
 }
 


### PR DESCRIPTION
PR #1471 changed where the config is located. This `sed` assumed
`config.yaml` was still in the current working directory. Look for it
in `${CONFIG_HOME}` instead. This variable is already set in the
script elsewhere.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
