### PR TITLE
ci: support vLLM installation in 4xA10 workflow

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-00c51d9c1374eda97
+          ec2-image-id: ami-03f6686697972e40a
           ec2-instance-type: g5.12xlarge
           subnet-id: subnet-02d230cffd9385bd4
           security-group-id: sg-06300447c4a5fbef3
@@ -129,11 +129,8 @@ jobs:
           sed 's/\[.*\]//' requirements.txt > constraints.txt
           python3.11 -m pip cache remove llama_cpp_python
           CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install --force-reinstall --no-binary llama_cpp_python -c constraints.txt llama_cpp_python
-                    
-          python3.11 -m pip install packaging wheel torch
-          python3.11 -m pip install instructlab-training[cuda]
-
-          python3.11 -m pip install .
+          python3.11 -m pip install packaging wheel torch -c constraints.txt
+          python3.11 -m pip install .[cuda] -r requirements-vllm-cuda.txt
 
       - name: Run e2e test
         env:


### PR DESCRIPTION
This PR ensure vLLM can be installed correctly in the 4xA10 workflow. Separate PRs will ensure the `-v` flag to basic-workflows.sh is utilized.
