### PR TITLE
fix: model server detection

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x1.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x1.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel jq
+          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
 
       - name: Install ilab
         run: |

--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel jq
+          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
 
       - name: Install ilab
         run: |

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel jq
+          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
 
       - name: Install ilab
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Install Packages
         run: |
-          sudo apt-get install -y cuda-toolkit git cmake build-essential virtualenv jq
+          sudo apt-get install -y cuda-toolkit git cmake build-essential virtualenv
           nvidia-smi
           sudo ls -l /dev/nvidia*
 

--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -36,14 +36,6 @@ export CONFIG_HOME
 export DATA_HOME
 export CONFIG_HOME
 
-# ensure we have all the commands before proceeding
-for cmd in ilab jq; do
-    if ! type -p $cmd; then
-        echo "Error: ${cmd} is not installed"
-        exit 1
-    fi
-done
-
 
 
 ########################################
@@ -71,28 +63,8 @@ function init_e2e_tests() {
     STATE_HOME=$(python -c 'import platformdirs; print(platformdirs.user_state_dir())')
     # ensure that our mock e2e dirs exist
     for dir in "${CONFIG_HOME}" "${DATA_HOME}" "${STATE_HOME}"; do
-        mkdir -p "${dir}"
+    	mkdir -p "${dir}"
     done
-}
-
-########################################
-# Returns the actively served model from
-# the InstructLab model server.
-# 
-# This function assumes that models is running
-# and is serving a model.
-# 
-# Globals:
-#   None
-# Arguments:
-#   None
-# Outputs:
-#   String - the model being served by ilab
-########################################
-function get_served_model_from_server() {
-    local model
-    model=$(curl --silent http://127.0.0.1:8000/v1/models | jq -r '.data[0].id')
-    printf '%s' "${model}"
 }
 
 
@@ -198,15 +170,13 @@ test_serve() {
 }
 
 test_chat() {
-    local served_model
     task Chat with the model
-
-    served_model=$(get_served_model_from_server)
-    CHAT_ARGS=('-m' "${served_model}")
-    if [[ "${MIXTRAL}" -eq 1 ]]; then
-        CHAT_ARGS+=('--model-family' 'mixtral')
+    CHAT_ARGS=()
+    if [ "$GRANITE" -eq 1 ]; then
+        CHAT_ARGS+=("-m" "${DATA_HOME}/instructlab/models/granite-7b-lab-Q4_K_M.gguf")
+    elif [ "$MIXTRAL" -eq 1 ]; then
+        CHAT_ARGS+=("-m" "${DATA_HOME}/instructlab/models/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf" "--model-family" "mixtral")
     fi
-
     printf 'Say "Hello" and nothing else\n' | ilab model chat -qq "${CHAT_ARGS[@]}"
 }
 

--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -172,10 +172,8 @@ test_serve() {
 test_chat() {
     task Chat with the model
     CHAT_ARGS=()
-    if [ "$GRANITE" -eq 1 ]; then
-        CHAT_ARGS+=("-m" "${DATA_HOME}/instructlab/models/granite-7b-lab-Q4_K_M.gguf")
-    elif [ "$MIXTRAL" -eq 1 ]; then
-        CHAT_ARGS+=("-m" "${DATA_HOME}/instructlab/models/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf" "--model-family" "mixtral")
+    if [ "$MIXTRAL" -eq 1 ]; then
+        CHAT_ARGS+=("--model-family" "mixtral")
     fi
     printf 'Say "Hello" and nothing else\n' | ilab model chat -qq "${CHAT_ARGS[@]}"
 }

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -206,10 +206,16 @@ def chat(
         # from the config is the same as the default value, then the user didn't provide a value
         # we then compare it with the value from the server to see if it's different
         if (
-            model == cfg.DEFAULTS.DEFAULT_MODEL
-            and ctx.obj.config.chat.model == cfg.DEFAULTS.DEFAULT_MODEL
+            # We need to get the base name of the model because the model path is a full path and
+            # the once from the config is just the model name
+            os.path.basename(model) == cfg.DEFAULTS.GGUF_MODEL_NAME
+            and os.path.basename(ctx.obj.config.chat.model)
+            == cfg.DEFAULTS.GGUF_MODEL_NAME
             and api_base == ctx.obj.config.serve.api_base()
         ):
+            logger.debug(
+                "No model was provided by the user as a CLI argument or in the config, will use the model from the server"
+            )
             try:
                 models = ilabclient.list_models(
                     api_base=api_base,
@@ -227,7 +233,7 @@ def chat(
                     and server_model != ctx.obj.config.chat.model
                     else model
                 )
-
+                logger.debug(f"Using model from server {model}")
             except ilabclient.ClientException as exc:
                 click.secho(
                     f"Failed to list models from {api_base}. Please check the API key and endpoint.",


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->


The detection was comparing a string with a fullpath with a basename. So
the model name was never matching and the condition was not entered.

Now when `ilab model chat` is called and a server is already running
with `ilab model serve`, the chat will fetch the model from the server
and present it in the chat header.

Signed-off-by: Sébastien Han <seb@redhat.com>

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
