### PR TITLE
Automatically trigger e2e on AWS

### DIFF
--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -3,12 +3,18 @@
 name: E2E (NVIDIA Tesla T4 x1)
 
 on:
-  workflow_dispatch:
-    inputs:
-      pr_or_branch:
-        description: 'pull request number or branch name'
-        required: true
-        default: 'main'
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
+      - release-*
 
 jobs:
   start-runner:
@@ -46,68 +52,18 @@ jobs:
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
 
-    permissions:
-      pull-requests: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
 
-      - name: Determine if pr_or_branch is a PR number
-        id: check_pr
-        run: |
-          if [[ "${{ github.event.inputs.pr_or_branch }}" =~ ^[0-9]+$ ]]; then
-            echo "is_pr=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_pr=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Check if gh cli is installed
-        id: gh_cli
-        run: |
-          if command -v gh &> /dev/null ; then
-            echo "gh_cli_installed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "gh_cli_installed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Install gh CLI
-        if: steps.gh_cli.outputs.gh_cli_installed == 'false'
-        run: |
-          sudo dnf install 'dnf-command(config-manager)' -y
-          sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-          sudo dnf install gh --repo gh-cli -y
-
-      - name: test gh CLI
-        run: |
-          gh --version
-
-      - name: set default repo
-        run: |
-          gh repo set-default ${{ github.server_url }}/${{ github.repository }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Add comment to PR
-        if: steps.check_pr.outputs.is_pr == 'true'
-        run: |
-          gh pr comment "${{ github.event.inputs.pr_or_branch }}" -b "${{ github.workflow }} workflow launched on this PR: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Fetch and checkout PR
-        if: steps.check_pr.outputs.is_pr == 'true'
+        id: fetch_pr
+        if: github.event_name == 'pull_request_target'
         run: |
-          gh pr checkout ${{ github.event.inputs.pr_or_branch }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout branch
-        if: steps.check_pr.outputs.is_pr == 'false'
-        run: |
-          git checkout ${{ github.event.inputs.pr_or_branch }}
+          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }}
+          git checkout pr-${{ github.event.pull_request.number }}
 
       - name: Install Packages
         run: |
@@ -129,20 +85,6 @@ jobs:
         run: |
           . venv/bin/activate
           ./scripts/basic-workflow-tests.sh -m
-
-      - name: Add comment to PR if the workflow failed
-        if: failure() && steps.check_pr.outputs.is_pr == 'true'
-        run: |
-          gh pr comment "${{ github.event.inputs.pr_or_branch }}" -b "e2e workflow failed on this PR: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}), please investigate."
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Add comment to PR if the workflow succeeded
-        if: success() && steps.check_pr.outputs.is_pr == 'true'
-        run: |
-          gh pr comment "${{ github.event.inputs.pr_or_branch }}" -b "e2e workflow succeeded on this PR: [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}), congrats!"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   stop-runner:
     name: Stop external EC2 runner

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -52,6 +52,11 @@ jobs:
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
 
+    # It is important that this job has no write permissions and has
+    # no access to any secrets. This part (e2e) is where we are running
+    # untrusted code from PRs.
+    permissions: {}
+
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -19,6 +19,9 @@ job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e.
 that runs automatically on all PRs and after commits merge to `main` or release
 branches.
 
+We are currently doing a trial of running the smallest AWS-based e2e workflow
+automatically against PRs, as well.
+
 There are other E2E jobs that can be triggered manually on the [actions
 page](https://github.com/instructlab/instructlab/actions) for the repository.
 These run on a variety of instance types and can be run at the discretion of


### PR DESCRIPTION
This PR is the next step of replacing the `e2e` job that runs on a GitHub hosted
runner in favor of running it on AWS. These changes get the job running
automatically just like the original `e2e`, but does not block merges on it for
now. We can let this run in parallel for a short time to make sure it's stable
before switching over to it completely.


e86902f ci: Run e2e-nvidia-t4-x1.yml automatically

commit e86902f62765d1c648c256b3656a4ac8a4a04449
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Jul 15 17:19:58 2024 -0400

    ci: Run e2e-nvidia-t4-x1.yml automatically
    
    This makes our smallest AWS-based e2e workflow run by default on PRs.
    The hardware configuration is roughly equivalent to the existing e2e
    job that runs by default on PRs on a github-hosted runner.
    
    I propose running this in parallel with the existing e2e workflow for
    a little while to evaluate its stability. The mergify configuraiton
    has not been updated so it will not block on the results of this new
    e2e variant.
    
    One detail of this workflow that is very important to note is that it
    is triggered on the `pull_request_target` event type instead of
    `pull_request`. The difference is that the workflow runs using the
    version checked in to `main` and does not use any code from the PR by
    default. This is for security reasons. We do not want any secrets
    exposed to code from PRs.
    
    The middle job of this workflow, e2e, runs on an ephemeral AWS worker.
    This workflow has no access to any secrets. This is the only place we
    switch over to code in the PR. This should be safe, as long as we are
    careful not to add any use of secrets to this part of the workflow.
    All secret usage must be kept outside of the part that runs on the AWS
    VM.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
