### PR TITLE
Add test to track config file changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,10 @@ toolbox-rm: check-toolbox ## Stop and remove toolbox container
 tests: check-tox ## Run unit and type checks
 	tox -e py3-unit,mypy
 
+.PHONY: regenerate-testdata
+regenerate-testdata: check-tox ## Run unit tests and regenerate test data
+	tox -e py3-unit -- --regenerate-testdata
+
 .PHONY: verify
 verify: check-tox ## Run linting and formatting checks via tox
 	tox p -m fastverify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,3 +228,9 @@ tests = ["tests/"]
 
 [tool.coverage.report]
 exclude_lines = ["@abc.abstractmethod", "if typing.TYPE_CHECKING"]
+
+[tool.pytest.ini_options]
+# don't collect src/instructlab/model/linux_test.py
+testpaths = "tests"
+# verbose diffs
+verbosity_assertions = 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,13 +12,23 @@ import typing
 from click.testing import CliRunner
 import pytest
 
-# First Party
-from instructlab.configuration import DEFAULTS
-
 # Local
 from .taxonomy import MockTaxonomy
 
 TESTS_PATH = pathlib.Path(__file__).parent.absolute()
+
+
+def pytest_addoption(parser) -> None:
+    parser.addoption(
+        "--regenerate-testdata",
+        action="store_true",
+        help="Regenerate test data like dumped config",
+    )
+
+
+@pytest.fixture
+def regenerate_testdata(request) -> bool:
+    return bool(request.config.getoption("--regenerate-testdata"))
 
 
 @pytest.fixture
@@ -49,6 +59,9 @@ def tmp_path_home(tmp_path: pathlib.Path) -> typing.Generator[pathlib.Path, None
 
     Yields `tmp_path` fixture path.
     """
+    # First Party
+    from instructlab.configuration import DEFAULTS
+
     with mock.patch.dict(os.environ):
         os.environ["HOME"] = str(tmp_path)
         for key in list(os.environ):

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -1,0 +1,80 @@
+chat:
+  context: default
+  greedy_mode: false
+  logs_dir: /data/instructlab/chatlogs
+  max_tokens: null
+  model: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
+  session: null
+  vi_mode: false
+  visible_overflow: true
+evaluate:
+  base_branch: null
+  base_model: instructlab/granite-7b-lab
+  branch: null
+  gpus: 1
+  mmlu:
+    batch_size: auto
+    few_shots: 2
+  mmlu_branch:
+    tasks_dir: /data/instructlab/datasets
+  model: null
+  mt_bench:
+    judge_model: prometheus-eval/prometheus-8x7b-v2.0
+    max_workers: 16
+    output_dir: /data/instructlab/internal/eval_data
+  mt_bench_branch:
+    taxonomy_path: /data/instructlab/taxonomy
+general:
+  debug_level: 0
+  log_level: INFO
+generate:
+  chunk_word_count: 1000
+  model: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
+  num_cpus: 10
+  output_dir: /data/instructlab/datasets
+  prompt_file: /data/instructlab/internal/prompt.txt
+  sdg_scale_factor: 30
+  seed_file: /data/instructlab/internal/seed_tasks.json
+  taxonomy_base: origin/main
+  taxonomy_path: /data/instructlab/taxonomy
+  teacher:
+    backend: null
+    chat_template: null
+    host_port: 127.0.0.1:8000
+    llama_cpp:
+      gpu_layers: -1
+      llm_family: ''
+      max_ctx_size: 4096
+    model_path: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
+    vllm:
+      llm_family: ''
+      vllm_args: []
+serve:
+  backend: null
+  chat_template: null
+  host_port: 127.0.0.1:8000
+  llama_cpp:
+    gpu_layers: -1
+    llm_family: ''
+    max_ctx_size: 4096
+  model_path: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
+  vllm:
+    llm_family: ''
+    vllm_args: []
+train:
+  additional_args: {}
+  ckpt_output_dir: /data/instructlab/checkpoints
+  data_output_dir: /data/instructlab/internal
+  data_path: /data/instructlab/datasets
+  deepspeed_cpu_offload_optimizer: false
+  effective_batch_size: 3840
+  is_padding_free: false
+  lora_quantize_dtype: nf4
+  lora_rank: 4
+  max_batch_len: 10000
+  max_seq_len: 4096
+  model_path: instructlab/granite-7b-lab
+  nproc_per_node: 1
+  num_epochs: 10
+  save_samples: 250000
+version: 1.0.0


### PR DESCRIPTION
A new test compares the config from `get_default_config` against a default config file in VCS. This allows us to track any change in the git history.

See: #1725 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
