### PR TITLE
only create persistent storage files/dirs when needed

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -539,7 +539,8 @@ def ensure_storage_directories_exist():
     ]
 
     for dirpath in dirs_to_make:
-        os.makedirs(dirpath, exist_ok=True)
+        if not os.path.exists(dirpath):
+            os.makedirs(dirpath, exist_ok=True)
 
     additional_args_and_defaults = {
         "learning_rate": 2e-5,
@@ -557,8 +558,11 @@ def ensure_storage_directories_exist():
     }
 
     # create exper_args file for users to see/edit
-    with open(DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_FILE, "w", encoding="utf-8") as outfile:
-        yaml.dump(additional_args_and_defaults, outfile)
+    if not os.path.isfile(DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_FILE):
+        with open(
+            DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_FILE, "w", encoding="utf-8"
+        ) as outfile:
+            yaml.dump(additional_args_and_defaults, outfile)
 
 
 class Lab:


### PR DESCRIPTION
the additional_args file as well as many persistent storage dirs are re-created on each ilab invocation. Only create them if they do not exist.

resolves #1704

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
