### PR TITLE
training fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ httpx>=0.25.0
 instructlab-eval>=0.0.8
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.2.0
-instructlab-sdg>=0.0.4.1
+instructlab-sdg>=0.1.2
 instructlab-training>=0.0.5
 jsonschema>=4.21.1
 llama_cpp_python[server]==0.2.79

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -256,12 +256,16 @@ DS_OPTIONS = "train_args.deepspeed_options"
 )
 @click.option(
     "--is-padding-free",
+    cls=clickext.ConfigOption,
+    config_sections=TRAIN_ARGS,
     type=bool,
     help="whether or not we are training a padding free transformer.",
 )
 @click.option(
     "--gpus",
     "nproc_per_node",
+    cls=clickext.ConfigOption,
+    config_sections=TORCHRUN_ARGS,
     type=int,
     help="this is the number of GPUs to use. This is a torch specific arg and must be called nproc-per-node",
 )


### PR DESCRIPTION
bump sdg to a version which handles `messages`. Also, fix defaulting for `--is-padding-free` and `--gpus`. Currently these two options have no defaults and the user must specify them to run training