### PR TITLE
Fixes incorrect file reference

### DIFF
--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -369,7 +369,7 @@ def train(
                 reverse=True,
             )
 
-        train_files = get_files(input_dir, "test_*")
+        train_files = get_files(input_dir, "train_*")
         test_files = get_files(input_dir, "test_*")
 
         if not train_files or not test_files:


### PR DESCRIPTION
This PR fixes an issue where the training script currently uses the test files for both the training and the test files.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
