### PR TITLE
refactor: Remove unnecessary `export`s from scripts

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -35,14 +35,12 @@ BOLD='\033[1m'
 NC='\033[0m' # No Color
 
 SCRIPTDIR=$(dirname "$0")
-export E2E_TEST_DIR
+E2E_TEST_DIR=
 # E2E_TEST_DIR="$(pwd)/__e2e_test"
-export CONFIG_HOME
-export DATA_HOME
-export CACHE_HOME
-export CONFIG_HOME
-
-
+CONFIG_HOME=
+DATA_HOME=
+CACHE_HOME=
+CONFIG_HOME=
 
 ########################################
 # This function initializes the directory

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -11,9 +11,9 @@
 set -ex
 
 # shellcheck disable=SC2155
-export SCRIPTDIR=$(dirname "$0")
+SCRIPTDIR=$(dirname "$0")
 # build a prompt string that includes the time, source file, line number, and function name
-export PS4='+$(date +"%Y-%m-%d %T") ${BASH_VERSION}:${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+PS4='+$(date +"%Y-%m-%d %T") ${BASH_VERSION}:${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
 
 if [ -n "$TEST_DIR" ]; then
     echo "TEST_DIR is set to $TEST_DIR by the caller, will not remove it"
@@ -22,22 +22,13 @@ fi
 
 # Support overriding the test directory for local testing otherwise creates a temporary directory
 TEST_DIR=${TEST_DIR:-$(mktemp -d)}
-
-export TEST_DIR
-export PACKAGE_NAME='instructlab'  # name we use of the top-level package directories for CLI data
-
-
-# get the directories from the platformdirs library
-export CONFIG_DIR
-export DATA_DIR
-export CACHE_DIR
-
+PACKAGE_NAME='instructlab'  # name we use of the top-level package directories for CLI data
 
 # we define the path here to reference elsewhere, but the existence of this file
 # will be managed by the ilab CLI
-export ILAB_CONFIGDIR_LOCATION
-export ILAB_CONFIG_FILE
-export ILAB_DATA_DIR
+ILAB_CONFIGDIR_LOCATION=
+ILAB_CONFIG_FILE=
+ILAB_DATA_DIR=
 
 
 ########################################
@@ -52,9 +43,6 @@ export ILAB_DATA_DIR
 #   ILAB_DATA_DIR
 #   ILAB_CONFIG_FILE
 #   ILAB_CONFIGDIR_LOCATION
-#   CACHE_DIR
-#   DATA_DIR
-#   CONFIG_DIR
 # Outputs:
 #   Writes logs to stdout
 ########################################
@@ -93,8 +81,8 @@ function init_test_script() {
 }
 
 
-export TEST_CTX_SIZE_LAB_SERVE_LOG_FILE=test_ctx_size_lab_serve.log
-export TEST_CTX_SIZE_LAB_CHAT_LOG_FILE=test_ctx_size_lab_chat.log
+TEST_CTX_SIZE_LAB_SERVE_LOG_FILE=test_ctx_size_lab_serve.log
+TEST_CTX_SIZE_LAB_CHAT_LOG_FILE=test_ctx_size_lab_chat.log
 
 for cmd in ilab expect timeout; do
     if ! type -p $cmd; then


### PR DESCRIPTION
`export` is used to pass a variable to a subprocess. These variables are not read by any subprocesses started by the scripts. No need to export them.


**Issue resolved by this Pull Request:**
Resolves #1798

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [X] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
