### PR TITLE
fix: check for .bin files during auto-detection of serving backend

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -128,8 +128,9 @@ def is_model_safetensors(model_path: pathlib.Path) -> bool:
         logger.debug("Failed to read directory: %s", e)
         return False
 
-    if not any(file.suffix == ".safetensors" for file in files):
-        logger.debug("'%s' has no *.safetensors files", model_path)
+    # directory should contain either .safetensors or .bin files to be considered valid
+    if not any(file.suffix in (".safetensors", ".bin") for file in files):
+        logger.debug("'%s' has no *.safetensors or *.bin files", model_path)
         return False
 
     basenames = {file.name for file in files}


### PR DESCRIPTION
Current check for auto-detection of backend requires a vLLM friendly model's directory to contain `*.safetensors` files to qualify as valid. However, we should also accept the presence of `*.bin` files in place of `*.safetensors` files as training outputs `.bin` checkpoints that can be served through vLLM


<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
