### PR TITLE
Update model storage locations to better reflect permanent vs ephemeral data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ### Features
 
 * `ilab` now uses dedicated directories for storing config and data files. On Linux, these
-  will generally be the XDG directories: `~/.config/instructlab` for config and
-  `~/.local/share/instructlab` for data. On MacOS, both the config and data is
-  located at `~/Library/Application Support/instructlab`.
+  will generally be the XDG directories: `~/.config/instructlab` for config,
+  `~/.local/share/instructlab` for data, and `~/.cache` for temporary files, including downloaded
+  models. On MacOS, both the config and data is located at
+  `~/Library/Application Support/instructlab`.
 * A new `ilab config show` command is introduced as a convenience feature, which prints out
    the contents of the ***actively loaded*** config, not just the contents of the config file.
 * `ilab system`: A new command group named `ilab system` has been added which will serve as the

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -95,7 +95,7 @@ class _InstructlabDefaults:
 
     @property
     def CHECKPOINTS_DIR(self) -> str:
-        return path.join(self._cache_home, STORAGE_DIR_NAMES.CHECKPOINTS)
+        return path.join(self._data_dir, STORAGE_DIR_NAMES.CHECKPOINTS)
 
     @property
     def DATASETS_DIR(self) -> str:
@@ -107,7 +107,7 @@ class _InstructlabDefaults:
 
     @property
     def MODELS_DIR(self) -> str:
-        return path.join(self._data_dir, STORAGE_DIR_NAMES.MODELS)
+        return path.join(self._cache_home, STORAGE_DIR_NAMES.MODELS)
 
     @property
     def DEFAULT_MODEL(self) -> str:

--- a/src/instructlab/model/test.py
+++ b/src/instructlab/model/test.py
@@ -150,7 +150,7 @@ def test(
             answers = linux_test(
                 ctx,
                 test_file,
-                models=[model, Path(DEFAULTS.MODELS_DIR) / "ggml-model-f16.gguf"],
+                models=[model, Path(DEFAULTS.CHECKPOINTS_DIR) / "ggml-model-f16.gguf"],
                 create_params={"max_tokens": 100},
             )
             for question, models in answers.items():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,8 @@ class TestConfig:
         package_name = "instructlab"
         internal_dirname = "internal"
         data_dir = platformdirs.user_data_dir(package_name)
-        default_model = f"{data_dir}/models/merlinite-7b-lab-Q4_K_M.gguf"
+        cache_dir = platformdirs.user_cache_dir(package_name)
+        default_model = f"{cache_dir}/models/merlinite-7b-lab-Q4_K_M.gguf"
 
         assert cfg.general is not None
         assert cfg.general.log_level == "INFO"
@@ -67,8 +68,8 @@ class TestConfig:
 
     def _assert_model_defaults(self, cfg):
         package_name = "instructlab"
-        data_dir = platformdirs.user_data_dir(package_name)
-        default_model = f"{data_dir}/models/merlinite-7b-lab-Q4_K_M.gguf"
+        cache_dir = platformdirs.user_cache_dir(package_name)
+        default_model = f"{cache_dir}/models/merlinite-7b-lab-Q4_K_M.gguf"
 
         assert cfg.chat is not None
         assert cfg.chat.model == default_model


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

After #1471 was merged, @tiran raised #1705 which highlighted that downloaded models are now stored in persistent storage (aka `XDG_DATA_HOME`), when they should really be stored in `XDG_CACHE_HOME`. Further investigation on my part revealed that trained models are actually being stored in cache as well - something we want to avoid, since there seems to be general agreement that trained models should be treated like persistent user data.

This PR updates those locations to be more consistent: downloaded models now go to the cache, and trained models now go to persistent storage.

CC: @RobotSail @tiran  

**Issue resolved by this Pull Request:**
Resolves #1705 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
