### PR TITLE
legacy train fix

### DIFF
--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -311,13 +311,13 @@ def train(
     if four_bit_quant and device != "cuda":
         ctx.fail("'--4-bit-quant' option requires '--device=cuda'")
 
-    effective_data_dir = Path(DEFAULTS.DATASETS_DIR)
+    effective_data_dir = Path(data_path or DEFAULTS.TAXONOMY_DIR)
     train_file = Path(effective_data_dir / "train_gen.jsonl")
     test_file = Path(effective_data_dir / "test_gen.jsonl")
     ckpt_output_dir = Path(kwargs["ckpt_output_dir"])
 
     # NOTE: If given a data_dir, input-dir is ignored in favor of existing!
-    if not data_path or data_path.strip() == DEFAULTS.DATASETS_DIR:
+    if not data_path or data_path == DEFAULTS.TAXONOMY_DIR:
         data_path = str(effective_data_dir)
         if not os.path.exists(input_dir):
             click.secho(

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -4,6 +4,7 @@
 # Standard
 from pathlib import Path
 from unittest.mock import patch
+import json
 import os
 import platform
 import sys
@@ -407,6 +408,116 @@ class TestLabTrain:
         assert len(linux_train_mock.call_args[1]) == 7
         is_macos_with_m_chip_mock.assert_called_once()
         assert not os.path.isfile(LINUX_GGUF_FILE)
+
+    @patch("instructlab.utils.is_macos_with_m_chip", return_value=False)
+    @patch.object(linux_train, "linux_train", return_value=Path("training_results"))
+    @patch(
+        "instructlab.llamacpp.llamacpp_convert_to_gguf.convert_llama_to_gguf",
+        side_effect=mock_convert_llama_to_gguf,
+    )
+    def test_double_train_linux(
+        self,
+        convert_llama_to_gguf_mock,
+        linux_train_mock,
+        is_macos_with_m_chip_mock,
+        tmp_path_home,
+    ):
+        cli_runner = CliRunner()
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path_home):
+            # re-initialize the defaults
+            setup_input_dir(DEFAULTS.DATASETS_DIR)
+            setup_input_dir()
+            setup_linux_dir()
+
+            # create the files so they already exist
+            test_legacy_message = json.dumps(
+                {"user": "hi", "system": "hi", "assistant": "hi"}
+            )
+            test_files_to_create = ["train_gen.jsonl", "test_gen.jsonl"]
+            for f in test_files_to_create:
+                with open(
+                    os.path.join(tmp_path_home, DEFAULTS.DATASETS_DIR, f),
+                    "w",
+                    encoding=ENCODING,
+                ) as outfile:
+                    outfile.write(f"{test_legacy_message}\n")
+
+            assert "train_gen.jsonl" in os.listdir(DEFAULTS.DATASETS_DIR)
+            assert "test_gen.jsonl" in os.listdir(DEFAULTS.DATASETS_DIR)
+            result = cli_runner.invoke(
+                lab.ilab,
+                [
+                    "--config=DEFAULT",
+                    "model",
+                    "train",
+                    "--legacy",
+                    "--input-dir",
+                    DEFAULTS.DATASETS_DIR,
+                    "--data-path",
+                    DEFAULTS.DATASETS_DIR,
+                ],
+            )
+            print(f"{result.exception=}")
+            print(f"{result.output=}")
+            print(f"{result.stdout=}")
+            assert result.exception is None
+            assert result.exit_code == 0
+            convert_llama_to_gguf_mock.assert_called_once()
+            assert convert_llama_to_gguf_mock.call_args[1]["model"] == Path(
+                "training_results/final"
+            )
+            assert convert_llama_to_gguf_mock.call_args[1]["pad_vocab"] is True
+            assert len(convert_llama_to_gguf_mock.call_args[1]) == 2
+            linux_train_mock.assert_called_once()
+            print(linux_train_mock.call_args[1])
+            assert linux_train_mock.call_args[1]["train_file"] == Path(
+                os.path.join(DEFAULTS.DATASETS_DIR, "train_gen.jsonl")
+            )
+            assert linux_train_mock.call_args[1]["test_file"] == Path(
+                os.path.join(DEFAULTS.DATASETS_DIR, "test_gen.jsonl")
+            )
+            assert linux_train_mock.call_args[1]["num_epochs"] == 10
+            assert linux_train_mock.call_args[1]["train_device"] is not None
+            assert not linux_train_mock.call_args[1]["four_bit_quant"]
+            assert len(linux_train_mock.call_args[1]) == 7
+            is_macos_with_m_chip_mock.assert_called_once()
+            assert not os.path.isfile(LINUX_GGUF_FILE)
+
+            assert "train_gen.jsonl" in os.listdir(DEFAULTS.DATASETS_DIR)
+            assert "test_gen.jsonl" in os.listdir(DEFAULTS.DATASETS_DIR)
+            # run this test a second time to ensure files are getting selected correctly
+            result = cli_runner.invoke(
+                lab.ilab,
+                [
+                    "--config=DEFAULT",
+                    "model",
+                    "train",
+                    "--legacy",
+                    "--input-dir",
+                    DEFAULTS.DATASETS_DIR,
+                    "--data-path",
+                    DEFAULTS.DATASETS_DIR,
+                ],
+            )
+            # assert result.exit_code == 0
+            assert result.exception is None
+            assert convert_llama_to_gguf_mock.call_args[1]["model"] == Path(
+                "training_results/final"
+            )
+            assert convert_llama_to_gguf_mock.call_args[1]["pad_vocab"] is True
+            assert len(convert_llama_to_gguf_mock.call_args[1]) == 2
+            print(linux_train_mock.call_args[1])
+            assert linux_train_mock.call_args[1]["train_file"] == Path(
+                os.path.join(DEFAULTS.DATASETS_DIR, "train_gen.jsonl")
+            )
+            assert linux_train_mock.call_args[1]["test_file"] == Path(
+                os.path.join(DEFAULTS.DATASETS_DIR, "test_gen.jsonl")
+            )
+            assert linux_train_mock.call_args[1]["num_epochs"] == 10
+            assert linux_train_mock.call_args[1]["train_device"] is not None
+            assert not linux_train_mock.call_args[1]["four_bit_quant"]
+            assert len(linux_train_mock.call_args[1]) == 7
+            assert not os.path.isfile(LINUX_GGUF_FILE)
 
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=False)
     @patch(


### PR DESCRIPTION
we should only shutil the files from input-dir to data-dir if data-dir DNE. The way this is happening now makes it so that you copy the same files on top of one another resulting in a `SameFileError`

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
