### PR TITLE
add `ilab model list`

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -156,3 +156,4 @@ vllm
 wikisql
 xcode
 xlarge
+Safetensor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
    `ilab config init` and can be used to specify alternative configurations for any command,
    ensuring that defaults such as taxonomy repositories and base models are honored from the global
    config.
+* `ilab model list`: a new command which lists all GGUF and Safetensor Models on the system.
 
 ### Breaking Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ issues = "https://github.com/instructlab/instructlab/issues"
 "serve" = "instructlab.model.serve:serve"
 "test" = "instructlab.model.test:test"
 "train" = "instructlab.model.train:train"
+"list" = "instructlab.model.list:model_list"
 
 [project.entry-points."instructlab.command.system"]
 "info" = "instructlab.system.info:info"
@@ -77,6 +78,7 @@ issues = "https://github.com/instructlab/instructlab/issues"
 "sysinfo" = "instructlab.system.info:info"
 "test" = "instructlab.model.test:test"
 "train" = "instructlab.model.train:train"
+"list" = "instructlab.model.list:model_list"
 
 [tool.setuptools_scm]
 version_file = "src/instructlab/_version.py"

--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -148,6 +148,25 @@ test_download() {
     fi
 }
 
+test_list() {
+    task List the Downloaded Models
+
+    if [ "$GRANITE" -eq 1 ]; then
+        step Listing the granite GGUF model only
+        ilab model list | grep granite-7b-lab-Q4_K_M.gguf
+    elif [ "$MIXTRAL" -eq 1 ]; then
+        step Listing the mixtral model only
+        ilab model list | grep mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf
+    else
+        step Listing the merlinite GGUF model only
+        ilab model list | grep merlinite-7b-lab-Q4_K_M.gguf4
+    fi
+    
+    # regardless, download merl safetensors to test that capability
+    ilab model download --repository instructlab/merlinite-7b-lab
+    ilab model list | grep instructlab/merlinite-7b-lab
+}
+
 test_serve() {
     # Accepts an argument of the model, or default here
     if [ "$GRANITE" -eq 1 ]; then

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -167,20 +167,24 @@ def is_model_gguf(model_path: pathlib.Path) -> bool:
     # Third Party
     from gguf.constants import GGUF_MAGIC
 
-    with open(model_path, "rb") as f:
-        # Memory-map the file on the first 4 bytes (this is where the magic number is)
-        mmapped_file = mmap.mmap(f.fileno(), length=4, access=mmap.ACCESS_READ)
+    try:
+        with open(model_path, "rb") as f:
+            # Memory-map the file on the first 4 bytes (this is where the magic number is)
+            mmapped_file = mmap.mmap(f.fileno(), length=4, access=mmap.ACCESS_READ)
 
-        # Read the first 4 bytes
-        first_four_bytes = mmapped_file.read(4)
+            # Read the first 4 bytes
+            first_four_bytes = mmapped_file.read(4)
 
-        # Convert the first four bytes to an integer
-        first_four_bytes_int = int(struct.unpack("<I", first_four_bytes)[0])
+            # Convert the first four bytes to an integer
+            first_four_bytes_int = int(struct.unpack("<I", first_four_bytes)[0])
 
-        # Close the memory-mapped file
-        mmapped_file.close()
+            # Close the memory-mapped file
+            mmapped_file.close()
 
-        return first_four_bytes_int == GGUF_MAGIC
+            return first_four_bytes_int == GGUF_MAGIC
+    except IsADirectoryError as exc:
+        logger.debug(f"GGUF Path is a directory, returning {exc}")
+        return False
 
 
 def determine_backend(model_path: pathlib.Path) -> Tuple[str, str]:

--- a/src/instructlab/model/list.py
+++ b/src/instructlab/model/list.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from pathlib import Path
+import logging
+import os
+import time
+
+# Third Party
+import click
+
+# First Party
+from instructlab import clickext
+from instructlab.configuration import DEFAULTS
+from instructlab.model.backends.backends import is_model_gguf, is_model_safetensors
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(name="list")
+@clickext.display_params
+@click.option(
+    "--model-dirs",
+    help="Base directories where models are stored.",
+    multiple=True,
+    default=[DEFAULTS.MODELS_DIR],
+    show_default=True,
+)
+@click.option(
+    "--list-checkpoints",
+    is_flag=True,
+)
+def model_list(model_dirs: list[str], list_checkpoints: bool):
+    """lists models"""
+    data = []
+    for directory in model_dirs:
+        for entry in Path(directory).iterdir():
+            # if file, just tally the size. This must be a GGUF.
+            if entry.is_file() and is_model_gguf(entry):
+                model, age, size = _analyze_gguf(entry)
+                data.append([model, age, size])
+            elif entry.is_dir():
+                for m in _analyze_dir(entry, list_checkpoints, directory):
+                    data.append(m)
+    print_table(["Model Name", "Last Modified", "Size"], data)
+
+
+# convert_bytes_to_proper_mag takes a dir/file size in Bytes and converts it to the proper Magnitude (MiB, GiB)
+def convert_bytes_to_proper_mag(f_size: float):
+    magnitudes = ["KiB", "MiB", "GiB", "TiB"]
+    magnitude = "B"
+    for mag in magnitudes:
+        if f_size >= 1024:
+            magnitude = mag
+            f_size /= 1024
+        else:
+            return f_size, magnitude
+    return f_size, magnitude
+
+
+# print_table displays the models on the system in a nicely formatted table
+def print_table(headers: list[str], data: list[list[str]]):
+    column_widths = [
+        max(len(str(row[i])) for row in data + [headers]) for i in range(len(headers))
+    ]
+    # Print separator line between headers and data
+    horizontal_lines = ["-" * (width + 2) for width in column_widths]
+    joining_line = "+" + "+".join(horizontal_lines) + "+"
+    print(joining_line)
+    outputs = []
+    for header, width in zip(headers, column_widths, strict=False):
+        outputs.append(f" {header:{width}} ")
+    print("|" + "|".join(outputs) + "|")
+    print(joining_line)
+    for row in data:
+        outputs = []
+        for item, width in zip(row, column_widths, strict=False):
+            outputs.append(f" {item:{width}} ")
+        print("|" + "|".join(outputs) + "|")
+    print(joining_line)
+
+
+AnalyzeResultGGUF = list[str]
+AnalyzeResultDir = list[list[str]]
+
+
+def _analyze_gguf(entry: Path) -> AnalyzeResultGGUF:
+    # stat the gguf, add it to the table
+    stat = Path(entry.absolute()).stat(follow_symlinks=False)
+    f_size = stat.st_size
+    f_size, magnitude = convert_bytes_to_proper_mag(f_size)
+    # add to table
+    modification_time = os.path.getmtime(entry.absolute())
+    modification_time_readable = time.strftime(
+        "%Y-%m-%d %H:%M:%S", time.localtime(modification_time)
+    )
+    return [entry.name, modification_time_readable, f"{f_size:.1f} {magnitude}"]
+
+
+def _analyze_dir(
+    entry: Path, list_checkpoints: bool, directory: str
+) -> AnalyzeResultDir:
+    actual_model_name = ""
+    all_files_sizes = 0
+    add_model = False
+    models = []
+    # walk entire dir.
+    for root, _, files in os.walk(entry.as_posix()):
+        normalized_path = os.path.normpath(root)
+        # Split the path into its components
+        parts = normalized_path.split(os.sep)
+        # Get the last two parts and join them back into a path
+        last_two_parts = os.path.join(parts[-2], parts[-1])
+        # if this is a dir it could be:
+        # top level repo dir `instructlab/`
+        # top level model dir `instructlab/granite-7b-lab`
+        # checkpoint top level dir `step-19`
+        # any lower level dir: `instructlab/granite-7b-lab/.huggingface/download.....`
+        # so, check if model is valid Safetensor, GGUF, or list it regardless w/ `--list-checkpoints`
+        # if --list-checkpoints is specified, we will list all checkpoints in the checkpoints dir regardless of the validity
+        if is_model_safetensors(Path(normalized_path)) or is_model_gguf(
+            Path(normalized_path)
+        ):
+            actual_model_name = last_two_parts
+            all_files_sizes = 0
+            add_model = True
+        else:
+            if list_checkpoints and directory is DEFAULTS.CHECKPOINTS_DIR:
+                logging.debug("Including model regardless of model validity")
+            else:
+                continue
+        for f in files:
+            # stat each file in the dir, add the size in Bytes, then convert to proper magnitude
+            full_file = os.path.join(root, f)
+            stat = Path(full_file).stat(follow_symlinks=False)
+            all_files_sizes += stat.st_size
+        all_files_sizes, magnitude = convert_bytes_to_proper_mag(all_files_sizes)
+        if add_model:
+            # add to table
+            modification_time = os.path.getmtime(entry.absolute())
+            modification_time_readable = time.strftime(
+                "%Y-%m-%d %H:%M:%S", time.localtime(modification_time)
+            )
+            models.append(
+                [
+                    actual_model_name,
+                    modification_time_readable,
+                    f"{all_files_sizes:.1f} {magnitude}",
+                ]
+            )
+    return models

--- a/src/instructlab/model/model.py
+++ b/src/instructlab/model/model.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# pylint: disable=redefined-builtin
 # Third Party
 import click
 

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -90,6 +90,7 @@ subcommands: list[Command] = [
     Command(("model", "serve")),
     Command(("model", "test")),
     Command(("model", "train")),
+    Command(("model", "list")),
     Command(("data",), needs_config=False),
     Command(("data", "generate")),
     Command(("system",), needs_config=False),
@@ -110,6 +111,7 @@ aliases = [
     "diff",
     "generate",
     "sysinfo",
+    "list",
 ]
 
 


### PR DESCRIPTION
`ilab model list` prints a table of all models in ~/.local/share/instructlab/models. Both GGUF and Safetensor models. This cmd also takes a `--list-checkpoints` flag that will expose the checkpoints generated by `ilab model train`. These live in ~/.cache/instructlab/checkpoints

also adds an e2e test checking functionality of gguf and safetensor models

an example output of this command looks like:

```
+------------------------------+---------------------+----------+
| Model Name                   | Last Modified       | Size     |
+------------------------------+---------------------+----------+
| merlinite-7b-lab-Q4_K_M.gguf | 2024-07-24 16:01:57 | 4.1 GiB  |
| instructlab/granite-7b-lab   | 2024-07-24 16:17:39 | 12.6 GiB |
+------------------------------+---------------------+----------+

```

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
