### PR TITLE
Knowledge v3 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ GitPython>=3.1.42
 httpx>=0.25.0
 instructlab-eval>=0.0.9
 instructlab-quantize>=0.1.0
-instructlab-schema>=0.2.0
-instructlab-sdg>=0.1.2,<0.2.0
+instructlab-schema>=0.3.1
+instructlab-sdg>=0.2.0
 instructlab-training>=0.3.0
 jsonschema>=4.21.1
 llama_cpp_python[server]==0.2.79

--- a/scripts/test-data/e2e-qna-knowledge.yaml
+++ b/scripts/test-data/e2e-qna-knowledge.yaml
@@ -1,21 +1,176 @@
-created_by: instructlab/sdg
-domain: textbook
+created_by: lukeinglis
+domain: anatomy_tonsil
+version: 3
 seed_examples:
- - question: |
-     what is the location of the tubal tonsils?
-   answer: |
-     The location of the tubal tonsils is the roof of the pharynx.
- - question: |
-     How long does the adenoid grow?
-   answer: |
-     The adenoid grows until the age of 5, starts to shrink at the age of 7 and becomes small in adulthood.
- - question: |
-     What is the immune systems first line of defense against ingested or inhaled foreign pathogens?
-   answer: |
-     The tonsils are the immune systems first line of defense.
-task_description: Teaching about human anatomy, specifically tonsils
+  - context: |
+      ## Structure
+      Humans are born with four types of tonsils: the pharyngeal tonsil, two
+      tubal tonsils, two palatine tonsils, and the lingual tonsils.[1]
+
+      <table>
+      <thead>
+      <tr class="header">
+      <th><p>Type</p></th>
+      <th><p><a href="Epithelium" title="wikilink">Epithelium</a></p></th>
+      <th><p><a href=":wikt:capsule" title="wikilink">Capsule</a></p></th>
+      <th><p><a href="Tonsillar_crypts" title="wikilink">Crypts</a></p></th>
+      <th><p>Location</p></th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr class="odd">
+      <td><p><a href="Adenoid" title="wikilink">Pharyngeal tonsil</a> (also
+      termed "adenoid")</p></td>
+      <td><p><a href="pseudostratified_epithelium" title="wikilink">Ciliated
+      pseudostratified columnar</a> (<a href="respiratory_epithelium"
+      title="wikilink">respiratory epithelium</a>)</p></td>
+      <td><p>Incompletely encapsulated</p></td>
+      <td><p>Small folds—sometimes described as crypts<a href="#fn1"
+      class="footnote-ref" id="fnref1"
+      role="doc-noteref"><sup>1</sup></a></p></td>
+      <td><p>Roof of <a href="pharynx" title="wikilink">pharynx</a></p></td>
+      </tr>
+      <tr class="even">
+      <td><p><a href="Tubal_tonsils" title="wikilink">Tubal tonsils</a></p></td>
+      <td><p>Ciliated pseudostratified columnar (respiratory epithelium)</p></td>
+      <td><p>Not encapsulated</p></td>
+      <td><p>No crypts</p></td>
+      <td><p>Roof of pharynx</p></td>
+      </tr>
+      <tr class="odd">
+      <td><p><a href="Palatine_tonsils" title="wikilink">Palatine tonsils</a></p></td>
+      <td><p>Stratified squamous epithelium</p></td>
+      <td><p>Fully encapsulated</p></td>
+      <td><p>Multiple deep crypts</p></td>
+      <td><p>Each side of the throat at the back of the mouth</p></td>
+      </tr>
+
+    questions_and_answers:
+      - question: What is the location of the tubal tonsils?
+        answer: The location of the tubal tonsils is the roof of the pharynx.
+      - question: |
+          Compare the epithelial types, encapsulation, and presence of
+          crypts in the pharyngeal, tubal, and palatine tonsils according to the
+          table provided.
+        answer: |
+          The pharyngeal tonsil features ciliated pseudostratified columnar
+          epithelium and is incompletely encapsulated with small folds sometimes
+          described as crypts. The tubal tonsils also have ciliated
+          pseudostratified columnar epithelium but are not encapsulated and do
+          not possess crypts. In contrast, the palatine tonsils are covered with
+          stratified squamous epithelium, are fully encapsulated, and contain
+          multiple deep crypts. These structural differences are indicative of
+          their varied anatomical locations and potentially their distinct
+          functions within the immune system.
+      - question: What type of epithelium is found in the pharyngeal tonsil?
+        answer: |
+          The type of epithelium found in the pharyngeal tonsil is ciliated
+          pseudostratified columnar (respiratory epithelium).
+
+
+  - context: |
+      The **tonsils** are a set of [lymphoid](Lymphatic_system "wikilink")
+      organs facing into the aerodigestive tract, which is known as
+      [Waldeyer's tonsillar ring](Waldeyer's_tonsillar_ring "wikilink") and
+      consists of the [adenoid tonsil](adenoid "wikilink") (or pharyngeal
+      tonsil), two [tubal tonsils](tubal_tonsil "wikilink"), two [palatine
+      tonsils](palatine_tonsil "wikilink"), and the [lingual
+      tonsils](lingual_tonsil "wikilink"). These organs play an important role
+      in the immune system.
+
+    questions_and_answers:
+      - question: What is the immune system's first line of defense?
+        answer: |
+          The tonsils are the immune system's first line of defense against
+          ingested or inhaled foreign pathogens.
+      - question: What is Waldeyer's tonsillar ring?
+        answer: |
+          Waldeyer's tonsillar ring is a set of lymphoid organs facing into the
+          aerodigestive tract, consisting of the adenoid tonsil, two tubal
+          tonsils, two palatine tonsils, and the lingual tonsils.
+      - question: How many tubal tonsils are part of Waldeyer's tonsillar ring?
+        answer: There are two tubal tonsils as part of Waldeyer's tonsillar ring.
+
+  - context: |
+      The palatine tonsils tend to reach their largest size in [puberty](puberty
+      "wikilink"), and they gradually undergo [atrophy](atrophy "wikilink")
+      thereafter. However, they are largest relative to the diameter of the
+      throat in young children. In adults, each palatine tonsil normally
+      measures up to 2.5 cm in length, 2.0 cm in width and 1.2 cm in
+      thickness.[2]
+
+    questions_and_answers:
+      - question: When do the palatine tonsils tend to reach their largest size?
+        answer: The palatine tonsils tend to reach their largest size in puberty.
+      - question: What are the typical dimensions of an adult palatine tonsil?
+        answer: |
+          In adults, each palatine tonsil normally measures up to 2.5 cm in
+          length, 2.0 cm in width, and 1.2 cm in thickness.
+      - question: How do the palatine tonsils change in size with age?
+        answer: |
+          The palatine tonsils tend to gradually undergo atrophy after puberty,
+          becoming smaller in size compared to their dimensions in young
+          children.
+
+  - context: |
+      The tonsils are immunocompetent organs that serve as the immune system's
+      first line of defense against ingested or inhaled foreign pathogens, and
+      as such frequently engorge with blood to assist in immune responses to
+      common illnesses such as the common cold. The tonsils have on their
+      surface specialized antigen capture cells called [microfold
+      cells](microfold_cell "wikilink") (M cells) that allow for the uptake of
+      antigens produced by pathogens. These M cells then alert the B cells and T
+      cells in the tonsil that a pathogen is present and an immune response is
+      stimulated.[3] B cells are activated and proliferate in areas called
+      germinal centers in the tonsil. These germinal centers are places where B
+      memory cells are created and [secretory antibody (IgA)](Immunoglobulin_A
+      "wikilink") is produced.
+
+    questions_and_answers:
+      - question: |
+          What are the specialized antigen capture cells on the surface of the
+          tonsils called?
+        answer: |
+          The specialized antigen capture cells on the surface of the tonsils
+          are called microfold cells (M cells).
+      - question: What is the role of microfold cells in the tonsils?
+        answer: |
+          Microfold cells (M cells) allow for the uptake of antigens produced by
+          pathogens. They alert the B cells and T cells in the tonsil that a
+          pathogen is present, stimulating an immune response.
+      - question: Where do B cells proliferate in the tonsils?
+        answer: B cells proliferate in areas called germinal centers in the tonsils.
+
+  - context: |
+      A [tonsillolith](tonsillolith "wikilink") (also known as a "tonsil stone")
+      is material that accumulates on the palatine tonsil. This can reach the
+      size of a [peppercorn](peppercorn "wikilink") and is white or cream in
+      color. The main substance is mostly [calcium](calcium "wikilink"), but it
+      has a strong unpleasant odor because of [hydrogen
+      sulfide](hydrogen_sulfide "wikilink") and [methyl
+      mercaptan](methyl_mercaptan "wikilink") and other chemicals.[6]
+
+    questions_and_answers:
+      - question: What is a tonsillolith?
+        answer: |
+          A tonsillolith (tonsil stone) is material that accumulates on the
+          palatine tonsil, reaching the size of a peppercorn and having a white
+          or cream color. It contains calcium and has a strong unpleasant odor
+          due to hydrogen sulfide, methyl mercaptan, and other chemicals.
+      - question: What is the main substance found in a tonsillolith?
+        answer: The main substance found in a tonsillolith is mostly calcium.
+      - question: Why do tonsilloliths have a strong unpleasant odor?
+        answer: |
+          Tonsilloliths have a strong unpleasant odor due to hydrogen sulfide,
+          methyl mercaptan, and other chemicals.
+
+document_outline: |
+  Overview of Human tonsils, describing their types, locations, structure,
+  function, and clinical significance, with a specific focus on their role in
+  the immune system and related health issues.
+
 document:
-  repo: https://github.com/russellb/taxonomy
-  commit: 86b15e9c5701886850e8f85ad67cb56e049997c1
+  repo: https://github.com/luke-inglis/il-anatomy-knowledge
+  commit: cc7c6ca
   patterns:
-  - tonsils.md
+    - anatomy1.md


### PR DESCRIPTION
See epic instructlab/sdg#160 for more information.

cc71e8b requirements: Make use of knowledge v3 versions of dependencies
fd50d86 e2e: Update knowledge sample to a v3 example

commit cc71e8bef521d04d112da116590f0bf427580475
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Jul 18 16:19:51 2024 -0400

    requirements: Make use of knowledge v3 versions of dependencies
       
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit fd50d866bea75991de902f5749ceee63c3dc5d25
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Jul 18 16:20:45 2024 -0400

    e2e: Update knowledge sample to a v3 example
    
    The knowledge schema changed to v3. Older versions are no longer
    supported. Update our testing accordingly.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
