### PR TITLE
Install instructlab[cuda] with flash-attn workaround

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x1.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x1.yml
@@ -120,20 +120,22 @@ jobs:
           export CUDA_HOME="/usr/local/cuda"
           export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
           export PATH="$PATH:$CUDA_HOME/bin"
-          python3.11 -m venv venv
+          python3.11 -m venv --upgrade-deps venv
           . venv/bin/activate
           nvidia-smi
-          sed 's/\[.*\]//' requirements.txt > constraints.txt
           python3.11 -m pip cache remove llama_cpp_python
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-binary llama_cpp_python -c constraints.txt llama_cpp_python
-          python3.11 -m pip install bitsandbytes
 
-          # TODO This should be added to instructlab-training
-          python3.11 -m pip install packaging wheel
+          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install .
 
-          python3.11 -m pip install instructlab-training[cuda]
+          # issue 1821: workaround for flash-attn
+          # install with Torch and build dependencies installed
+          python3.11 -m pip install packaging wheel setuptools-scm
+          python3.11 -m pip install .[cuda]
 
-          python3.11 -m pip install .
+      - name: ilab system info
+        run: |
+          . venv/bin/activate
+          ilab system info
 
       - name: Run e2e test
         run: |

--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -123,14 +123,22 @@ jobs:
           export CUDA_HOME="/usr/local/cuda"
           export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
           export PATH="$PATH:$CUDA_HOME/bin"
-          python3.11 -m venv venv
+          python3.11 -m venv --upgrade-deps venv
           . venv/bin/activate
           nvidia-smi
-          sed 's/\[.*\]//' requirements.txt > constraints.txt
           python3.11 -m pip cache remove llama_cpp_python
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-binary llama_cpp_python -c constraints.txt llama_cpp_python
-          python3.11 -m pip install packaging wheel torch -c constraints.txt
+
+          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install .
+
+          # issue 1821: workaround for flash-attn and vllm
+          # install with Torch and build dependencies installed
+          python3.11 -m pip install packaging wheel setuptools-scm
           python3.11 -m pip install .[cuda] -r requirements-vllm-cuda.txt
+
+      - name: ilab system info
+        run: |
+          . venv/bin/activate
+          ilab system info
 
       - name: Run e2e test
         env:

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -80,11 +80,20 @@ jobs:
           export PATH="/home/ec2-user/.local/bin:/usr/local/cuda/bin:$PATH"
           python3.11 -m venv --upgrade-deps venv
           . venv/bin/activate
-          sed 's/\[.*\]//' requirements.txt > constraints.txt
+          nvidia-smi
           python3.11 -m pip cache remove llama_cpp_python
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-binary llama_cpp_python -c constraints.txt llama_cpp_python
-          python3.11 -m pip install bitsandbytes
-          python3.11 -m pip install .
+
+          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install .
+
+          # issue 1821: workaround for flash-attn
+          # install with Torch and build dependencies installed
+          python3.11 -m pip install packaging wheel setuptools-scm
+          python3.11 -m pip install .[cuda]
+
+      - name: ilab system info
+        run: |
+          . venv/bin/activate
+          ilab system info
 
       - name: Run e2e test
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -142,14 +142,22 @@ jobs:
       - name: Install ilab
         run: |
           export PATH="/home/runner/.local/bin:/usr/local/cuda/bin:$PATH"
-          python3 -m venv venv
+          python3.11 -m venv --upgrade-deps venv
           . venv/bin/activate
-          sed 's/\[.*\]//' requirements.txt > constraints.txt
-          python3 -m pip cache remove llama_cpp_python
-          CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3 -m pip install --no-binary llama_cpp_python -c constraints.txt llama_cpp_python
-          # needed for --4-bit-quant option to ilab model train
-          python3 -m pip install bitsandbytes
-          python3 -m pip install .
+          nvidia-smi
+          python3.11 -m pip cache remove llama_cpp_python
+
+          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install .
+
+          # issue 1821: workaround for flash-attn
+          # install with Torch and build dependencies installed
+          python3.11 -m pip install packaging wheel setuptools-scm
+          python3.11 -m pip install .[cuda]
+
+      - name: ilab system info
+        run: |
+          . venv/bin/activate
+          ilab system info
 
       - name: Run e2e test
         run: |


### PR DESCRIPTION
Install instructlab with `cuda` optional dependency. This installs `instructlab-training[cuda]` with `bitsandbytes` and `flash-attn>=2.4.0`.

To workaround a packaging bug in flash-attn<=2.6.1, first install instructlab without optional dependencies, then install it again with `cuda` optional dependency, packaging, and wheel. flash-attn needs Torch, wheel, and packaging to build without declaring the build dependencies.

**Issue resolved by this Pull Request:**
Is related to #1821 but does not resolve it.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
