### PR TITLE
Only load mt_bench or mmlu as needed

### DIFF
--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -58,16 +58,6 @@ def get_evaluator(
     if all needed configuration is present, returns the appropriate Evaluator class for the benchmark
     otherwise raises an exception for the missing values
     """
-    # Third Party
-    from instructlab.eval.mmlu import MMLUBranchEvaluator, MMLUEvaluator
-    from instructlab.eval.mt_bench import MTBenchBranchEvaluator, MTBenchEvaluator
-
-    benchmark_map = {
-        Benchmark.MMLU: MMLUEvaluator,
-        Benchmark.MMLU_BRANCH: MMLUBranchEvaluator,
-        Benchmark.MT_BENCH: MTBenchEvaluator,
-        Benchmark.MT_BENCH_BRANCH: MTBenchBranchEvaluator,
-    }
 
     # ensure skills benchmarks have proper arguments if selected
     if benchmark in {Benchmark.MT_BENCH, Benchmark.MT_BENCH_BRANCH}:
@@ -96,16 +86,21 @@ def get_evaluator(
                 fg="red",
             )
             raise click.exceptions.Exit(1)
-        evaluator_class = benchmark_map[benchmark]
         if benchmark == Benchmark.MT_BENCH:
-            return evaluator_class(
+            # Third Party
+            from instructlab.eval.mt_bench import MTBenchEvaluator
+
+            return MTBenchEvaluator(
                 TEST_MODEL_NAME,
                 JUDGE_MODEL_NAME,
                 output_dir,
                 max_workers,
                 merge_system_user_message=merge_system_user_message,
             )
-        return evaluator_class(
+        # Third Party
+        from instructlab.eval.mt_bench import MTBenchBranchEvaluator
+
+        return MTBenchBranchEvaluator(
             TEST_MODEL_NAME,
             JUDGE_MODEL_NAME,
             taxonomy_path,
@@ -130,23 +125,28 @@ def get_evaluator(
                 fg="red",
             )
             raise click.exceptions.Exit(1)
-        evaluator_class = benchmark_map[benchmark]
         if benchmark == Benchmark.MMLU:
+            # Third Party
+            from instructlab.eval.mmlu import MMLUEvaluator
+
             min_tasks = os.environ.get("INSTRUCTLAB_EVAL_MMLU_MIN_TASKS")
             if min_tasks is not None:
                 tasks = ["mmlu_abstract_algebra", "mmlu_anatomy", "mmlu_astronomy"]
-                evaluator = evaluator_class(
+                evaluator = MMLUEvaluator(
                     model,
                     tasks=tasks,
                     few_shots=few_shots,
                     batch_size=batch_size,
                 )
             else:
-                evaluator = evaluator_class(
+                evaluator = MMLUEvaluator(
                     model, few_shots=few_shots, batch_size=batch_size
                 )
             return evaluator
-        return evaluator_class(
+        # Third Party
+        from instructlab.eval.mmlu import MMLUBranchEvaluator
+
+        return MMLUBranchEvaluator(
             model,
             tasks_dir,
             ["mmlu_pr"],


### PR DESCRIPTION
This helps a bit with loading performance.  It also helps a current issue with lm_eval messing with the logger settings since it's not needed from mt_bench and mt_bench_branch.

This logic also removes the benchmark class map which wasn't really worth creating just to reference 1 time.


Related: https://github.com/instructlab/eval/issues/65

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
