### PR TITLE
fix: vllm serving with multiple gpus not shutting down properly

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -201,11 +201,12 @@ def get(model_path: pathlib.Path, backend: str | None) -> str:
     return backend
 
 
+# TODO: This is only used by vLLM but should move to vllm.py
 def shutdown_process(process: subprocess.Popen, timeout: int) -> None:
     """
     Shuts down a process
 
-    Sends SIGTERM and then after a timeout if the process still is not terminated sends a SIGKILL
+    Sends SIGINT and then after a timeout if the process still is not terminated sends a SIGKILL
 
     Args:
         process (subprocess.Popen): process of the vllm server
@@ -213,7 +214,8 @@ def shutdown_process(process: subprocess.Popen, timeout: int) -> None:
     Returns:
         Nothing
     """
-    process.terminate()
+    # vLLM responds to SIGINT by shutting down gracefully and reaping the children
+    process.send_signal(signal.SIGINT)
     try:
         process.wait(timeout)
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
Internally, we run vLLM using the Python interpreter as described in the [official
documentation](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html).

vLLM is intended to run via the CLI and be terminated by sending SIGINT (Ctrl+C). This way, when the signal is received, vLLM will properly shut down and reap its child processes.

Another approach was developed by @alimaredia
[here](https://github.com/alimaredia/instructlab/commit/8edfb81ef915b65179bb0f07c94ff82488c8bdbd).
This method involved listing and registering child processes launched by
vLLM, then manually killing each child process during shutdown. @tiran
and I agree that this approach is overkill and should only be used if
there is an urgent bug in vLLM that needs to be fixed quickly. However,
this is not the case, as vLLM correctly responds to SIGINT and
terminates its child processes.

Closes: https://github.com/instructlab/instructlab/issues/1601
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
