### PR TITLE
test: allow func test to use a specific temporary directory

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,9 @@ basepython = {[testenv:py3]basepython}
 
 [testenv:py3-functional]
 basepython = {[testenv:py3]basepython}
+passenv =
+    {[testenv]passenv}
+    TEST_DIR
 
 # format, check, and linting targets don't build and install the project to
 # speed up testing.


### PR DESCRIPTION
Since #1471, the directory structure has changed and the functional test was altered to setup the new directory and create a temporary directory for the test data. While this makes sense when running on a fresh new runner, this makes the local test quite annoying since:

a new temp is created
a model is downloaded in this directory

Now, for local users, the script can be run like this:

```
SKIP_TEST_DIR_CLEANUP=1 TEST_DIR=/tmp/foo ./scripts/functional-tests.sh
```

This assumes you control your test directory and its cleanup.

Closes: https://github.com/instructlab/instructlab/issues/1774
Signed-off-by: Sébastien Han <seb@redhat.com>


<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
