### PR TITLE
Add CUDA requirements file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
    provides its own template), 'tokenizer' (uses the model's tokenizer config), and an external
    file name.
 * Default log format changes to include the logger name in the logs.
+* Introduces CUDA-specific requirements in a new file `requirements-cuda.txt`. To install these
+  CUDA-enabled dependencies, simply run `pip install instructlab[cuda]`.
 
 ### Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
       python3 -m venv --upgrade-deps venv
       source venv/bin/activate
       pip cache remove llama_cpp_python
-      pip install instructlab \
+      pip install instructlab[cuda] \
          -C cmake.args="-DLLAMA_CUDA=on" \
          -C cmake.args="-DLLAMA_NATIVE=off"
    ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ package-dir = { "" = "src" }
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 optional-dependencies.hpu = { file = ["requirements-hpu.txt"] }
+optional-dependencies.cuda = { file = ["requirements-cuda.txt"] }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,0 +1,1 @@
+instructlab-training[cuda]>=0.2.0


### PR DESCRIPTION
This PR introduces a new file `requirements-cuda.txt` which contains all of the dependencies that cannot install unless CUDA is available.
Presently, the only package this contains is `instructlab-training` which has a dependency on flash-attn.

To make use of this, you can install the `ilab` CLI by doing `pip install instructlab[cuda]`.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
