### PR TITLE
Fix security and UnboundLocalError in config show (PR #1471)

### DIFF
--- a/src/instructlab/config/show.py
+++ b/src/instructlab/config/show.py
@@ -10,16 +10,12 @@ from instructlab import clickext
 @click.command()
 @click.pass_context
 @clickext.display_params
-def show(
-    ctx: click.Context,
-) -> None:
+def show(ctx: click.Context) -> None:
     """Displays the current config as YAML"""
     # TODO: make this use pretty colors like jq/yq
     try:
-        config_yaml = yaml.load(
-            ctx.obj.config.model_dump_json(), Loader=yaml.FullLoader
-        )
+        config_yaml = yaml.safe_load(ctx.obj.config.model_dump_json())
     except yaml.YAMLError as e:
         click.secho(f"Error loading config as YAML: {e}", fg="red")
-        ctx.abort()
+        ctx.exit(2)
     click.echo(yaml.dump(config_yaml, indent=4))

--- a/tests/test_lab_config.py
+++ b/tests/test_lab_config.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Third Party
+from click.testing import CliRunner
+import yaml
+
+# First Party
+from instructlab import configuration, lab
+
+
+def test_ilab_config_show(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(lab.ilab, ["--config", "DEFAULT", "config", "show"])
+    assert result.exit_code == 0, result.stderr
+
+    parsed = yaml.safe_load(result.stdout_bytes)
+    assert parsed
+
+    assert configuration.Config(**parsed)


### PR DESCRIPTION
`ilab config show` mishandles an exception in YAML parsing. It does not exit when `yaml.load()` fails with an exception. Instead it leaves `config_yaml` undefined, which leads to an `UnboundLocalError` error.

The code was also using the wrong yaml loader. All other code paths are using a safe loader, which prevents accidental code execution and security problems. The FullLoader is not safe. PyYAML's documentation even warns against using it:

> WARNING: As of pyyaml-5.3.1 there are still trivial exploits. Do
> not use this on untrusted data for now.

The command now exits with error code 2 on error and uses safe loading. Our code is unlikely to be affected by the unsafe operation, but better safe than sorry.

**Issue resolved by this Pull Request:**
See #1471 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
