### PR TITLE
fix train-profile, switch additional args to [str, typing.any]

### DIFF
--- a/scripts/test-data/train-profile-a10.yaml
+++ b/scripts/test-data/train-profile-a10.yaml
@@ -1,37 +1,21 @@
-torch_args:
-  nnodes: 1
-  node_rank: 0
-  nproc_per_node: 1
-  rdzv_endpoint: 127.0.0.1:12222
-  rdzv_id: 123
-train_args:
-  ckpt_output_dir: checkpoints
-  data_output_dir: train-output
-  data_path: ./taxonomy_data
-  deepspeed_options:
-    cpu_offload_optimizer: true
-    cpu_offload_optimizer_pin_memory: false
-    cpu_offload_optimizer_ratio: 1
-    save_samples: null
-  effective_batch_size: 100
-  is_padding_free: false
-  learning_rate: 2e-6
-  lora:
-    alpha: 32
-    dropout: 0.1
-    quantize_data_type: nf4
-    rank: 2
-    target_modules:
-    - q_proj
-    - k_proj
-    - v_proj
-    - o_proj
-  max_batch_len: 1000
-  max_seq_len: 96
-  mock_data: false
-  mock_data_len: 0
-  model_path: instructlab/granite-7b-lab
-  num_epochs: 1
-  random_seed: 42
-  save_samples: 100
+additional_args:
   warmup_steps: 10
+  learning_rate: 2e-6
+  lora_dropout: 0.1
+  lora_alpha: 32
+  deepspeed_cpu_offload_optimizer_pin_memory: false
+  deepspeed_cpu_oddload_optimizer_ratio: 1
+ckpt_output_dir: checkpoints
+data_output_dir: train-output
+data_path: ./taxonomy_data
+deepspeed_cpu_offload_optimizer: true
+effective_batch_size: 100
+lora_quantize_dtype: nf4
+lora_rank: 2
+max_batch_len: 1000
+max_seq_len: 96
+model_path: instructlab/granite-7b-lab
+num_epochs: 1
+save_samples: 100
+is_padding_free: false
+nproc_per_node: 1

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -365,7 +365,7 @@ class _train(BaseModel):
 
     nproc_per_node: int
 
-    additional_args: dict[str, str]
+    additional_args: dict[str, typing.Any]
 
 
 class Config(BaseModel):


### PR DESCRIPTION
the current a10 train profile didn't get adjusted for additional_args support

also, so that each entry in additional_args doesn't need to be strings, switch the value type to `typing.Any`

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
