### PR TITLE
Rename to `ilab system info` and fix `ilab sysinfo`

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -130,7 +130,7 @@ rm -f "${ILAB_CONFIG_FILE}"
 ilab --version
 
 # print system information
-ilab system sysinfo
+ilab system info
 
 # pipe 3 carriage returns to ilab config init to get past the prompts
 echo -e "\n\n\n" | ilab init

--- a/scripts/infra/README.md
+++ b/scripts/infra/README.md
@@ -72,7 +72,7 @@ scripts/infra/cloud-instance.sh ec2 pip-install-with-nvidia
 scripts/infra/cloud-instance.sh ec2 ssh
 # Run commands on the instance through ssh
 scripts/infra/cloud-instance.sh ec2 ssh ls -la
-scripts/infra/cloud-instance.sh ec2 ssh "source instructlab/venv/bin/activate && ilab system sysinfo"
+scripts/infra/cloud-instance.sh ec2 ssh "source instructlab/venv/bin/activate && ilab system info"
 # Sync your local git repo to the repo on the instance
 scripts/infra/cloud-instance.sh ec2 sync
 # Make changes in your local git without committing

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -34,7 +34,7 @@ class ExpandAliasesGroup(click.Group):
             cmd = self.aliases[cmd_name]["cmd"]
             group = self.aliases[cmd_name]["group"].name
             c = self.aliases[cmd_name]["cmd"].name
