### PR TITLE
Add autodetection and vllm arg adjustment for bitsandbytes quantization

### DIFF
--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -285,12 +285,15 @@ def build_vllm_cmd(
     # Auto-detect whether model is quantized w/ bitsandbytes and add potentially missing args
     quant_arg_present = contains_argument("--quantization", vllm_args)
     load_arg_present = contains_argument("--load-format", vllm_args)
-    if not quant_arg_present or not load_arg_present:
+    eager_arg_present = contains_argument("--enforce-eager", vllm_args)
+    if not (quant_arg_present and load_arg_present and eager_arg_present):
         if is_bnb_quantized(model_path):
             if not quant_arg_present:
                 vllm_cmd.extend(["--quantization", "bitsandbytes"])
             if not load_arg_present:
                 vllm_cmd.extend(["--load-format", "bitsandbytes"])
+            if not eager_arg_present:
+                vllm_cmd.append("--enforce-eager")
 
     # Force multiprocessing for distributed serving, vLLM will try "ray" if it's installed but we do
     # not support it (yet?). We don't install Ray but we might end up running on systems that have it,

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+import json
 import logging
 import os
 import pathlib
@@ -202,6 +203,29 @@ def run_vllm(
     return vllm_process, tmp_files
 
 
+def is_bnb_quantized(model_path: pathlib.Path) -> bool:
+    """
+    Check if provided model has quantization config with bitsandbytes specified.
+
+    Args:
+        model_path    (Path):         The path to the model files
+
+    Returns:
+        bool: Whether or not the model has been quantized via bitsandbytes
+    """
+    config_json = model_path / "config.json"
+    if not model_path.is_dir() or not config_json.is_file():
+        return False
+
+    with config_json.open(encoding="utf-8") as f:
+        config = json.load(f)
+
+    return (
+        "quantization_config" in config
+        and config["quantization_config"].get("quant_method", "") == "bitsandbytes"
+    )
+
+
 def build_vllm_cmd(
     host: str,
     port: int,
@@ -258,6 +282,13 @@ def build_vllm_cmd(
             path = pathlib.Path(chat_template)
             verify_template_exists(path)
             vllm_cmd.extend(["--chat-template", chat_template])
+
+    # Auto-detect whether model is quantized w/ bitsandbytes and add potentially missing args
+    if is_bnb_quantized(model_path):
+        if not contains_argument("--quantization", vllm_args):
+            vllm_cmd.extend(["--quantization", "bitsandbytes"])
+        if not contains_argument("--load-format", vllm_args):
+            vllm_cmd.extend(["--load-format", "bitsandbytes"])
 
     # Force multiprocessing for distributed serving, vLLM will try "ray" if it's installed but we do
     # not support it (yet?). We don't install Ray but we might end up running on systems that have it,

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -292,6 +292,7 @@ def build_vllm_cmd(
                 vllm_cmd.extend(["--quantization", "bitsandbytes"])
             if not load_arg_present:
                 vllm_cmd.extend(["--load-format", "bitsandbytes"])
+            # Currently needed to retain generation quality w/ 4-bit bnb + vLLM (bypass graph bug)
             if not eager_arg_present:
                 vllm_cmd.append("--enforce-eager")
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -313,6 +313,7 @@ def test_build_vllm_cmd_with_bnb_quant(tmp_path: pathlib.Path):
         "bitsandbytes",
         "--load-format",
         "bitsandbytes",
+        "--enforce-eager",
         "--distributed-executor-backend",
         "mp",
     ]


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

When loading a bitsandbytes quantized model with vllm, we need to ensure that the `--quantization` and `--load-format` args are appropriately set to `bitsandbytes`, otherwise the model cannot be loaded. This PR introduces the logic to check whether a model is vllm quantized and adjust the `vllm_args` accordingly.

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
