### PR TITLE
removes tokenizer.model from required safetensors model files"

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -136,7 +136,6 @@ def is_model_safetensors(model_path: pathlib.Path) -> bool:
     requires_files = {
         "config.json",
         "tokenizer.json",
-        "tokenizer.model",
         "tokenizer_config.json",
     }
     diff = requires_files.difference(basenames)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -22,7 +22,7 @@ def create_safetensors_model_files(safetensors_model_path: pathlib.Path, valid: 
     test_json_dict = {"a": 1, "b": 2}
     json_object = json.dumps(test_json_dict, indent=4)
 
-    for file in ["config.json", "tokenizer.json", "tokenizer_config.json"]:
+    for file in ["tokenizer.json", "tokenizer_config.json"]:
         os.makedirs(os.path.dirname(safetensors_model_path / file), exist_ok=True)
         with open(safetensors_model_path / file, "a+", encoding="UTF-8") as f:
             f.write(json_object)
@@ -32,10 +32,8 @@ def create_safetensors_model_files(safetensors_model_path: pathlib.Path, valid: 
     ) as f:
         f.write("")
     if valid:
-        with open(
-            safetensors_model_path / "tokenizer.model", "a+", encoding="UTF-8"
-        ) as f:
-            f.write("")
+        with open(safetensors_model_path / "config.json", "a+", encoding="UTF-8") as f:
+            f.write(json_object)
 
 
 def test_free_port():


### PR DESCRIPTION
`tokenizer.model` isn't required for a model directory to be a `.safetensors` model- this broke model loading for me because the checkpoints that we save don't have this file. This appears to be a common, but not a required file. (look at metaai/llama3-8b)
