### PR TITLE
e2e: Fix path to config file

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -114,7 +114,7 @@ test_init() {
 
     step Checking config.yaml
     if [ "${MIXTRAL}" -eq 1 ]; then
-        sed -i -e 's/models\/merlinite.*/models\/mixtral-8x7b-instruct-v0\.1\.Q4_K_M\.gguf/' "${CONFIG_HOME}/config.yaml"
+        sed -i -e 's/models\/merlinite.*/models\/mixtral-8x7b-instruct-v0\.1\.Q4_K_M\.gguf/' "${CONFIG_HOME}/instructlab/config.yaml"
     fi
 }
 

--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -110,7 +110,7 @@ test_smoke() {
 
 test_init() {
     task Initializing ilab
-    [ -f config.yaml ] || ilab config init --non-interactive
+    ilab config init --non-interactive
 
     step Checking config.yaml
     if [ "${MIXTRAL}" -eq 1 ]; then


### PR DESCRIPTION

017414f e2e: Fix path to config file
07e6607 e2e: Always create a new config file

commit 017414f497627d9834575e0cf2b17afa9b11d125
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jul 10 08:00:53 2024 -0400

    e2e: Fix path to config file
    
    This is related to changes made in #1471.
    
    PR #1645 was a previous attempt at fixing this, but the path wasn't
    quite right. It missed `instructlab/` within the base config dir.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 07e66073b8517def46b51c7f15aa6959952cb392
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Jul 10 09:29:21 2024 -0400

    e2e: Always create a new config file
    
    The previous code tried to only create a config file if it did not
    already exist. This script has evolved to assume it has ownership of
    the config, so we should always be creating it. We want to test that
    part of the workflow, as well.
    
    This came up when it was pointed out that the check for an existing
    file was no longer valid after #1471.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