-            print(
+            click.echo(
                 f"You are using an aliased command, this will be deprecated in a future release. Please consider using `ilab {group} {c}` instead"
             )
             return cmd
@@ -68,6 +68,7 @@ aliases = {
     "download": {"group": model_group.model, "cmd": model_group.download},
     "diff": {"group": taxonomy_group.taxonomy, "cmd": taxonomy_group.diff},
     "generate": {"group": data_group.data, "cmd": data_group.generate},
+    "sysinfo": {"group": system_group.system, "cmd": system_group.info},
 }
 
 

--- a/src/instructlab/sysinfo.py
+++ b/src/instructlab/sysinfo.py
@@ -1,6 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-# First Party
-from instructlab.system.sysinfo import get_sysinfo
-
-if __name__ == "__main__":
-    get_sysinfo()

--- a/src/instructlab/system/info.py
+++ b/src/instructlab/system/info.py
@@ -12,20 +12,20 @@ import click
 
 def _platform_info() -> typing.Dict[str, typing.Any]:
     """Platform and machine information"""
-    info = {
+    d = {
         "sys.version": sys.version,
         "sys.platform": sys.platform,
         "os.name": os.name,
         "platform.release": platform.release(),
         "platform.machine": platform.machine(),
     }
-    if sys.version_info >= (3, 10) and sys.platform == "linux":
+    if sys.platform == "linux":
         os_release = platform.freedesktop_os_release()
         for key in ["ID", "VERSION_ID", "PRETTY_NAME"]:
             value = os_release.get(key)
             if value:
-                info[f"os-release.{key}"] = value
-    return info
+                d[f"os-release.{key}"] = value
+    return d
 
 
 def _torch_info() -> typing.Dict[str, typing.Any]:
@@ -53,7 +53,7 @@ def _torch_cuda_info() -> typing.Dict[str, typing.Any]:
     if not torch.cuda.is_available():
         return {}
 
-    info = {
+    d = {
         "torch.cuda.bf16": torch.cuda.is_bf16_supported(),
         "torch.cuda.current": torch.cuda.current_device(),
     }
@@ -62,12 +62,12 @@ def _torch_cuda_info() -> typing.Dict[str, typing.Any]:
         device = torch.device("cuda", idx)
         free, total = torch.cuda.mem_get_info(device)
         capmax, capmin = torch.cuda.get_device_capability(device)
-        info[f"torch.cuda.{idx}.name"] = torch.cuda.get_device_name(device)
-        info[f"torch.cuda.{idx}.free"] = f"{(free / 1024**3):.1f}"
-        info[f"torch.cuda.{idx}.total"] = f"{(total / 1024**3):.1f}"
-        info[f"torch.cuda.{idx}.capability"] = f"{capmax}.{capmin}"
+        d[f"torch.cuda.{idx}.name"] = torch.cuda.get_device_name(device)
+        d[f"torch.cuda.{idx}.free"] = f"{(free / 1024**3):.1f}"
+        d[f"torch.cuda.{idx}.total"] = f"{(total / 1024**3):.1f}"
+        d[f"torch.cuda.{idx}.capability"] = f"{capmax}.{capmin}"
 
-    return info
+    return d
 
 
 def _torch_hpu_info() -> typing.Dict[str, typing.Any]:
@@ -81,7 +81,7 @@ def _torch_hpu_info() -> typing.Dict[str, typing.Any]:
     except ImportError:
         return {}
 
-    info = {
+    d = {
         # 'habana_frameworks' has package name 'habana_torch_plugin'
         "habana_torch_plugin.version": importlib.metadata.version(
             "habana_torch_plugin"
@@ -89,20 +89,20 @@ def _torch_hpu_info() -> typing.Dict[str, typing.Any]:
         "torch.hpu.is_available": hpu.is_available(),
     }
 
-    if not info["torch.hpu.is_available"]:
-        return info
+    if not d["torch.hpu.is_available"]:
+        return d
 
-    info["torch.hpu.device_count"] = hpu.device_count()
+    d["torch.hpu.device_count"] = hpu.device_count()
     for idx in range(hpu.device_count()):
         device = torch.device("hpu", idx)
-        info[f"torch.hpu.{idx}.name"] = hpu.get_device_name(device)
-        info[f"torch.hpu.{idx}.capability"] = hpu.get_device_capability(device)
+        d[f"torch.hpu.{idx}.name"] = hpu.get_device_name(device)
+        d[f"torch.hpu.{idx}.capability"] = hpu.get_device_capability(device)
         prop: str = hpu.get_device_properties(device)
-        info[f"torch.hpu.{idx}.properties"] = prop.strip("()")
+        d[f"torch.hpu.{idx}.properties"] = prop.strip("()")
     for key, value in sorted(os.environ.items()):
         if key.startswith(("PT_", "HABANA", "LOG_LEVEL_", "ENABLE_CONSOLE")):
-            info[f"env.{key}"] = value
-    return info
+            d[f"env.{key}"] = value
+    return d
 
 
 def _llama_cpp_info() -> typing.Dict[str, typing.Any]:
@@ -129,18 +129,18 @@ def _instructlab_info():
 
 def get_sysinfo() -> typing.Dict[str, typing.Any]:
     """Get system information"""
-    info = {}
-    info.update(_platform_info())
-    info.update(_instructlab_info())
-    info.update(_torch_info())
-    info.update(_torch_cuda_info())
-    info.update(_torch_hpu_info())
-    info.update(_llama_cpp_info())
-    return info
+    d = {}
+    d.update(_platform_info())
+    d.update(_instructlab_info())
+    d.update(_torch_info())
+    d.update(_torch_cuda_info())
+    d.update(_torch_hpu_info())
+    d.update(_llama_cpp_info())
+    return d
 
 
 @click.command()
-def sysinfo():
+def info():
     """Print system information"""
     for key, value in get_sysinfo().items():
         print(f"{key}: {value}")

--- a/src/instructlab/system/system.py
+++ b/src/instructlab/system/system.py
@@ -7,7 +7,7 @@ from click_didyoumean import DYMGroup
 import click
 
 # Local
-from .sysinfo import sysinfo
+from .info import info
 
 logger = logging.getLogger(__name__)
 
@@ -20,4 +20,4 @@ def system(ctx):
     ctx.default_map = ctx.parent.default_map
 
 
-system.add_command(sysinfo)
+system.add_command(info)

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -58,29 +58,44 @@ def test_ilab_cli_imports():
     subprocess.check_call([sys.executable, "-c", "; ".join(code)], text=True)
 
 
-@pytest.mark.parametrize(
-    "first,second",
-    [
-        # split first and second level for nicer pytest output
-        (None, None),
-        ("config", None),
-        ("config", "init"),
-        ("config", "show"),
-        ("model", None),
-        ("model", "chat"),
-        ("model", "convert"),
-        ("model", "download"),
-        ("model", "evaluate"),
-        ("model", "serve"),
-        ("model", "test"),
-        ("model", "train"),
-        ("data", None),
-        ("data", "generate"),
-        ("system", "sysinfo"),
-        ("taxonomy", None),
-        ("taxonomy", "diff"),
-    ],
-)
+subcommands = [
+    # split first and second level for nicer pytest output
+    # first, second, extra args
+    (None, None, ()),
+    ("config", None, ()),
+    ("config", "init", ()),
+    ("config", "show", ()),
+    ("model", None, ()),
+    ("model", "chat", ()),
+    ("model", "convert", ()),
+    ("model", "download", ()),
+    ("model", "evaluate", ("--benchmark", "mmlu")),
+    ("model", "serve", ()),
+    ("model", "test", ()),
+    ("model", "train", ()),
+    ("data", None, ()),
+    ("data", "generate", ()),
+    ("system", None, ()),
+    ("system", "info", ()),
+    ("taxonomy", None, ()),
+    ("taxonomy", "diff", ()),
+]
+
+aliases = [
+    "serve",
+    "train",
+    "chat",
+    "test",
+    "evaluate",
+    "init",
+    "download",
+    "diff",
+    "generate",
+    "sysinfo",
+]
+
+
+@pytest.mark.parametrize("first,second", [sc[:2] for sc in subcommands])
 def test_ilab_cli_help(first: str | None, second: str | None, cli_runner):
     cmd = ["--config", "DEFAULT"]
     if first is not None:
@@ -90,3 +105,11 @@ def test_ilab_cli_help(first: str | None, second: str | None, cli_runner):
     cmd.append("--help")
     result = cli_runner.invoke(lab.ilab, cmd)
     assert result.exit_code == 0, result.stdout
+
+
+@pytest.mark.parametrize("alias", aliases)
+def test_ilab_cli_deprecated_help(alias: str, cli_runner):
+    cmd = ["--config", "DEFAULT", alias, "--help"]
+    result = cli_runner.invoke(lab.ilab, cmd)
+    assert result.exit_code == 0, result.stdout
+    assert "this will be deprecated in a future release" in result.stdout


### PR DESCRIPTION
PR #1471 moved `ilab sysinfo` to `ilab system sysinfo`, but did not add an alias for `ilab sysinfo`.

- rename command to `ilab system info` to remove redundant `sys` prefix
- add alias to map `ilab sysinfo` to `ilab system info`
- add tests to verify aliases and now primary subcommand

**Issue resolved by this Pull Request:**
Resolves: #1661

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
