### PR TITLE
deps: limit upper bound for torch dep to 2.3.z

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,8 +33,8 @@ sentencepiece>=0.2.0
 tokenizers>=0.11.1
 toml>=0.10.2
 # Habana Labs 1.16.2 has PyTorch 2.2.2a0+gitxxx pre-release
-torch>=2.2.2a0,<3.0.0 ; python_version == '3.10'
-torch>=2.3.0,<3.0.0 ; python_version >= '3.11'
+torch>=2.2.2a0,<2.4.0 ; python_version == '3.10'
+torch>=2.3.0,<2.4.0 ; python_version >= '3.11'
 tqdm>=4.66.2
 # 'optimum' for Intel Gaudi needs transformers <4.41.0,>=4.40.0
 transformers>=4.40.0 ; python_version == '3.10'

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -6,7 +6,7 @@ optimum-habana>=1.12.0
 # Habana Labs 1.16.2 has NumPy 1.23.5
 numpy>=1.23.5,<2.0.0
 # Habana Labs 1.16.2 has PyTorch 2.2.2a0+gitxxx pre-release
-torch>=2.2.2a0,<3.0.0
+torch>=2.2.2a0,<2.4.0
 # Habana Labs frameworks
 habana-torch-plugin>=1.16.2
 habana_gpu_migration>=1.16.2


### PR DESCRIPTION
PyTorch 2.4.0 has been released, but for now we want to keep the upper bound for this dependency to 2.3.z

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
