### PR TITLE
docs: Reflect updates to training CI status

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -86,7 +86,7 @@ The project currently supports the usage of the following runners for the E2E jo
 |              | full                     |⎯|⎯|⎯|✅|
 | **Training** | legacy+Linux             |⎯|⎯|✅|⎯|
 |              | legacy+Linux+4-bit-quant |✅|✅|⎯|⎯|
-|              | training-lib             |⎯|⎯|✅(*1)|❌|
+|              | training-lib             |⎯|⎯|⎯|✅|
 | **Eval**     | eval                     |⎯|⎯|✅(*2)|❌️|
 
 Points of clarification (*):


### PR DESCRIPTION
- We now run legacy training only for `a10g-x1`.

- We run the training-lib in `a10g-x4`, including the use
  of the `full` SDG pipeline as input into training.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
