### PR TITLE
fix: match mergify automerge rules to actionlint rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,13 +13,13 @@ pull_request_rules:
     - label!=needs-rebase
     - check-success=DCO
 
-    # If files are changed in .github/, the actionlint check must pass
+    # If workflow configuration files in .github/ are changed, the actionlint check must pass
     - or:
       - and:
         # regex should match the one in .github/workflows/actionlint.yml
-        - files~=.github/.*$
+        - files~=\.github/(actions|workflows)/(.*\.ya?ml|actionlint\..*)
         - check-success=actionlint
-      - -files~=.github/.*$
+      - -files~=\.github/(actions|workflows)/(.*\.ya?ml|actionlint\..*)
 
     # e2e workflow
     - or:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,6 +7,7 @@ on:
       - "main"
       - "release-**"
     paths:
+      - '.github/actions/*.ya?ml'
       - '.github/workflows/*.ya?ml'
       - '.github/workflows/actionlint.*' # This workflow
   pull_request:
@@ -14,6 +15,7 @@ on:
       - "main"
       - "release-**"
     paths:
+      - '.github/actions/*.ya?ml'
       - '.github/workflows/*.ya?ml'
       - '.github/workflows/actionlint.*' # This workflow
 


### PR DESCRIPTION
This fixes an issue I hit in https://github.com/instructlab/instructlab/pull/1724 - previously, changing a non-workflow file in `.github` would block automerge as Mergify expected a result from `actionlint`, but `actionlint` only runs when a workflow file is changed. This PR aligns the regexs we are using in the respective configurations.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
