### PR TITLE
utils: Drop reading of taxonomy data

### DIFF
--- a/src/instructlab/taxonomy/diff.py
+++ b/src/instructlab/taxonomy/diff.py
@@ -48,7 +48,7 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
     """
     # pylint: disable=import-outside-toplevel
     # Local
-    from ..utils import get_taxonomy_diff, read_taxonomy
+    from ..utils import get_taxonomy_diff, validate_taxonomy
 
     if not taxonomy_base:
         taxonomy_base = ctx.obj.config.generate.taxonomy_base
@@ -71,7 +71,7 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
             for f in updated_taxonomy_files:
                 click.echo(f)
     try:
-        read_taxonomy(None, taxonomy_path, taxonomy_base, yaml_rules)
+        validate_taxonomy(None, taxonomy_path, taxonomy_base, yaml_rules)
     except (SystemExit, yaml.YAMLError) as exc:
         if not quiet:
             click.secho(

--- a/src/instructlab/taxonomy/diff.py
+++ b/src/instructlab/taxonomy/diff.py
@@ -48,7 +48,7 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
     """
     # pylint: disable=import-outside-toplevel
     # Local
-    from ..utils import get_taxonomy_diff, validate_taxonomy
+    from ..utils import TaxonomyReadingException, get_taxonomy_diff, validate_taxonomy
 
     if not taxonomy_base:
         taxonomy_base = ctx.obj.config.generate.taxonomy_base
@@ -62,7 +62,7 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
         else:  # taxonomy_path is dir
             try:
                 updated_taxonomy_files = get_taxonomy_diff(taxonomy_path, taxonomy_base)
