### PR TITLE
tests: clarify the presence of some variables 

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -67,6 +67,9 @@ function init_test_script() {
     HOME="${TEST_DIR}"  # to ensure platformdirs uses the test directory for the duration of this script
     printf 'changing home directory to "%s", was: "%s"\n' "${HOME}" "${prev_home}"
 
+    # DO NOT REMOVE THE VARIABLE ASSIGNMENTS BELOW
+    # They might seem redundant given that `mkdir -p`` is called later, but they are necessary to
+    # ensure the directories are created by ilab CLI
     # get the directories from the platformdirs library
     CONFIG_DIR=$(python -c "import platformdirs; print(platformdirs.user_config_dir())")
     DATA_DIR=$(python -c "import platformdirs; print(platformdirs.user_data_dir())")


### PR DESCRIPTION
At first glance, these variables might seem unnecessary given that the
same Python call is done later, and `mkdir -p` will create everything.
The idea is only to create the base directory and let `ilab` create the
subsequent folders.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

Should go **AFTER** https://github.com/instructlab/instructlab/pull/1762