### PR TITLE
Fix model serve extra args

### DIFF
--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -33,7 +33,7 @@ signal.signal(signal.SIGTERM, signal_handler)
 
 
 @click.command(
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": False},
 )
 @click.option(
     "--model-path",


### PR DESCRIPTION
`ilab model serve` no longer accepts unknown extra arguments before the argument separator `--`. Click's documentation is a bit confusing. The combination of `ignore_unknown_options=True` and `allow_extra_args=True` allows for additional arguments after the separator and blocks unknown arguments before the separator.

**Issue resolved by this Pull Request:**
See: #1738

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
