### PR TITLE
feat: print default config file when running ilab

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -77,8 +77,8 @@ aliases = {
     "--config",
     "config_file",
     type=click.Path(),
-    default=lambda: cfg.DEFAULTS.CONFIG_FILE,
-    show_default="config in user config directory",
+    default=cfg.DEFAULTS.CONFIG_FILE,
+    show_default=True,
     help="Path to a configuration file.",
 )
 @click.option(


### PR DESCRIPTION
Just running `ilab` can be helpful in determining the default location of the config file.

```
$ ilab
Usage: ilab [OPTIONS] COMMAND [ARGS]...

  CLI for interacting with InstructLab.

  If this is your first time running ilab, it's best to start with `ilab
  config init` to create the environment.

Options:
  --config PATH  Path to a configuration file.  [default:
                 /home/ec2-user/.config/instructlab/config.yaml]
```

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
