### PR TITLE
Update batch size to not be described in terms of gpus and allow non integer values

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -308,7 +308,7 @@ class _serve(BaseModel):
 
 class _mmlu(BaseModel):
     few_shots: int
-    batch_size: int
+    batch_size: str
 
 
 class _mtbench(BaseModel):
@@ -437,7 +437,7 @@ def get_default_config() -> Config:
             ),
             mmlu=_mmlu(
                 few_shots=2,
-                batch_size=5,
+                batch_size="auto",
             ),
             mt_bench_branch=_mtbenchbranch(taxonomy_path=DEFAULTS.TAXONOMY_DIR),
             mmlu_branch=_mmlubranch(tasks_dir=DEFAULTS.DATASETS_DIR),

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -359,10 +359,10 @@ def launch_server(
 )
 @click.option(
     "--batch-size",
-    type=click.INT,
+    type=click.STRING,
     cls=clickext.ConfigOption,
     config_sections="mmlu",
-    help="Number of GPUs. Needed for running mmlu or mmlu_branch.",
+    help="Batch size for mmlu and mmlu_branch evaluation. Valid values are a positive integer, 'auto' to select the largest batch size that will fit in memory, or 'auto:N' to reselect the largest batch size N times'.",
 )
 @click.option(
     "--tasks-dir",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -197,7 +197,7 @@ evaluate:
   gpus: 1
   mmlu:
     few_shots: 2
-    batch_size: 5
+    batch_size: auto
   mmlu_branch:
     tasks_dir: /path/to/sdg
   mt_bench:


### PR DESCRIPTION
Allowing STRING types allows for the valid values of auto and auto:N to be set in addition to integers.

Also adjusting the default to auto to remove the magic number and hopefully have better out of the box tuning.

Corresponding change on the eval side: https://github.com/instructlab/eval/pull/67

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
