### PR TITLE
Update Initialize link

### DIFF
--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -143,7 +143,7 @@ CUDAHOSTCXX=$(which clang++-17) pip install --force-reinstall llama_cpp_python==
 ```
 
 Proceed to the `Initialize` section of
-the [CLI README](https://github.com/instructlab/instructlab?tab=readme-ov-file#%EF%B8%8F-initialize-lab),
+the [CLI README](https://github.com/instructlab/instructlab?tab=readme-ov-file#%EF%B8%8F-initialize-ilab),
 and use the `nvtop` utility to validate GPU utilization when interacting
 with `ilab model chat` or `ilab data generate`
 


### PR DESCRIPTION
This PR fixes the link that points to the README Initialize section.

As this is a very simple fix, I didn't open an issue. Please let me know if I should do so (or if any further changes are needed).

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [X] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
