### PR TITLE
Add signal handling to gracefully terminate vLLM server

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -217,10 +217,15 @@ def shutdown_process(process: subprocess.Popen, timeout: int) -> None:
         Nothing
     """
     # vLLM responds to SIGINT by shutting down gracefully and reaping the children
+    logger.debug(f"Sending SIGINT to vLLM server PID {process.pid}")
     process.send_signal(signal.SIGINT)
     try:
+        logger.debug("Waiting for vLLM server to shut down gracefully")
         process.wait(timeout)
     except subprocess.TimeoutExpired:
+        logger.debug(
+            f"Sending SIGKILL to vLLM server since timeout ({timeout}s) expired"
+        )
         process.kill()
 
 

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -3,6 +3,8 @@
 # Standard
 import logging
 import pathlib
+import signal
+import sys
 
 # Third Party
 import click
@@ -13,6 +15,21 @@ from instructlab.model.backends import backends
 from instructlab.model.backends.backends import ServerException
 
 logger = logging.getLogger(__name__)
+
+
+def signal_handler(
+    num_signal,
+    __,
+):
+    """
+    Signal handler for termination signals
+    """
+    print(f"Received termination signal {num_signal}, exiting...")
+    sys.exit(0)
+
+
+# Register the signal handler for SIGTERM
+signal.signal(signal.SIGTERM, signal_handler)
 
 
 @click.command(
@@ -150,3 +167,10 @@ def serve(
     except ServerException as exc:
         click.secho(f"Error creating server: {exc}", fg="red")
         raise click.exceptions.Exit(1)
+
+    except KeyboardInterrupt:
+        logger.info("Server terminated by keyboard")
+
+    finally:
+        backend_instance.shutdown()
+        raise click.exceptions.Exit(0)


### PR DESCRIPTION
Before this patch, if `ilab model serve` received a SIGTERM, it would
exit abruptly, leaving the vLLM process and its child processes
orphaned.

This commit adds a signal handler to the main entrypoint of 'ilab' for
SIGTERM. This allows both llama-cpp and vLLM servers to exit gracefully
when receiving a termination signal, ensuring that resources are
properly released and shutdown procedures are correctly executed.

The handler is setup to catch SIGTERM, once received, it executes
`signal_handler()`, which calls exit 0, the code then goes into its
final sequence through `finally` which stops the server and return. At
this point, `ilab` has exited properly and cleanly.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
