### PR TITLE
docs: details for mac prerequisite instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
 
    #### Install with Apple Metal on M1/M2/M3 Macs
 
-      > **NOTE**: Make sure your system Python build is `Mach-O 64-bit executable arm64` by using `file -b $(command -v python)`.
+      > **NOTE**: Make sure your system Python build is `Mach-O 64-bit executable arm64` by using `file -b $(command -v python)`,
+      > or if your system is setup with [pyenv](https://github.com/pyenv/pyenv) by using the `file -b $(pyenv which python)` command.
 
       ```shell
       python3 -m venv --upgrade-deps venv


### PR DESCRIPTION
Hi 👋 
especially as Mac OSX ships with python, many use pyenv to avoid conflicting with the system's python.

Following the current command instructions on a system with pyenv would actually return

```
Bourne-Again shell script text executable, ASCII text
```

of the shim instead of the executable.

![image](https://github.com/instructlab/instructlab/assets/1699252/4227e779-63bc-4095-a233-e0899c106f1b)

This PR proposes for newcomers another command to try,
instead of maybe stumbling on the first difference in the setup prerequisite check :) 

wdyt ?

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
