### PR TITLE
WIP: Introduce 'device' flag to evaluate

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -333,6 +333,11 @@ class _evaluate(BaseModel):
     gpus: Optional[int] = Field(
         default=None, description="Number of GPUs to use for running evaluation."
     )
+    device: str = Field(
+        default="auto",
+        description="PyTorch device (e.g. `cpu`, `cuda`, or `mps`) for running models.",
+        pattern="cpu|cuda|mps|auto"
+    )
     mmlu: _mmlu = Field(
         default_factory=_mmlu,
         description="MMLU benchmarking settings",

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -50,6 +50,7 @@ def get_evaluator(
     batch_size,
     tasks_dir,
     merge_system_user_message,
+    device: str,
 ) -> "Evaluator":
     """takes in arguments from the CLI and uses 'benchmark' to validate other arguments
     if all needed configuration is present, returns the appropriate Evaluator class for the benchmark
@@ -498,6 +499,11 @@ def launch_server(
     is_flag=True,
     help="Print serving engine logs.",
 )
+@click.option(
+    "--device",
+    type=click.Choice(["cpu", "cuda", "mps", "auto"]),
+    cls=clickext.ConfigOption,
+)
 @click.pass_context
 @clickext.display_params
 def evaluate(
@@ -518,6 +524,7 @@ def evaluate(
     merge_system_user_message,
     backend,
     judge_backend,
+    device: str,
     tls_insecure,  # pylint: disable=unused-argument
     tls_client_cert,  # pylint: disable=unused-argument
     tls_client_key,  # pylint: disable=unused-argument
@@ -544,6 +551,7 @@ def evaluate(
         batch_size,
         tasks_dir,
         merge_system_user_message,
+        device: str,
     )
 
     # Third Party


### PR DESCRIPTION
This commit introduces a 'device' flag to evaluate, which allows for specifying a PyTorch device for running models. It also sets a default device in the config to cpu.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
