### PR TITLE
Add pyspelling to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ pre-commit>=3.0.4,<4.0
 pydeps>=1.12.12,<2
 pylint>=2.16.2,<4.0
 pylint-pydantic
+pyspelling>=2.0
 pytest
 pytest-asyncio
 pytest-cov[toml]


### PR DESCRIPTION
We currently make use of pyspelling to validate that the docs have valid spelling.
However, we don't have a direct way of ensuring pyspelling is installed without requiring
the developer to do it manually.
This PR fixes that by adding pyspelling to the requirements-dev.txt file.


<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
