### PR TITLE
Updates legacy training to save in global checkpoints directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@
 * The `--num-instructions` option to `ilab data generate` has been deprecated.
   See `--sdg-scale-factor` for an updated option providing similar
   functionality.
+* `ilab model train --legacy`: Trained GGUF models are now saved in the global user checkpoints directory.
+  Previously, checkpoints were always saved into a directory local to where the user called it from.
 
 ## v0.17
 

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -462,7 +462,7 @@ def train(
             shutil.rmtree(final_results_dir)
         final_results_dir.mkdir()
 
-        gguf_models_dir = Path("./models")
+        gguf_models_dir = Path(DEFAULTS.CHECKPOINTS_DIR)
         gguf_models_dir.mkdir(exist_ok=True)
         gguf_models_file = gguf_models_dir / "ggml-model-f16.gguf"
 


### PR DESCRIPTION
Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

Currently, when we train models we always save in a directory relative to the caller called './models'.
This PR updates the legacy training code to save checkpoints into the global checkpoints directory.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
