### PR TITLE
add -T option to e2e

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -130,8 +130,7 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           . venv/bin/activate
-          # TODO Add training once training with the training lib is supported in e2e
-          SKIP_TRAIN=1 ./scripts/basic-workflow-tests.sh -mFM
+          ./scripts/basic-workflow-tests.sh -mFMT
 
       - name: Add comment to PR if the workflow failed
         if: failure() && steps.check_pr.outputs.is_pr == 'true'

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -40,6 +40,7 @@ the E2E job configuration files found
 | `F` | Run "fullsize" SDG |
 | `g` | Run with Granite model |
 | `v` | Run with vLLM for serving |
+| `T` | Use the 'full' training library rather than legacy training |
 
 ### Trigger via GitHub Web UI
 


### PR DESCRIPTION
-T enables the e2e to be run with JUST the full training library. When used the --legacy tests will be skipped.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
