### PR TITLE
Need to deepcopy config to handle compound objects

### DIFF
--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=ungrouped-imports
 # Standard
-from copy import copy
+from copy import deepcopy
 import enum
 import logging
 import multiprocessing
@@ -245,7 +245,7 @@ def launch_server(
     backend,
     enable_serving_output,
 ) -> tuple:
-    eval_serve = copy(ctx.obj.config.serve)
+    eval_serve = deepcopy(ctx.obj.config.serve)
     if backend is None:
         try:
             backend = eval_serve.backend = backends.get(pathlib.Path(model), backend)


### PR DESCRIPTION
The previous logic wasn't handling any of the objects inside the serving config.  So when it got to an object like vllm_args, it was modifying it directly.  And it would be reused across multiple server launches.


So the generate step of eval would start with these vllm args:
```
['--served-model-name', 'test_model']
```

and the evaluate step would start with these args:
```
['--served-model-name', 'test_model', '--tensor-parallel-size', '1', '--served-model-name', 'judge_model']
```

And then get erroneous messages like:
```
Using gpus from --gpus or evaluate config and ignoring --tensor-parallel-size configured in serve vllm_args
```
because --tensor-parallel-size  and the first --served-model-name was left in the args from before


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
