### PR TITLE
Add support for an `ilab` global config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@
 * The `generate` section of the config now has a `teacher` section. This section configures the
   teacher model when it is automatically served in the background. This new section has the same
   values as the `serve` section of the config.
+* Support for `ILAB_GLOBAL_CONFIG` environment variable: When set, this environment variable
+   specifies a global configuration file that serves as the template for the
+   `~/.config/instructlab/config.yaml` user space config. This bypasses the interactive mode in
+   `ilab config init` and can be used to specify alternative configurations for any command,
+   ensuring that defaults such as taxonomy repositories and base models are honored from the global
+   config.
 
 ### Breaking Changes
 

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -62,6 +62,11 @@ class _InstructlabDefaults:
     # define static defaults up here
     API_KEY = "no_api_key"
 
+    # ILAB_GLOBAL_CONFIG is the environment variable that can be used to override the default config
+    # file. When set, the CLI will use the file specified in the environment variable as a sample to
+    # generate the default config file.
+    ILAB_GLOBAL_CONFIG = "ILAB_GLOBAL_CONFIG"
+
     # TODO: Consolidate --model and --model-path into one --model-path flag since we always need a path now
     MODEL_NAME_OLD = "merlinite-7b-lab-Q4_K_M"
     MERLINITE_GGUF_REPO = "instructlab/merlinite-7b-lab-GGUF"

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -27,6 +27,7 @@ multiprocessing.set_start_method(cfg.DEFAULTS.MULTIPROCESSING_START_METHOD, forc
     "config_file",
     type=click.Path(),
     default=cfg.DEFAULTS.CONFIG_FILE,
+    envvar=cfg.DEFAULTS.ILAB_GLOBAL_CONFIG,
     show_default=True,
     help="Path to a configuration file.",
 )

--- a/tests/test_lab_config.py
+++ b/tests/test_lab_config.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Standard
+import logging
+import pathlib
+
 # Third Party
 from click.testing import CliRunner
+import pytest
 import yaml
 
 # First Party
@@ -16,3 +21,40 @@ def test_ilab_config_show(cli_runner: CliRunner) -> None:
     assert parsed
 
     assert configuration.Config(**parsed)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        (["config", "init"]),
+        (
+            ["init"]
+        ),  # TODO: remove this test once the deprecated alias 'ilab init' is removed
+    ],
+)
+def test_ilab_config_init_with_env_var_config(
+    cli_runner: CliRunner, tmp_path: pathlib.Path, command: list
+) -> None:
+    # Common setup code
+    cfg = configuration.get_default_config()
+    assert cfg.general.log_level == logging.getLevelName(logging.INFO)
+    cfg.general.log_level = logging.getLevelName(logging.DEBUG)
+    cfg_file = tmp_path / "config-gold.yaml"
+    with cfg_file.open("w") as f:
+        yaml.dump(cfg.model_dump(), f)
+
+    # Invoke the CLI command
+    result = cli_runner.invoke(
+        lab.ilab, command, env={"ILAB_GLOBAL_CONFIG": cfg_file.as_posix()}
+    )
+    assert result.exit_code == 0, result.stdout
+
+    # Load and check the generated config file
+    config_path = pathlib.Path(configuration.DEFAULTS.CONFIG_FILE)
+    assert config_path.exists()
+    with config_path.open(encoding="utf-8") as f:
+        parsed = yaml.safe_load(f)
+    assert parsed
+    assert configuration.Config(**parsed).general.log_level == logging.getLevelName(
+        logging.DEBUG
+    )


### PR DESCRIPTION
When the env var `ILAB_GLOBAL_CONFIG` is set, that config is used as the
template to render the ~/.config/instructlab/config.yaml user space
config. The interactive mode is skipped when calling `ilab config init`.
This works at the `ilab` main entrypoint, this can be used to specify a
different configuration file too when running any commands.

This ensures defaults like taxonomy repos, base models, etc, are honored
from the global config.

Co-authored-by: Sébastien Han <seb@redhat.com>
Signed-off-by: Charlie Doern <cdoern@redhat.com>
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
