### PR TITLE
Fix config error reporting

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -599,7 +599,7 @@ class Lab:
         `ilab config init`. First level subcommand functions call this
         method when they need a config for one of their subcommands.
         """
-        if self.config is None:
+        if self.error_msg is not None:
             ctx.fail(self.error_msg)
 
 


### PR DESCRIPTION
My commit 15c9df78 introduces a bug in config loading. A missing or invalid `config.yaml` no longer raised an error. The bug was originally found by Alina Ryan.

The test suite now checks for required and optional config file for every command and sub command.

**Issue resolved by this Pull Request:**
Resolves #1834
Resolves #1831

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
