### PR TITLE
Auto documentation of Config Pydantic schema

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,7 +5,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -j auto
+SPHINXOPTS    ?= -j auto --keep-going --fail-on-warning -n
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,10 +16,13 @@ author = "InstructLab Authors"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
+    "enum_tools.autoenum",
     "myst_parser",
+    "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
     "sphinx_click",
+    "sphinxcontrib.autodoc_pydantic",
 ]
 
 templates_path = ["templates"]
@@ -61,9 +64,30 @@ nitpick_ignore = [
     ("py:class", "ConfigDict"),
     ("py:class", "FieldInfo"),
 ]
+nitpick_ignore_regex = [
+    # instructlab.configuration
+    ("py:class", "annotated_types\..*"),
+    ("py:class", "pydantic\.types\..*"),
+    ("py:obj", "typing\..*"),
+    ("py:obj", "instructlab\.configuration\..*"),
+]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "furo"
 html_static_path = ["static"]
+
+# autodoc settings
+# add_module_names = False
+
+# https://autodoc-pydantic.readthedocs.io/
+# settings
+autodoc_pydantic_model_show_json = False
+autodoc_pydantic_settings_show_json = False
+autodoc_pydantic_model_show_config_summary = False
+# fields
+autodoc_pydantic_model_show_field_summary = True
+# validators
+autodoc_pydantic_model_show_validator_summary = False
+autodoc_pydantic_model_show_validator_members = False

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,47 @@
+ilab configuration
+==================
+
+.. module:: instructlab.configuration
+
+InstructLab's configuration is read from ``config.yaml`` file. The
+configuration is handled avalided by a `Pydantic <https://docs.pydantic.dev/>`_
+schema.
+
+.. autopydantic_model:: Config
+   :model-show-json: True
+
+General
+-------
+
+.. autopydantic_model:: _general
+
+model chat
+----------
+
+.. autopydantic_model:: _chat
+
+model evaluate
+--------------
+
+.. autopydantic_model:: _evaluate
+.. autopydantic_model:: _mmlu
+.. autopydantic_model:: _mmlubranch
+.. autopydantic_model:: _mtbench
+.. autopydantic_model:: _mtbenchbranch
+
+model generate
+--------------
+
+.. autopydantic_model:: _generate
+
+model serve
+-----------
+
+.. autopydantic_model:: _serve
+.. autopydantic_model:: _serve_llama_cpp
+.. autopydantic_model:: _serve_vllm
+
+model train
+-----------
+
+.. autopydantic_model:: _train

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ Welcome to InstructLab's documentation!
    :caption: Contents:
 
    ilab.rst
+   config.rst
    gpu-acceleration.md
    amd-rocm.md
    habana-gaudi.md

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,5 @@ sphinx
 myst-parser
 furo
 sphinx-click
+autodoc-pydantic
+enum-tools[sphinx]

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -190,7 +190,7 @@ class _general(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     # additional fields with defaults
-    log_level: StrictStr = "INFO"
+    log_level: str = "INFO"
     debug_level: int = 0
 
     @field_validator("log_level")
@@ -235,9 +235,10 @@ class _chat(BaseModel):
     visible_overflow: bool = True
     context: str = "default"
     session: typing.Optional[str] = None
-    logs_dir: str = Field(
-        default_factory=lambda: DEFAULTS.CHATLOGS_DIR
-    )  # use a lambda to avoid caching
+
+    logs_dir: str = Field(default_factory=lambda: DEFAULTS.CHATLOGS_DIR)
+    "Path to log directory for chat logs"
+
     greedy_mode: bool = False
     max_tokens: typing.Optional[int] = None
 
@@ -247,13 +248,21 @@ class _serve_vllm(BaseModel):
 
     llm_family: str = ""
     # arguments to pass into vllm process
-    vllm_args: list[str] | None = None
+    vllm_args: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Additional command line arguments for vLLM, see "
+            "`command line arguments for server <https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#command-line-arguments-for-the-server>`_"
+        ),
+    )
 
 
 class _serve_llama_cpp(BaseModel):
     """Class describing configuration of llama-cpp serving backend."""
 
     gpu_layers: int = -1
+    "Number of layers to offload to GPU, -1: offload all layers."
+
     max_ctx_size: PositiveInt = 4096
     llm_family: str = ""
 
@@ -416,11 +425,7 @@ def get_default_config() -> Config:
         ),
         serve=_serve(
             model_path=DEFAULTS.DEFAULT_MODEL,
-            llama_cpp=_serve_llama_cpp(
-                gpu_layers=-1,
-                max_ctx_size=4096,
-                llm_family="",
-            ),
+            llama_cpp=_serve_llama_cpp(),
             vllm=_serve_vllm(
                 llm_family="",
                 vllm_args=[],


### PR DESCRIPTION
Add autodoc-pydantic to automatically create documentation from our configuration schema.

See: https://autodoc-pydantic.readthedocs.io

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
