### PR TITLE
Adds pip install . line into functional-tests.sh

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -8,6 +8,8 @@ export SCRIPTDIR=$(dirname "$0")
 # build a prompt string that includes the time, source file, line number, and function name
 export PS4='+$(date +"%Y-%m-%d %T") ${BASH_VERSION}:${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
+pip install .
+
 export TEST_DIR
 export PACKAGE_NAME='instructlab'  # name we use of the top-level package directories for CLI data
 


### PR DESCRIPTION
PR #1471 accidentally removed a line in `scripts/functional-tests.sh` which ran `pip install .` everytime at the beginning of the file. This PR reverts that change.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

