### PR TITLE
Remove magic number for eval max_workers recommendation

### DIFF
--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -5,6 +5,7 @@
 from copy import copy
 import enum
 import logging
+import multiprocessing
 import os
 import pathlib
 import typing
@@ -272,9 +273,10 @@ def launch_server(
                 "Evaluate requires a context size of >= 5120, ignoring serve configuration for max_ctx_size"
             )
         # llama-cpp fails fast on too many incoming requests and returns errors to client
-        if max_workers > 16:
+        recommended_workers = max(multiprocessing.cpu_count() // 2, 1)
+        if max_workers > recommended_workers:
             logging.warning(
-                "When using llama-cpp, we recommend setting max_workers to a maximum of 16"
+                f"Based on your hardware configuration, when using llama-cpp, we recommend setting max-workers to a maximum of {recommended_workers}"
             )
         if gpus:
             logging.debug("Ignoring --gpus option for llama-cpp serving")


### PR DESCRIPTION
The new logic recommends a value to be half the number of cores (rounded down) that are available in the hardware to match llama-cpp's behavior.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
