### PR TITLE
fix: add checks to ensure evaluate model args are valid

### DIFF
--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -126,6 +126,15 @@ def get_evaluator(
                 fg="red",
             )
             raise click.exceptions.Exit(1)
+        # ensure user is passing full safetensors if they specify a local directory
+        # TODO: also allow GGUF once the following is resolved: https://github.com/instructlab/eval/issues/50
+        if os.path.isdir(model):
+            if not backends.is_model_safetensors(pathlib.Path(model)):
+                click.secho(
+                    "MMLU and MMLUBranch can currently only be used with safetensors",
+                    fg="red",
+                )
+                raise click.exceptions.Exit(1)
         if benchmark == Benchmark.MMLU:
             # Third Party
             from instructlab.eval.mmlu import MMLUEvaluator

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -87,6 +87,19 @@ def get_evaluator(
                 fg="red",
             )
             raise click.exceptions.Exit(1)
+        if os.path.exists(model):
+            model = pathlib.Path(model)
+            valid_model = False
+            if model.is_dir():
+                valid_model = backends.is_model_safetensors(model)
+            elif model.is_file():
+                valid_model = backends.is_model_gguf(model)
+            if not valid_model:
+                click.secho(
+                    "MTBench and MTBenchBranch need to be passed either a safetensors directory or a GGUF file",
+                    fg="red",
+                )
+                raise click.exceptions.Exit(1)
         if benchmark == Benchmark.MT_BENCH:
             # Third Party
             from instructlab.eval.mt_bench import MTBenchEvaluator
@@ -131,7 +144,7 @@ def get_evaluator(
         if os.path.isdir(model):
             if not backends.is_model_safetensors(pathlib.Path(model)):
                 click.secho(
-                    "MMLU and MMLUBranch can currently only be used with safetensors",
+                    "MMLU and MMLUBranch can currently only be used with a safetensors directory",
                     fg="red",
                 )
                 raise click.exceptions.Exit(1)

--- a/tests/test_lab_evaluate.py
+++ b/tests/test_lab_evaluate.py
@@ -496,7 +496,7 @@ def test_invalid_tasks_dir(cli_runner: CliRunner):
     assert result.exit_code != 0
 
 
-def test_invalid_mmlu_model(cli_runner: CliRunner, tmp_path):
+def test_invalid_model_path_mmlu(cli_runner: CliRunner, tmp_path):
     test_dir = tmp_path / "test"
     test_dir.mkdir()
     result = cli_runner.invoke(
@@ -512,7 +512,29 @@ def test_invalid_mmlu_model(cli_runner: CliRunner, tmp_path):
         ],
     )
     assert (
-        "MMLU and MMLUBranch can currently only be used with safetensors"
+        "MMLU and MMLUBranch can currently only be used with a safetensors directory"
+        in result.output
+    )
+    assert result.exit_code != 0
+
+
+def test_invalid_model_path_mt_bench(cli_runner: CliRunner, tmp_path):
+    test_dir = tmp_path / "test"
+    test_dir.mkdir()
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+            "--benchmark",
+            "mt_bench",
+            "--model",
+            test_dir,
+        ],
+    )
+    assert (
+        "MTBench and MTBenchBranch need to be passed either a safetensors directory or a GGUF file"
         in result.output
     )
     assert result.exit_code != 0

--- a/tests/test_lab_evaluate.py
+++ b/tests/test_lab_evaluate.py
@@ -494,3 +494,25 @@ def test_invalid_tasks_dir(cli_runner: CliRunner):
     )
     assert "Tasks dir not found:" in result.output
     assert result.exit_code != 0
+
+
+def test_invalid_mmlu_model(cli_runner: CliRunner, tmp_path):
+    test_dir = tmp_path / "test"
+    test_dir.mkdir()
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+            "--benchmark",
+            "mmlu",
+            "--model",
+            test_dir,
+        ],
+    )
+    assert (
+        "MMLU and MMLUBranch can currently only be used with safetensors"
+        in result.output
+    )
+    assert result.exit_code != 0


### PR DESCRIPTION
While testing Eval, I noticed we are passing a GGUF file by default to the `evaluate` command but Evaluation won't fully support GGUF until https://github.com/instructlab/eval/issues/50 is complete

I filed https://github.com/instructlab/instructlab/issues/1792 to track this on the CLI side, but adding this minor check as well in the meantime

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
