### PR TITLE
docs: Update text matrix for clarity purposes

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -60,13 +60,18 @@ The project currently supports the usage of the following runners for the E2E jo
 
 ### E2E Test Matrix
 
-| Area | Feature | [`e2e.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e.yml) | [`e2e-nvidia-t4-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-t4-x1.yml) | [`e2e-nvidia-a10g-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-a10g-x1.yml) | [`e2e-nvidia-a10g-x4.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-a10g-x4.yml) | High fidelity target (target combo once pieces work together) |
-| --- | --- | --- | --- | --- | --- | --- |
-| **Serving**  | llama-cpp                |✅|✅|✅|✅|❌|
-|              | vllm                     |❌|❌|❌|❌|✅|
-| **Generate** | simple                   |✅|✅|✅|❌|❌|
-|              | full                     |❌|❌|❌|✅|✅|
-| **Training** | legacy+Linux             |❌|❌|✅|❌|❌|
-|              | legacy+Linux+4-bit-quant |✅|✅|❌|❌|❌|
-|              | training-lib             |❌|❌|❌|❌|✅|
-| **Eval**     | eval                     |❌|❌|✅|❌|✅|
+| Area | Feature | [`e2e.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e.yml) | [`e2e-nvidia-t4-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-t4-x1.yml) | [`e2e-nvidia-a10g-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-a10g-x1.yml) | [`e2e-nvidia-a10g-x4.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-a10g-x4.yml) |
+| --- | --- | --- | --- | --- | --- |
+| **Serving**  | llama-cpp                |✅|✅|✅|✅ (temporary)|
+|              | vllm                     |⎯|⎯|⎯|❌|
+| **Generate** | simple                   |✅|✅|✅|⎯|
+|              | full                     |⎯|⎯|⎯|✅|
+| **Training** | legacy+Linux             |⎯|⎯|✅|⎯|
+|              | legacy+Linux+4-bit-quant |✅|✅|⎯|⎯|
+|              | training-lib             |⎯|⎯|✅|❌|
+| **Eval**     | eval                     |⎯|⎯|✅|❌️|
+
+Notes not reflected in the matrix:
+
+* The `training-lib` testing is not testing using the output of the Generate step. <https://github.com/instructlab/instructlab/issues/1655>
+* The `eval` testing is not evaluating the output of the Training step. <https://github.com/instructlab/instructlab/issues/1540>


### PR DESCRIPTION
* Use dashes instead of red Xes to indicate where something isn't
  used, but it's intentional and not a problem.

* Drop the target column. Our gaps are now reflected by red Xes.

* Note where the training-lib is now exercised.

* Add notes on some coverage gaps that aren't easy to reflect in the
  matrix.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
