### PR TITLE
Support the pretraining samples in the legacy dataset conversion utility

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -136,6 +136,7 @@ png
 pre
 preceeds
 preprint
+pretraining
 pyenv
 qlora
 quant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@
 * `ilab model list`: a new command which lists all GGUF and Safetensor Models on the system.
 * `ilab data list`: a new command which lists the generated datasets in the user's datasets
   directory.
+* Legacy Linux training now supports the new messages format. When a dataset is provided in the
+  HuggingFace messages format, `ilab` will automatically convert it back into the legacy format.
+* Legacy Linux training is now compatible with the phase07 pretraining format.
 
 ### Breaking Changes
 

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -18,7 +18,6 @@ import pytest
 from instructlab import lab
 from instructlab.configuration import DEFAULTS
 from instructlab.train import linux_train
-from instructlab.utils import MessageSample
 
 INPUT_DIR = "test_generated"
 TRAINING_RESULTS_DIR = "training_results"
@@ -209,86 +208,6 @@ class TestLabTrain:
             assert result.exception is not None
             assert "Could not read from data directory" in result.output
             assert result.exit_code == 1
-
-    @patch("instructlab.utils.is_macos_with_m_chip", return_value=False)
-    @patch.object(linux_train, "linux_train", return_value=Path("training_results"))
-    @patch(
-        "instructlab.llamacpp.llamacpp_convert_to_gguf.convert_llama_to_gguf",
-        side_effect=mock_convert_llama_to_gguf,
-    )
-    def test_legacy_train_with_messages(
-        self,
-        convert_llama_to_gguf_mock,
-        linux_train_mock,
-        is_macos_with_m_chip_mock,
-        cli_runner: CliRunner,
-    ):
-        setup_linux_dir()
-        setup_input_dir(DEFAULTS.DATASETS_DIR)
-        # write the dataset out somewhere
-        new_dataset: typing.List[MessageSample] = [
-            {
-                "messages": [
-                    {
-                        "role": "system",
-                        "content": "You are a friendly assistant",
-                    },
-                    {"role": "user", "content": "What is 2 + 2?"},
-                    {"role": "assistant", "content": "2 + 2 = 4"},
-                ],
-                "group": " test",
-                "dataset": "test-dataset",
-                "metadata": "test",
-            }
-        ]
-        dataset_contents = ""
-        for line in new_dataset:
-            json_str = json.dumps(line)
-            dataset_contents += json_str + "\n"
-
-        with open(
-            os.path.join(DEFAULTS.DATASETS_DIR, "test_dataset.jsonl"),
-            mode="w",
-            encoding=ENCODING,
-        ) as outfile:
-            outfile.write(dataset_contents)
-        with open(
-            os.path.join(DEFAULTS.DATASETS_DIR, "train_dataset.jsonl"),
-            mode="w",
-            encoding=ENCODING,
-        ) as outfile:
-            outfile.write(dataset_contents)
-        result = cli_runner.invoke(
-            lab.ilab,
-            [
-                "--config=DEFAULT",
-                "model",
-                "train",
-                "--legacy",
-                "--input-dir",
-                DEFAULTS.DATASETS_DIR,
-            ],
-        )
-        assert result.exit_code == 0
-        convert_llama_to_gguf_mock.assert_called_once()
-        assert convert_llama_to_gguf_mock.call_args[1]["model"] == Path(
-            "training_results/final"
-        )
-        assert convert_llama_to_gguf_mock.call_args[1]["pad_vocab"] is True
-        assert len(convert_llama_to_gguf_mock.call_args[1]) == 2
-        linux_train_mock.assert_called_once()
-        assert linux_train_mock.call_args[1]["train_file"] == Path(
-            os.path.join(DEFAULTS.DATASETS_DIR, "train_gen.jsonl")
-        )
-        assert linux_train_mock.call_args[1]["test_file"] == Path(
-            os.path.join(DEFAULTS.DATASETS_DIR, "test_gen.jsonl")
-        )
-        assert linux_train_mock.call_args[1]["num_epochs"] == 10
-        assert linux_train_mock.call_args[1]["train_device"] is not None
-        assert not linux_train_mock.call_args[1]["four_bit_quant"]
-        assert len(linux_train_mock.call_args[1]) == 7
-        is_macos_with_m_chip_mock.assert_called_once()
-        assert not os.path.isfile(LINUX_GGUF_FILE)
 
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=True)
     @patch(
@@ -538,9 +457,6 @@ class TestLabTrain:
                     DEFAULTS.DATASETS_DIR,
                 ],
             )
-            print(f"{result.exception=}")
-            print(f"{result.output=}")
-            print(f"{result.stdout=}")
             assert result.exception is None
             assert result.exit_code == 0
             convert_llama_to_gguf_mock.assert_called_once()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 # Standard
 from unittest.mock import Mock, patch
+import typing
 
 # Third Party
 import git
@@ -10,6 +11,7 @@ import yaml
 
 # First Party
 from instructlab import utils
+from instructlab.utils import Message, MessageSample
 
 
 class TestUtils:
@@ -28,6 +30,157 @@ class TestUtils:
                 skip_checkout=True,
             )
             git_clone_checkout.assert_called_once()
