### PR TITLE
feat: add serve config for teacher model in `ilab data generate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
 * The `instructlab` package now uses optional dependencies for each supported hardware `cpu`,
   `cuda`, `hpu`, `mps`, and `rocm`. To install InstructLab for e.g. NVIDIA CUDA, use
   `pip install instructlab[cuda]`.
+* Add a `--enable-serving-output` flag for `ilab data generate`. This flag determines whether vLLM
+  will have its output suppressed when it serves the teacher model in the background.
+* The `generate` section of the config now has a `teacher` section. This section configures the
+  teacher model when it is automatically served in the background. This new section has the same
+  values as the `serve` section of the config.
 
 ### Breaking Changes
 

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -308,7 +308,7 @@ class _generate(BaseModel):
     chunk_word_count: PositiveInt = DEFAULTS.CHUNK_WORD_COUNT
     # DEPRECATED: see sdg_scale_factor instead
     # Left in place so that we can still detect and give a warning if its
-    # specified in an old configuraiton file.
+    # specified in an old configuration file.
     num_instructions: Optional[int] = Field(
         default=-1, deprecated="see 'sdg_scale_factor' instead", exclude=True
     )

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -265,13 +265,20 @@ class _serve(BaseModel):
     model_config = ConfigDict(extra="ignore", protected_namespaces=())
 
     # vllm configuration
-    vllm: _serve_vllm
+    vllm: _serve_vllm = _serve_vllm(
+        llm_family="",
+        vllm_args=[],
+    )
 
     # llama-cpp configuration
-    llama_cpp: _serve_llama_cpp
+    llama_cpp: _serve_llama_cpp = _serve_llama_cpp(
+        gpu_layers=-1,
+        max_ctx_size=4096,
+        llm_family="",
+    )
 
     # required fields
-    model_path: StrictStr
+    model_path: StrictStr = Field(default_factory=lambda: DEFAULTS.DEFAULT_MODEL)
     # additional fields with defaults
     host_port: StrictStr = "127.0.0.1:8000"
     chat_template: Optional[str] = None
@@ -296,7 +303,7 @@ class _generate(BaseModel):
     taxonomy_base: StrictStr
 
     # additional fields with defaults
-    teacher: _serve
+    teacher: _serve = Field(default_factory=_serve)
     num_cpus: PositiveInt = DEFAULTS.NUM_CPUS
     chunk_word_count: PositiveInt = DEFAULTS.CHUNK_WORD_COUNT
     # DEPRECATED: see sdg_scale_factor instead
@@ -406,18 +413,6 @@ def get_default_config() -> Config:
             model=DEFAULTS.DEFAULT_MODEL,
             taxonomy_path=DEFAULTS.TAXONOMY_DIR,
             taxonomy_base=DEFAULTS.TAXONOMY_BASE,
-            teacher=_serve(
-                model_path=DEFAULTS.DEFAULT_MODEL,
-                llama_cpp=_serve_llama_cpp(
-                    gpu_layers=-1,
-                    max_ctx_size=4096,
-                    llm_family="",
-                ),
-                vllm=_serve_vllm(
-                    llm_family="",
-                    vllm_args=[],
-                ),
-            ),
         ),
         serve=_serve(
             model_path=DEFAULTS.DEFAULT_MODEL,

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -144,6 +144,11 @@ logger = logging.getLogger(__name__)
     hidden=True,
     help="Data generation pipeline to use. Available: simple, full, or a valid path to a directory of pipeline worlfow YAML files. Note that 'full' requires a larger teacher model, Mixtral-8x7b.",
 )
+@click.option(
+    "--enable-serving-output",
+    is_flag=True,
+    help="Print serving engine logs.",
+)
 @click.pass_context
 @clickext.display_params
 def generate(
@@ -168,6 +173,7 @@ def generate(
     tls_client_passwd,
     model_family,
     pipeline,
+    enable_serving_output,
 ):
     """Generates synthetic data to enhance your example data"""
     # pylint: disable=import-outside-toplevel
@@ -197,8 +203,10 @@ def generate(
         backend_instance = backends.select_backend(ctx.obj.config.generate.teacher)
 
         try:
-            # Run the llama server
-            api_base = backend_instance.run_detached(http_client(ctx.params))
+            # Run the backend server
+            api_base = backend_instance.run_detached(
+                http_client(ctx.params), background=not enable_serving_output
+            )
         except Exception as exc:
             click.secho(f"Failed to start server: {exc}", fg="red")
             raise click.exceptions.Exit(1)

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -194,7 +194,7 @@ def generate(
         from instructlab.model.backends import backends
 
         ctx.obj.config.serve.llama_cpp.llm_family = model_family
-        backend_instance = backends.select_backend(ctx.obj.config.serve)
+        backend_instance = backends.select_backend(ctx.obj.config.generate.teacher)
 
         try:
             # Run the llama server

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,7 +42,6 @@ class TestConfig:
         assert cfg.general.log_level == "INFO"
 
         assert cfg.generate is not None
-        assert cfg.generate.teacher is not None
         assert cfg.generate.teacher.model_path == default_model
         assert cfg.generate.teacher.llama_cpp is not None
         assert cfg.generate.teacher.llama_cpp.gpu_layers == -1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,17 @@ class TestConfig:
         assert cfg.general.log_level == "INFO"
 
         assert cfg.generate is not None
+        assert cfg.generate.teacher is not None
+        assert cfg.generate.teacher.model_path == default_model
+        assert cfg.generate.teacher.llama_cpp is not None
+        assert cfg.generate.teacher.llama_cpp.gpu_layers == -1
+        assert cfg.generate.teacher.llama_cpp.max_ctx_size == 4096
+        assert cfg.generate.teacher.llama_cpp.llm_family == ""
+        assert cfg.generate.teacher.vllm is not None
+        assert cfg.generate.teacher.vllm.vllm_args == []
+        assert cfg.generate.teacher.host_port == "127.0.0.1:8000"
+        assert cfg.generate.teacher.backend is None
+        assert cfg.generate.teacher.chat_template is None
         assert cfg.generate.model == default_model
         assert cfg.generate.taxonomy_path == f"{data_dir}/taxonomy"
         assert cfg.generate.taxonomy_base == "origin/main"
@@ -121,6 +132,16 @@ class TestConfig:
   log_level: INFO
 generate:
   model: models/merlinite-7b-lab-Q4_K_M.gguf
+  teacher:
+    model_path: models/granite-7b-lab-Q4_K_M.gguf
+    chat_template: tokenizer
+    llama_cpp:
+      gpu_layers: 1
+      max_ctx_size: 2048
+      llm_family: ''
+    vllm:
+      vllm_args:
+         - --tensor-parallel-size=8
 """
             )
         with pytest.raises(
@@ -187,6 +208,16 @@ generate:
   model: models/granite-7b-lab-Q4_K_M.gguf
   taxonomy_base: upstream/main
   taxonomy_path: mytaxonomy
+  teacher:
+    model_path: models/granite-7b-lab-Q4_K_M.gguf
+    chat_template: tokenizer
+    llama_cpp:
+      gpu_layers: 1
+      max_ctx_size: 2048
+      llm_family: ''
+    vllm:
+      vllm_args:
+         - --tensor-parallel-size=8
 serve:
   model_path: models/granite-7b-lab-Q4_K_M.gguf
   chat_template: tokenizer


### PR DESCRIPTION
Currently `ilab data generate` uses the configuration from the `serve` section of configuration file to serve the teacher model in the background. 

In the case where a user is using a specific model only as the teacher model, the user would have to edit the `serve` section of the config with the teacher model's settings.

Since the teacher model and it's configuration is static, and the serve section is dynamic, the teacher model and it's configuration should live in the `generate` section of the configuration. 

Giving the teacher model it's own configuration section also prevents the user from accidentally serving the teacher model, if they have not changed the `serve` section.

This PR is meant to be a starting point. Further work should evolve the configuration of the teacher model in `ilab data generate` to be similar to how the `ilab model evaluate` command configures the judge model for MT-Bench.

This PR also includes a commit that adds the `--enable-serving-output` flag to `ilab data generate`. This flag serves the same purpose as it does in `ilab model evaluate`.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
