### PR TITLE
ci: ensure $FULLTRAIN for 4xA10 workflow

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -145,7 +145,7 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           . venv/bin/activate
-          ./scripts/basic-workflow-tests.sh -mFMT
+          ./scripts/basic-workflow-tests.sh -mfFMT
 
       - name: Add comment to PR if the workflow failed
         if: failure() && steps.check_pr.outputs.is_pr == 'true'


### PR DESCRIPTION
The 4xA10 workflow is intended to mirror the full ilab workflow. If `FULLTRAIN`  is set to `0` the final ilab chat and serve aren't run (https://github.com/instructlab/instructlab/blob/main/scripts/basic-workflow-tests.sh#L304). If the evaluation flag was specified in the future it would not be run as well.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
