### PR TITLE
Add a colon before the log message

### DIFF
--- a/src/instructlab/log.py
+++ b/src/instructlab/log.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 
-FORMAT = "%(levelname)s %(asctime)s %(filename)s:%(lineno)d: %(funcName)s %(message)s"
+FORMAT = "%(levelname)s %(asctime)s %(filename)s:%(lineno)d: %(funcName)s: %(message)s"
 
 
 class CustomFormatter(logging.Formatter):


### PR DESCRIPTION
Before the patch the log line would have a colon, then the function name and the log message. It's a bit hard to read. Now, we have the colon before the log message so it's easier to see where the log message starts.

Before:

```
INFO 2024-07-15 14:44:29,514 llama_cpp.py:177: server Starting server process,
```

After:

```
INFO 2024-07-15 14:44:29,514 llama_cpp.py:177: server: Starting server process,
```

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
