### PR TITLE
tests: Don't access result.stderr from cliRunner

### DIFF
--- a/tests/test_lab_config.py
+++ b/tests/test_lab_config.py
@@ -10,7 +10,7 @@ from instructlab import configuration, lab
 
 def test_ilab_config_show(cli_runner: CliRunner) -> None:
     result = cli_runner.invoke(lab.ilab, ["--config", "DEFAULT", "config", "show"])
-    assert result.exit_code == 0, result.stderr
+    assert result.exit_code == 0, result.stdout
 
     parsed = yaml.safe_load(result.stdout_bytes)
     assert parsed


### PR DESCRIPTION
Our cliRunner mixes stderr and stdout (mix_stderr=True is the default for the click runner.) So, accessing result.stderr won't work.

