### PR TITLE
chore: warn when vllm is used with unsupported arguments

### DIFF
--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -155,6 +155,9 @@ def serve(
             num_threads=num_threads,
         )
     elif backend == backends.VLLM:
+        # Warn if unsupported backend parameters are passed
+        warn_for_unsuported_backend_param(ctx)
+
         # Instantiate the vllm server
         if ctx.args:
             # extra click arguments after "--"
@@ -191,3 +194,13 @@ def serve(
     finally:
         backend_instance.shutdown()
         raise click.exceptions.Exit(0)
+
+
+def warn_for_unsuported_backend_param(
+    ctx: click.Context,
+):
+    for param in ["gpu_layers", "num_threads", "max_ctx_size"]:
+        if ctx.get_parameter_source(param) == click.core.ParameterSource.COMMANDLINE:
+            logger.warning(
+                f"Option '--{param.replace('_','-')}' not supported by the backend."
+            )


### PR DESCRIPTION
The serve cli has 3 options that won't do anything when the vllm backend is used, namely:

* gpu_layers
* num_threads
* max_ctx_size

If the user passes:

```
ilab model serve --backend --max-ctx-size 2048
```

A warning will be printed indicating the option is not supported:

```
WARNING 2024-07-18 10:38:21,649 instructlab.model.serve:203: Option
--max-ctx-size not supported by the backend.
```

Closes: https://github.com/instructlab/instructlab/issues/1773
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
