### PR TITLE
Automatically find the actively served model when testing chat

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x1.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x1.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel jq
 
       - name: Install ilab
         run: |

--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel jq
 
       - name: Install ilab
         run: |

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel jq
 
       - name: Install ilab
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Install Packages
         run: |
-          sudo apt-get install -y cuda-toolkit git cmake build-essential virtualenv
+          sudo apt-get install -y cuda-toolkit git cmake build-essential virtualenv jq
           nvidia-smi
           sudo ls -l /dev/nvidia*
 


### PR DESCRIPTION
In our current end-to-end workflow test, we rely on hard-coding the path to the model being served by `ilab serve`
in order to initiate a chat instance. This can lead to a lot of unnecessary maintenance and testing that must be done
by the maintainers to ensure that the provided path is always correct.

Frustratingly, ilab is usually only ever serving one model at a time, and will tell you the correct model path when you actually run the chat as an end-user.

As a workaround in lieu of ilab automatically knowing which model to chat with, this PR changes the test behavior to instead query the ilab model server to find the actively served model and just plugs that directly in as the correct model path.


- **chore: add jq to the packages that are installed during the e2e CI**
- **feat: updates the test_chat test to query the ilab server to get the actively served model by `ilab serve` and plug that into the chat args instead of manually hardcoding which model we're using on the system.**


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
