### PR TITLE
taxonomy: Remove click default for --taxonomy-path

### DIFF
--- a/src/instructlab/taxonomy/diff.py
+++ b/src/instructlab/taxonomy/diff.py
@@ -11,7 +11,6 @@ import yaml
 
 # First Party
 from instructlab import clickext
-from instructlab.configuration import DEFAULTS
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +20,6 @@ logger = logging.getLogger(__name__)
     "--taxonomy-path",
     type=click.Path(),
     help="Path to where the taxonomy is stored locally.",
-    default=lambda: DEFAULTS.TAXONOMY_DIR,
     show_default="Default taxonomy location in the instructlab data directory.",
 )
 @click.option(


### PR DESCRIPTION
This default value always results in the `DEFAULTS.TAXONOMY_DIR` being used when `--taxonomy-path` is not specified on the command line. This then ignores the `taxonomy_path` in the config.yaml.

Resolves: #2086

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
