### PR TITLE
Add max workers recommendation for vllm and adjust default

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -433,7 +433,7 @@ def get_default_config() -> Config:
             mt_bench=_mtbench(
                 judge_model=DEFAULTS.JUDGE_MODEL_MT,
                 output_dir=DEFAULTS.EVAL_DATA_DIR,
-                max_workers=40,
+                max_workers=16,
             ),
             mmlu=_mmlu(
                 few_shots=2,


### PR DESCRIPTION
The recommendation is based on the number of cpus available since it relates to the number of cpu bound worker threads.  There is also some correlation to gpus as well and the results will vary based on hardware, so the recommended range is fairly wide +- 50% from the #cpus.

Also change the default max_workers in config to work better with lower end hardware.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