-            except (SystemExit, GitError) as exc:
+            except (TaxonomyReadingException, GitError) as exc:
                 click.secho(
                     f"Reading taxonomy failed with the following error: {exc}",
                     fg="red",
@@ -72,7 +72,7 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
                 click.echo(f)
     try:
         validate_taxonomy(None, taxonomy_path, taxonomy_base, yaml_rules)
-    except (SystemExit, yaml.YAMLError) as exc:
+    except (TaxonomyReadingException, yaml.YAMLError) as exc:
         if not quiet:
             click.secho(
                 f"Reading taxonomy failed with the following error: {exc}",

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -152,7 +152,7 @@ def get_taxonomy_diff(repo="taxonomy", base="origin/main"):
         try:
             head_commit = repo.commit(base)
         except gitdb.exc.BadName as e:
-            raise SystemExit(
+            raise TaxonomyReadingException(
                 yaml.YAMLError(
                     f'Couldn\'t find the taxonomy git ref "{base}" from the current HEAD'
                 )
@@ -169,7 +169,7 @@ def get_taxonomy_diff(repo="taxonomy", base="origin/main"):
         try:
             current_commit = current_commit.parents[0]
         except IndexError as e:
-            raise SystemExit(
+            raise TaxonomyReadingException(
                 yaml.YAMLError(
                     f'Couldn\'t find the taxonomy base branch "{base}" from the current HEAD'
                 )
@@ -226,7 +226,7 @@ def get_documents(
 
             if file_contents:
                 return file_contents
-            raise SystemExit("Couldn't find knowledge documents")
+            raise TaxonomyReadingException("Couldn't find knowledge documents")
         except (OSError, exc.GitCommandError, FileNotFoundError) as e:
             raise e
 
@@ -460,7 +460,9 @@ def validate_taxonomy(_logger, taxonomy, taxonomy_base, yaml_rules):
                 f"{warnings} warnings (see above) due to taxonomy file not (fully) usable."
             )
         if errors:
-            raise SystemExit(yaml.YAMLError("Taxonomy file with errors! Exiting."))
+            raise TaxonomyReadingException(
+                yaml.YAMLError("Taxonomy file with errors! Exiting.")
+            )
     else:  # taxonomy is dir
         # Gather the new or changed YAMLs using git diff
         updated_taxonomy_files = get_taxonomy_diff(taxonomy, taxonomy_base)
@@ -480,7 +482,7 @@ def validate_taxonomy(_logger, taxonomy, taxonomy_base, yaml_rules):
                 f"{total_warnings} warnings (see above) due to taxonomy files that were not (fully) usable."
             )
         if total_errors:
-            raise SystemExit(
+            raise TaxonomyReadingException(
                 yaml.YAMLError(f"{total_errors} taxonomy files with errors! Exiting.")
             )
 

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -191,18 +191,18 @@ class SourceDict(TypedDict):
     patterns: List[str]
 
 
-def get_documents(
+def _validate_documents(
     source: SourceDict,
     skip_checkout: bool = False,
-) -> List[str]:
+) -> None:
     """
-    Retrieve the content of files from a Git repository.
+    Validate that we can retrieve the content of files from a Git repository.
 
     Args:
         source (dict): Source info containing repository URL, commit hash, and list of file patterns.
 
     Returns:
-         List[str]: List of document contents.
+         None
     """ ""
     repo_url = source.get("repo", "")
     commit_hash = source.get("commit", "")
@@ -215,18 +215,19 @@ def get_documents(
                 temp_dir=temp_dir,
                 skip_checkout=skip_checkout,
             )
-            file_contents = []
 
             logger.debug("Processing files...")
+            opened_files = False
             for pattern in file_patterns:
                 for file_path in glob.glob(os.path.join(repo.working_dir, pattern)):
                     if os.path.isfile(file_path) and file_path.endswith(".md"):
-                        with open(file_path, "r", encoding="utf-8") as file:
-                            file_contents.append(file.read())
+                        with open(file_path, "r", encoding="utf-8"):
+                            # Success! we could open the file.
+                            # We don't actually care about the contents, though.
+                            opened_files = True
 
-            if file_contents:
-                return file_contents
-            raise TaxonomyReadingException("Couldn't find knowledge documents")
+            if not opened_files:
+                raise TaxonomyReadingException("Couldn't find knowledge documents")
         except (OSError, exc.GitCommandError, FileNotFoundError) as e:
             raise e
 
@@ -382,7 +383,7 @@ def validate_taxonomy_file(file_path: str, yaml_rules: Optional[str] = None):
         if not contents:
             logger.warning(f"Skipping {file_path_p} because it is empty!")
             warnings += 1
-            return None, warnings, errors
+            return warnings, errors
         if not isinstance(contents, Mapping):
             logger.error(
                 f"{file_path_p} is not valid. The top-level element is not an object with key-value pairs."
@@ -444,6 +445,15 @@ def validate_taxonomy_file(file_path: str, yaml_rules: Optional[str] = None):
             errors += validation_errors
             return warnings, errors
 
+        # If the taxonomy file includes a document reference, validate that
+        # we can retrieve the content of the document
+        if "document" in contents:
+            try:
+                _validate_documents(contents["document"])
+            except Exception as e:
+                errors += 1
+                logger.error(f"Failed to load document content for {file_path_p}: {e}")
+
     except Exception as e:
         errors += 1
         raise TaxonomyReadingException(f"Exception {e} raised in {file_path_p}") from e
@@ -460,9 +470,7 @@ def validate_taxonomy(_logger, taxonomy, taxonomy_base, yaml_rules):
                 f"{warnings} warnings (see above) due to taxonomy file not (fully) usable."
             )
         if errors:
-            raise TaxonomyReadingException(
-                yaml.YAMLError("Taxonomy file with errors! Exiting.")
-            )
+            raise TaxonomyReadingException(yaml.YAMLError("Taxonomy file with errors!"))
     else:  # taxonomy is dir
         # Gather the new or changed YAMLs using git diff
         updated_taxonomy_files = get_taxonomy_diff(taxonomy, taxonomy_base)
@@ -483,7 +491,7 @@ def validate_taxonomy(_logger, taxonomy, taxonomy_base, yaml_rules):
             )
         if total_errors:
             raise TaxonomyReadingException(
-                yaml.YAMLError(f"{total_errors} taxonomy files with errors! Exiting.")
+                yaml.YAMLError(f"{total_errors} taxonomy files with errors!")
             )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,16 +19,15 @@ class TestUtils:
         "instructlab.utils.git_clone_checkout",
         return_value=Mock(spec=git.Repo, working_dir="tests/testdata/temp_repo"),
     )
-    def test_get_document(self, git_clone_checkout):
+    def test_validate_documents(self, git_clone_checkout):
         with open(
             "tests/testdata/knowledge_valid.yaml", "r", encoding="utf-8"
         ) as qnafile:
-            documents = utils.get_documents(
+            utils._validate_documents(
                 source=yaml.safe_load(qnafile).get("document"),
                 skip_checkout=True,
             )
             git_clone_checkout.assert_called_once()
-            assert len(documents) == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Nothing uses the parsed taxonomy data that was returned by this code.
There is a proposal to change the taxonomy schema. Instead of fixing
this copy of this code, make it stop reading the contents aside from
doing automated validation.

Rename these functions to `validate_taxonomy` instead of
`read_taxonomy` since we only care about the validation part and not
returning any data from them.

If we look at changing this to use a new API, this helps clarify what
functionality we actually care about (validation, not the data).

Related to https://github.com/instructlab/sdg/issues/160

Signed-off-by: Russell Bryant <rbryant@redhat.com>
