### PR TITLE
requirements: Set a cap on instructlab-sdg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ httpx>=0.25.0
 instructlab-eval>=0.0.9
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.2.0
-instructlab-sdg>=0.1.2
+instructlab-sdg>=0.1.2,<0.2.0
 instructlab-training>=0.0.5
 jsonschema>=4.21.1
 llama_cpp_python[server]==0.2.79


### PR DESCRIPTION
instructlab-sdg 0.2.0 will include changes that are not backwards
compatible. Temporarily cap our dependency here. This cap will be
lifted and replaced with `>=0.2.0` in a future change.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