+
+    def test_convert_to_legacy_from_pretraining_messages(
+        self,
+    ):
+        new_dataset: typing.List[MessageSample] = [
+            {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are a friendly assistant",
+                    },
+                    {
+                        "role": "pretraining",
+                        "content": "<|user|>What is 2+2?<|assistant|>2+2=4",
+                    },
+                ],
+                "group": " test",
+                "dataset": "test-dataset",
+                "metadata": "test",
+            }
+        ]
+        legacy = utils.ensure_legacy_dataset(new_dataset)
+        assert len(legacy) == 1
+        assert legacy[0]["system"] == "You are a friendly assistant"
+        assert legacy[0]["user"] == "What is 2+2?"
+        assert legacy[0]["assistant"] == "2+2=4"
+
+    @pytest.mark.parametrize(
+        "content,exception,match",
+        [
+            ("<|user|>What is 2+2? 2+2=4", ValueError, "<|assistant|>"),
+            ("<|assistant|>2+2=4", ValueError, "<|user|>"),
+            ("<|user|>what is 2+2?<|assistant|>2+2=4", None, ""),
+        ],
+    )
+    def test_invalid_pretraining_messages(
+        self, content: str, exception: Exception | None, match: str
+    ):
+        new_dataset: typing.List[MessageSample] = [
+            {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are a friendly assistant",
+                    },
+                    {
+                        "role": "pretraining",
+                        "content": content,
+                    },
+                ],
+                "group": " test",
+                "dataset": "test-dataset",
+                "metadata": "test",
+            }
+        ]
+        if exception:
+            with pytest.raises(ValueError, match=match):
+                utils.ensure_legacy_dataset(new_dataset)
+        else:
+            utils.ensure_legacy_dataset(new_dataset)
+
+    def test_pretraining_messages_without_system(self):
+        new_dataset: typing.List[MessageSample] = [
+            {
+                "messages": [
+                    {
+                        "role": "pretraining",
+                        "content": "<|user|>What is 2+2?<|assistant|>2+2=4",
+                    },
+                ],
+                "group": " test",
+                "dataset": "test-dataset",
+                "metadata": "test",
+            }
+        ]
+        legacy = utils.ensure_legacy_dataset(new_dataset)
+        assert len(legacy) == 1
+        assert legacy[0]["system"] == ""
+
+    def test_convert_to_legacy_from_messages(self):
+        messages: typing.List[MessageSample] = [
+            {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are a friendly assistant",
+                    },
+                    {"role": "user", "content": "Who is pickle rick?"},
+                    {
+                        "role": "assistant",
+                        "content": "As an AI language model, I have absolutely no idea.",
+                    },
+                ],
+                "group": " test",
+                "dataset": "test-dataset",
+                "metadata": "test",
+            }
+        ]
+        legacy = utils.ensure_legacy_dataset(messages)
+        assert len(legacy) == 1
+        sample = legacy[0]
+        assert sample["system"] == "You are a friendly assistant"
+        assert sample["user"] == "Who is pickle rick?"
+        assert (
+            sample["assistant"] == "As an AI language model, I have absolutely no idea."
+        )
+
+    @pytest.mark.parametrize(
+        "system,user,assistant",
+        [
+            (None, None, None),
+            ("You are a friendly assistant trained by ACME corp", None, None),
+            (None, "Who is pickle rick?", None),
+            (
+                "You are a friendly assistant trained by ACME corp",
+                "Who is pickle rick?",
+                None,
+            ),
+            (None, None, "As an AI language model, I have absolutely no idea."),
+            (
+                "You are a friendly assistant trained by ACME corp",
+                None,
+                "As an AI language model, I have absolutely no idea.",
+            ),
+            (
+                None,
+                "Who is pickle rick?",
+                "As an AI language model, I have absolutely no idea.",
+            ),
+        ],
+    )
+    def test_invalid_datasets(
+        self, system: str | None, user: str | None, assistant: str | None
+    ):
+        messages: typing.List[Message] = []
+        if system:
+            messages.append({"content": system, "role": "system"})
+        if user:
+            messages.append({"content": user, "role": "user"})
+        if assistant:
+            messages.append({"content": assistant, "role": "assistant"})
+        dataset: typing.List[MessageSample] = [
+            {
+                "messages": messages,
+                "group": "ACME",
+                "dataset": "The Pickle Rick Collection",
+                "metadata": "{{ pickle: rick, }}",
+            }
+        ]
+        with pytest.raises(ValueError):
+            utils.ensure_legacy_dataset(dataset)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

PR #1644 introduced a dataset conversion utility which provided the ability for datasets
in the HuggingFaces messages format to be converted into the legacy format used by Linux train.

However; SDG is now planning on providing a pretraining dataset which is represented as
phase007. This new dataset will usually only contain only a single message which can be identified
by the `pretraining` role inside the `messages` list. E.g.:

```json
{
	"messages": [
		{
			"role": "pretraining",
			"content": "<|user|>Why did the chicken cross the road?<|assistant|>To get to the other side!"
		}
	]
}
```

This PR provides support for this new dataset format by identifying if a dataset contains the
`pretraining` sample and then parsing it out to map into the legacy sample format:
```json
{
	"user": "Why did the chicken cross the road?",
	"assistant": "To get to the other side!",
	"system": ""
}
```


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
