### PR TITLE
introduce backends.common to reduce circular dependencies

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -31,26 +31,11 @@ from ...client import check_api_base
 from ...configuration import _serve as serve_config
 from ...configuration import get_api_base, get_model_family
 from ...utils import split_hostport
+from .common import CHAT_TEMPLATE_AUTO, LLAMA_CPP, VLLM, templates
 
 logger = logging.getLogger(__name__)
 
-LLAMA_CPP = "llama-cpp"
-VLLM = "vllm"
 SUPPORTED_BACKENDS = frozenset({LLAMA_CPP, VLLM})
-API_ROOT_WELCOME_MESSAGE = "Hello from InstructLab! Visit us at https://instructlab.ai"
-CHAT_TEMPLATE_AUTO = "auto"
-CHAT_TEMPLATE_TOKENIZER = "tokenizer"
-
-templates = [
-    {
-        "model": "merlinite",
-        "template": "{% for message in messages %}\n{% if message['role'] == 'user' %}\n{{ '<|user|>\n' + message['content'] }}\n{% elif message['role'] == 'system' %}\n{{ '<|system|>\n' + message['content'] }}\n{% elif message['role'] == 'assistant' %}\n{{ '<|assistant|>\n' + message['content'] + eos_token }}\n{% endif %}\n{% if loop.last and add_generation_prompt %}\n{{ '<|assistant|>' }}\n{% endif %}\n{% endfor %}",
-    },
-    {
-        "model": "mixtral",
-        "template": "{{ bos_token }}\n{% for message in messages %}\n{% if message['role'] == 'user' %}\n{{ '[INST] ' + message['content'] + ' [/INST]' }}\n{% elif message['role'] == 'assistant' %}\n{{ message['content'] + eos_token}}\n{% endif %}\n{% endfor %}",
-    },
-]
 
 
 class Closeable(typing.Protocol):

--- a/src/instructlab/model/backends/common.py
+++ b/src/instructlab/model/backends/common.py
@@ -1,0 +1,20 @@
+# Standard
+import logging
+
+logger = logging.getLogger(__name__)
+
+API_ROOT_WELCOME_MESSAGE = "Hello from InstructLab! Visit us at https://instructlab.ai"
+CHAT_TEMPLATE_AUTO = "auto"
+CHAT_TEMPLATE_TOKENIZER = "tokenizer"
+LLAMA_CPP = "llama-cpp"
+VLLM = "vllm"
+templates = [
+    {
+        "model": "merlinite",
+        "template": "{% for message in messages %}\n{% if message['role'] == 'user' %}\n{{ '<|user|>\n' + message['content'] }}\n{% elif message['role'] == 'system' %}\n{{ '<|system|>\n' + message['content'] }}\n{% elif message['role'] == 'assistant' %}\n{{ '<|assistant|>\n' + message['content'] + eos_token }}\n{% endif %}\n{% if loop.last and add_generation_prompt %}\n{{ '<|assistant|>' }}\n{% endif %}\n{% endfor %}",
+    },
+    {
+        "model": "mixtral",
+        "template": "{{ bos_token }}\n{% for message in messages %}\n{% if message['role'] == 'user' %}\n{{ '[INST] ' + message['content'] + ' [/INST]' }}\n{% elif message['role'] == 'assistant' %}\n{{ message['content'] + eos_token}}\n{% endif %}\n{% endfor %}",
+    },
+]

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -21,10 +21,6 @@ import llama_cpp.server.app as llama_app
 from ...client import check_api_base
 from ...configuration import get_api_base
 from .backends import (
-    API_ROOT_WELCOME_MESSAGE,
-    CHAT_TEMPLATE_AUTO,
-    CHAT_TEMPLATE_TOKENIZER,
-    LLAMA_CPP,
     BackendServer,
     ServerException,
     UvicornServer,
@@ -33,6 +29,12 @@ from .backends import (
     get_uvicorn_config,
     is_temp_server_running,
     verify_template_exists,
+)
+from .common import (
+    API_ROOT_WELCOME_MESSAGE,
+    CHAT_TEMPLATE_AUTO,
+    CHAT_TEMPLATE_TOKENIZER,
+    LLAMA_CPP,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -17,9 +17,6 @@ import httpx
 # Local
 from ...configuration import get_api_base
 from .backends import (
-    CHAT_TEMPLATE_AUTO,
-    CHAT_TEMPLATE_TOKENIZER,
-    VLLM,
     BackendServer,
     Closeable,
     ServerException,
@@ -29,6 +26,7 @@ from .backends import (
     shutdown_process,
     verify_template_exists,
 )
+from .common import CHAT_TEMPLATE_AUTO, CHAT_TEMPLATE_TOKENIZER, VLLM
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The backends module and modules llama_cpp and vllm have circular dependency, which is anti-pattern.

The backends module, along with the llama_cpp and vllm modules, have a circular dependencies, which is considered an anti-pattern."
    
This PR is intentionally kept small to facilitate an easier code review. The plan is to relocate the relevant code from `backends` to `common` in a subsequent PR, eliminating the circular dependency entirely.

Current state:
```mermaid
graph LR;
  backends --> llama_cpp
  llama_cpp --> backends
  backends --> vllm
  vllm --> backends
```
Desired state:

```mermaid
graph LR;
  backends --> llama_cpp
  llama_cpp -->common
  backends --> common
  backends --> vllm
  vllm --> common
```

References:
1. https://en.wikipedia.org/wiki/Circular_dependency
2. https://en.wikipedia.org/wiki/Acyclic_dependencies_principle