### PR TITLE
Allow for separate judge backend option

### DIFF
--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -387,7 +387,12 @@ def launch_server(
 @click.option(
     "--backend",
     type=click.Choice(tuple(backends.SUPPORTED_BACKENDS)),
-    help="Serving backend to use for evaluation. Options are vllm and llama-cpp.",
+    help="Serving backend to use for the model and base model (if applicable) during evaluation. Options are vllm and llama-cpp.",
+)
+@click.option(
+    "--judge-backend",
+    type=click.Choice(tuple(backends.SUPPORTED_BACKENDS)),
+    help="Serving backend to use for the judge model for during mt_bench or mt_bench_branch evaluation. Options are vllm and llama-cpp.",
 )
 @click.option(
     "--tls-insecure",
@@ -438,6 +443,7 @@ def evaluate(
     gpus,
     merge_system_user_message,
     backend,
+    judge_backend,
     tls_insecure,  # pylint: disable=unused-argument
     tls_client_cert,  # pylint: disable=unused-argument
     tls_client_key,  # pylint: disable=unused-argument
@@ -491,7 +497,7 @@ def evaluate(
                     JUDGE_MODEL_NAME,
                     max_workers,
                     gpus,
-                    backend,
+                    judge_backend,
                     enable_serving_output,
                 )
                 overall_score, qa_pairs, turn_scores, error_rate = (
@@ -567,7 +573,7 @@ def evaluate(
                     JUDGE_MODEL_NAME,
                     max_workers,
                     gpus,
-                    backend,
+                    judge_backend,
                     enable_serving_output,
                 )
                 for i, evaluator in enumerate(evaluators):


### PR DESCRIPTION
This is to allow for cases when for example your model or base model need to be served with llama-cpp but your judge needs to be served by vllm.  That would work as is if backend isn't specified.  But as soon as you need to force a backend, currently it would force the backend to be the same for the model and judge model

Ex:

```
(venv) [ec2-user@ip-10-0-1-95 instructlab]$ ilab model evaluate --judge-model models/instructlab/granite-7b-lab --benchmark mt_bench --backend llama-cpp --judge-backend vllm
Generating answers...
WARNING 2024-07-12 22:22:51,358 evaluate.py:276: launch_server When using llama-cpp, we recommend setting max_workers to a maximum of 16
  0%|                                                                                                                                                     | 0/4 [00:00<?, ?it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [02:16<00:00, 34.06s/it]
Evaluating answers...
INFO 2024-07-12 22:25:16,422 vllm.py:149: run_vllm vLLM starting up on pid 3485 at http://127.0.0.1:36937/v1
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:18<00:00,  2.26s/it]
# SKILL EVALUATION REPORT

## MODEL
models/merlinite-7b-lab-Q4_K_M.gguf

### AVERAGE:
9.0 (across 1)

### TURN ONE:
9.0

### TURN TWO:
N/A

### ERROR RATE:
0.88
```

**Issue resolved by this Pull Request:**
Resolves #1602
Two other PRs have already addressed issues noted in #1602: #1692 and #1564

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
