### PR TITLE
e2e: Fix directory for running script

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -130,7 +130,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           . venv/bin/activate
-          cd instructlab
           # TODO Add training once training with the training lib is supported in e2e
           SKIP_TRAIN=1 ./scripts/basic-workflow-tests.sh -cmFM
 


### PR DESCRIPTION
This `cd instructlab` is left over from when I was testing this
workflow on another repository. In that case, it was cloning
instructlab separately, so it had to `cd` into it here to run the
script. Now that we're running out of this repo, this line is not
needed.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
