### PR TITLE
fix: ensure multiprocessing is used for distributed serving in vLLM

### DIFF
--- a/tests/test_lab_serve.py
+++ b/tests/test_lab_serve.py
@@ -38,6 +38,7 @@ def assert_template(args, expect_chat, path_chat, chat_value):
         if hit_chat:
             template = s
             template_exists = pathlib.Path(s).exists()
+            break  # break as soon as we find the chat template otherwise we will get the next argument and template_exists will fail
         if s == "--chat-template":
             hit_chat = True
 


### PR DESCRIPTION
This commit introduces a dedicated function, `build_vllm_cmd` to construct the vLLM command required to run the server. It ensures that the command includes necessary arguments such as host, port, and model path.

It also explicitly sets the distributed executor backend to multiprocessing to avoid unintended use of Ray, even if it's installed on the system. It uses the "--distributed-executor-backend mp" argument to the vLLM command if it's not already present. With this, we ensure that multiprocessing is used for distributed serving, even if Ray is installed on the system, as Ray is not supported yet.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
