### PR TITLE
training additional_args

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,8 +83,7 @@ class TestConfig:
         assert cfg.serve.model_path == default_model
 
         assert cfg.train is not None
-        assert cfg.train.train_args is not None
-        assert cfg.train.train_args.model_path == "instructlab/granite-7b-lab"
+        assert cfg.train.model_path == "instructlab/granite-7b-lab"
 
     def test_default_config(self, cli_runner):  # pylint: disable=unused-argument
         cfg = config.get_default_config()

--- a/tests/test_lab_diff.py
+++ b/tests/test_lab_diff.py
@@ -83,7 +83,8 @@ class TestLabDiff:
                 self.taxonomy.root,
             ],
         )
-        assert self.taxonomy.untracked_files == [untracked_file]
+
+        assert untracked_file in self.taxonomy.untracked_files
         # Invalid extension is silently filtered out
         assert untracked_file not in result.output
         assert result.exit_code == 0


### PR DESCRIPTION
This work introduces additional_args a new part of the training config which holds less commonly edited options. Users can edit

```
additional_args {

}
```
to their _train config class to set some of these options.

additional_args also lives in persistent storage in  ~/.local/share/instructlab/internal/train_configuration/additional/additional_args.yaml This involved creating a few new subdirectories.

_train has been flattened since all of the torch_args were moved into the additional_args this is what a template config.yaml train section currently looks like:

```
train:
  ckpt_output_dir: /home/cdoern/.cache/instructlab/checkpoints
  data_output_dir: /home/cdoern/.local/share/instructlab/internal
  data_path: /home/cdoern/.local/share/instructlab/datasets
  deepspeed_cpu_offload_optimizer: false
  effective_batch_size: 3840
  additional_args: {}
  is_padding_free: false
  lora_quantize_dtype: nf4
  lora_rank: 4
  max_batch_len: 10000
  max_seq_len: 4096
  model_path: instructlab/granite-7b-lab
  nproc_per_node: 1
  num_epochs: 10
  save_samples: 250000
```

the additional args I have moved out of _train so far are:

```
deepspeed_cpu_offload_optimizer_pin_memory: false
deepspeed_cpu_offload_optimizer_ratio: 1
learning_rate: 2.0e-05
lora_alpha: 32
lora_dropout: 0.1
lora_target_modules:
- q_proj
- k_proj
- v_proj
- o_proj
nnodes: 1
node_rank: 0
random_seed: 42
rdzv_endpoint: 127.0.0.1:12222
rdzv_id: 123
warmup_steps: 25
```

These additional_args are still populated into the default_map for the ilab model train flags. They will not, however, show up as defaults in the config.yaml. If the users adds an override for one of these options in their additional_args portion of the config.yaml, we will honor that.