### PR TITLE
Removing orphaned pylint comment

### DIFF
--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -244,9 +244,6 @@ def launch_server(
     backend,
     enable_serving_output,
 ) -> tuple:
-    # pylint: disable=import-outside-toplevel
-    # First Party
-
     eval_serve = copy(ctx.obj.config.serve)
     if backend is None:
         try:


### PR DESCRIPTION
It was orphaned with this change: https://github.com/instructlab/instructlab/pull/1564/files

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
