### PR TITLE
Add remaining eval benchmarks to basic-workflow-tests

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -133,7 +133,7 @@ test_download() {
         ilab model download --repository instructlab/granite-7b-lab-GGUF --filename granite-7b-lab-Q4_K_M.gguf
     elif [ "$BACKEND" = "vllm" ]; then
         step Downloading the model for vLLM
-        ilab download --repository instructlab/merlinite-7b-lab
+        ilab model download --repository instructlab/merlinite-7b-lab
     elif [ "$MIXTRAL" -eq 1 ]; then
         step Downloading the mixtral model
         ilab model download --repository TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF --filename mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf --hf-token "${HF_TOKEN}"


### PR DESCRIPTION
This commit adds the remaining ilab model evaluate benchmarks to the basic-workflow-tests script including mmlu_branch, mt_bench, and mt_bench_branch. Also, includes downloading merlinite to be used
as a judge model in the 'branch' benchmarks.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
