### PR TITLE
revert: use GGUF file as default model

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -29,7 +29,7 @@ from instructlab.configuration import (
 @click.option(
     "--model-path",
     type=click.Path(),
-    default=lambda: DEFAULTS.DEFAULT_GGUF_MODEL,
+    default=lambda: DEFAULTS.DEFAULT_MODEL,
     show_default="The instructlab data files location per the user's system.",
     help="Path to the model used during generation.",
 )

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -61,7 +61,7 @@ class _InstructlabDefaults:
     API_KEY = "no_api_key"
 
     # TODO: Consolidate --model and --model-path into one --model-path flag since we always need a path now
-    MODEL_NAME = "merlinite-7b-lab-Q4_K_M"
+    MODEL_NAME_OLD = "merlinite-7b-lab-Q4_K_M"
     MERLINITE_GGUF_REPO = "instructlab/merlinite-7b-lab-GGUF"
     GGUF_MODEL_NAME = "merlinite-7b-lab-Q4_K_M.gguf"
     MODEL_REPO = "instructlab/granite-7b-lab"
@@ -111,10 +111,6 @@ class _InstructlabDefaults:
 
     @property
     def DEFAULT_MODEL(self) -> str:
-        return path.join(self.MODELS_DIR, self.MODEL_NAME)
-
-    @property
-    def DEFAULT_GGUF_MODEL(self) -> str:
         return path.join(self.MODELS_DIR, self.GGUF_MODEL_NAME)
 
     @property

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -694,7 +694,7 @@ def chat_cli(
     for m in model_list:
         model_ids.append(m.id)
     if not any(model == m for m in model_ids):
-        if model == cfg.DEFAULTS.MODEL_NAME:
+        if model == cfg.DEFAULTS.MODEL_NAME_OLD:
             logger.info(
                 f"Model {model} is not a full path. Try running ilab config init or edit your config to have the full model path for serving, chatting, and generation."
             )

--- a/src/instructlab/model/linux_test.py
+++ b/src/instructlab/model/linux_test.py
@@ -87,7 +87,7 @@ def linux_test(
     # linux_test
     logger.debug("test_file=%s", test_file)
     if not models:
-        models = [DEFAULTS.DEFAULT_GGUF_MODEL]
+        models = [DEFAULTS.DEFAULT_MODEL]
     if not create_params:
         create_params = {}
 

--- a/src/instructlab/model/test.py
+++ b/src/instructlab/model/test.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "-m",
     "--model",
-    default=lambda: DEFAULTS.DEFAULT_GGUF_MODEL,
+    default=lambda: DEFAULTS.DEFAULT_MODEL,
     show_default=True,
     help="Base model name to test on Linux",
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,7 @@ class TestConfig:
         package_name = "instructlab"
         internal_dirname = "internal"
         data_dir = platformdirs.user_data_dir(package_name)
-        default_model = f"{data_dir}/models/merlinite-7b-lab-Q4_K_M"
+        default_model = f"{data_dir}/models/merlinite-7b-lab-Q4_K_M.gguf"
 
         assert cfg.general is not None
         assert cfg.general.log_level == "INFO"
@@ -68,7 +68,7 @@ class TestConfig:
     def _assert_model_defaults(self, cfg):
         package_name = "instructlab"
         data_dir = platformdirs.user_data_dir(package_name)
-        default_model = f"{data_dir}/models/merlinite-7b-lab-Q4_K_M"
+        default_model = f"{data_dir}/models/merlinite-7b-lab-Q4_K_M.gguf"
 
         assert cfg.chat is not None
         assert cfg.chat.model == default_model


### PR DESCRIPTION
There is a mismatch between the default model path set during `ilab config init` and the one that the Pydantic (BaseModel) object holds. Currently, the default model path is set to
`merlinite-7b-lab-Q4_K_M.gguf` in the `config.yaml` when we run `ilab config init`. However, the config object holds the model path `merlinite-7b-lab-Q4_K_M`. This discrepancy can lead to confusion and potential errors when the model path is used in other parts of the codebase. To resolve this issue, we should ensure that the default model path set during `ilab config init` matches the one stored in the config object. This will help maintain consistency and prevent any unexpected behavior due to the mismatched model paths.

It's unclear why the default model was changed in
https://github.com/instructlab/instructlab/pull/1471. The commit message does not provide any explanation for this change.
What was found is that originally `merlinite-7b-lab-Q4_K_M` was pointing `DEFAULT_MODEL_OLD` and the `DEFAULT_MODEL` was
`models/merlinite-7b-lab-Q4_K_M.gguf`. `DEFAULT_MODEL_OLD` was only used once in a chat function.

This adjustment is causing issues across various components, such as:

* `ilab model download` downloads the GGUF model.  * `ilab model serve` points to the model directory.

As a result, unless we specify the model with `--model-path`, the serve command does not work.

Now, the default model points to "merlinite-7b-lab-Q4_K_M.gguf" in the config AND when running `ilab config init`.

Closes: https://github.com/instructlab/instructlab/issues/1736
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
