### PR TITLE
feat: configurable log formatter

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -133,6 +133,7 @@ Shaders
 Shivchander
 Srivastava
 sshkey
+subcommand
 subdirectory
 Sudalairaj
 Taj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v0.19
 
+### Features
+
+* Add `log_format` to the `config.yaml` file to allow for customizing the log format.
+
 ### Breaking Changes
 
 * InstructLab now uses XDG-based directories on macOS, similar to Linux.

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -4,6 +4,7 @@
 from os import path
 from re import match
 from typing import Any, Optional, Union
+import logging
 import os
 import sys
 import textwrap
@@ -54,6 +55,11 @@ class _general(BaseModel):
     # additional fields with defaults
     log_level: StrictStr = Field(default="INFO", description="Log level for logging.")
     debug_level: int = Field(default=0, description="Debug level for logging.")
+    log_format: StrictStr = Field(
+        default="%(levelname)s %(asctime)s %(name)s:%(lineno)d: %(message)s",
+        description="Log format. https://docs.python.org/3/library/logging.html#logrecord-attributes",
+        validate_default=True,
+    )
 
     @field_validator("log_level")
     def validate_log_level(cls, v):
@@ -74,6 +80,19 @@ class _general(BaseModel):
                 f"'{v}' is not a valid log level name. valid levels: {valid_levels}"
             )
         return v.upper()
+
+    @field_validator("log_format")
+    @classmethod
+    def validate_log_format(cls, log_format):
+        try:
+            logging.PercentStyle(log_format).validate()
+            return log_format
+        except ValueError as e:
+            raise ValueError(
+                f"\nFailed to configure log format: {e}\n"
+                "Have you specified a valid log format?\n"
+                "Consider reading: https://docs.python.org/3/library/logging.html#logrecord-attributes"
+            ) from e
 
     @model_validator(mode="after")
     def after_debug_level(self):
@@ -1063,7 +1082,9 @@ def init(
         log.configure_logging(
             log_level=config_obj.general.log_level.upper(),
             debug_level=config_obj.general.debug_level,
+            fmt=config_obj.general.log_format,
         )
+
         # subtly get the additional args per cfg section
         # if any are missing, add in sane defaults
         train_additional = ctx.default_map["train"]["additional_args"]

--- a/src/instructlab/log.py
+++ b/src/instructlab/log.py
@@ -3,9 +3,8 @@
 # Standard
 import logging
 import os
+import pathlib
 import sys
-
-FORMAT = "%(levelname)s %(asctime)s %(name)s:%(lineno)d: %(message)s"
 
 
 class CustomFormatter(logging.Formatter):
@@ -37,15 +36,17 @@ class LoggerWriter:
         return False
 
 
-def stdout_stderr_to_logger(logger, log_file):
+def stdout_stderr_to_logger(
+    logger: logging.Logger, log_file: pathlib.Path | None, fmt: str
+):
     if log_file:
         # Use the existing log file if it exists and append to it
         mode = "a"
         # Create file handler
         file_handler = logging.FileHandler(log_file, mode, encoding="utf-8")
         logger.addHandler(file_handler)
-        # Create formatter and set it for both handlers
-        formatter = CustomFormatter(FORMAT)
+        # Create formatter and add it to the handler
+        formatter = CustomFormatter(fmt)
         file_handler.setFormatter(formatter)
 
     sys.stdout = LoggerWriter(logger.info)
@@ -56,7 +57,7 @@ def configure_logging(
     *,
     log_level: str,
     debug_level: int = 0,
-    fmt: str = FORMAT,
+    fmt: str,
 ) -> None:
     """Configure logging framework"""
     root = logging.getLogger()

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -126,7 +126,9 @@ def serve(
         raise click.exceptions.Exit(1)
 
     # Redirect server stdout and stderr to the logger
-    log.stdout_stderr_to_logger(logger, log_file)
+    log.stdout_stderr_to_logger(
+        logger=logger, log_file=log_file, fmt=ctx.obj.config.general.log_format
+    )
 
     if chat_template is None:
         chat_template = ctx.obj.config.serve.chat_template

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -217,6 +217,11 @@ serve:
             "--qlora-adapter-name-or-path=$HOME/qlora-adapter-name-or-path"
         )
 
+    def test_validate_log_format_invalid(self):
+        cfg = config.get_default_config()
+        with pytest.raises(ValueError):
+            cfg.general.validate_log_format("INVALID")
+
     def test_get_model_family(self):
         good_cases = {
             # two known families
@@ -320,11 +325,12 @@ general:
     ],
 )
 def test_logging(log_level, debug_level, root, instructlab, openai_httpx):
-    configure_logging(log_level=log_level, debug_level=debug_level)
+    configure_logging(log_level=log_level, debug_level=debug_level, fmt="%(message)s")
     assert logging.getLogger("root").getEffectiveLevel() == root
     assert logging.getLogger("instructlab").getEffectiveLevel() == instructlab
     assert logging.getLogger("openai").getEffectiveLevel() == openai_httpx
     assert logging.getLogger("httpx").getEffectiveLevel() == openai_httpx
+    assert logging.getLogger("root").handlers[0].formatter._fmt == "%(message)s"
 
 
 @patch.multiple(

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -83,6 +83,9 @@ general:
   # Debug level for logging.
   # Default: 0
   debug_level: 0
+  # Log format. https://docs.python.org/3/library/logging.html#logrecord-attributes
+  # Default: %(levelname)s %(asctime)s %(name)s:%(lineno)d: %(message)s
+  log_format: '%(levelname)s %(asctime)s %(name)s:%(lineno)d: %(message)s'
   # Log level for logging.
   # Default: INFO
   log_level: INFO


### PR DESCRIPTION
Using the new `log_format` option under the `general` section of the
config file, we can now configure an alternative log format that suits
our needs.The default line remains the same, however if you want to
remove timestamps from the log message you should remove `%(asctime)s`.

Note: the formating is validated, but make sure you read the module
[attributes](https://docs.python.org/3/library/logging.html#logrecord-attributes)
when building the format string.

Closes: https://github.com/instructlab/instructlab/issues/1720
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
