### PR TITLE
Training: update e2e test

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -36,7 +36,6 @@ NC='\033[0m' # No Color
 
 SCRIPTDIR=$(dirname "$0")
 export E2E_TEST_DIR
-# E2E_TEST_DIR="$(pwd)/__e2e_test"
 export CONFIG_HOME
 export DATA_HOME
 export CACHE_HOME

--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -307,6 +307,7 @@ test_train() {
 
     if [ "$TRAIN_LIBRARY" -eq 1 ]; then
         DATA=$(find "${DATA_HOME}"/instructlab/datasets -name 'messages_*' | head -n 1)
+
         # TODO Only cuda for now
         # the train profile specified in test_init overrides the majority of TRAIN_ARGS, including things like num_epochs. While it looks like much of those settings are being lost, they just have different values here.
         TRAIN_ARGS=("--device=cuda" "--model-path=${GRANITE_SAFETENSOR_REPO}" "--data-path=${DATA}" "--lora-quantize-dtype=nf4" "--4-bit-quant" "--effective-batch-size=4" "--is-padding-free=False")
@@ -317,8 +318,8 @@ test_train() {
         ilab model train "${TRAIN_ARGS[@]}"
     else
         # TODO Only cuda for now
-        TRAIN_ARGS+=("--legacy" "--device=cuda")
-        if [ "$LEGACYTRAIN" -eq 0 ]; then
+        TRAIN_ARGS+=("--legacy" "--device=cuda" "--data-path" "${DATA_HOME}/instructlab/datasets")
+        if [ "${FULLTRAIN}" -eq 0 ]; then
             TRAIN_ARGS+=("--4-bit-quant")
         fi
         if [ "${BACKEND}" != "vllm" ]; then

--- a/scripts/test-data/train-profile-a10.yaml
+++ b/scripts/test-data/train-profile-a10.yaml
@@ -6,8 +6,8 @@ additional_args:
   deepspeed_cpu_offload_optimizer_pin_memory: false
   deepspeed_cpu_oddload_optimizer_ratio: 1
 ckpt_output_dir: checkpoints
-data_output_dir: train-output
-data_path: ./taxonomy_data
+data_output_dir: /dev/shm  # use shared memory when processing the dataset
+data_path: /root/.local/share/instructlab/datasets  # todo: make this more dynamic / less fragile somehow 
 deepspeed_cpu_offload_optimizer: true
 effective_batch_size: 100
 lora_quantize_dtype: nf4

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -589,7 +589,7 @@ def train(
             shutil.rmtree(final_results_dir)
         final_results_dir.mkdir()
 
-        gguf_models_dir = Path(DEFAULTS.MODELS_DIR)
+        gguf_models_dir = Path(DEFAULTS.CHECKPOINTS_DIR)
         gguf_models_dir.mkdir(exist_ok=True)
         gguf_models_file = gguf_models_dir / "ggml-model-f16.gguf"
 

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -589,7 +589,7 @@ def train(
             shutil.rmtree(final_results_dir)
         final_results_dir.mkdir()
 
-        gguf_models_dir = Path(DEFAULTS.CHECKPOINTS_DIR)
+        gguf_models_dir = Path(DEFAULTS.MODELS_DIR)
         gguf_models_dir.mkdir(exist_ok=True)
         gguf_models_file = gguf_models_dir / "ggml-model-f16.gguf"
 


### PR DESCRIPTION
Updates the AWS E2E test to use the root user's datasets directory and uses /dev/shm for outputting the shared memory.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
