### PR TITLE
feat: display default dirs in `ilab system info`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * The `generate` section of the config now has a `teacher` section. This section configures the
   teacher model when it is automatically served in the background. This new section has the same
   values as the `serve` section of the config.
+* `ilab system info` now includes the default config, data, and cache directories used by `ilab`.
 
 ### Breaking Changes
 

--- a/src/instructlab/system/info.py
+++ b/src/instructlab/system/info.py
@@ -11,6 +11,7 @@ import click
 
 # First Party
 from instructlab import clickext
+from instructlab.configuration import DEFAULTS
 
 
 def _platform_info() -> typing.Dict[str, typing.Any]:
@@ -130,6 +131,33 @@ def _instructlab_info():
     return {f"{name}.version": ver for name, ver in pkgs}
 
 
+def _default_paths() -> dict[str, str]:
+    """Default directories used by ilab"""
+    # d = {
+    #     "defaults.chatlogs_dir": DEFAULTS.CHATLOGS_DIR,
+    #     "defaults.checkpoints_dir": DEFAULTS.CHECKPOINTS_DIR,
+    #     "defaults.config_file": DEFAULTS.CONFIG_FILE,
+    #     "defaults.datasets_dir": DEFAULTS.DATASETS_DIR,
+    #     "defaults.eval_data_dir": DEFAULTS.EVAL_DATA_DIR,
+    #     "defaults.internal_data_dir": DEFAULTS.INTERNAL_DIR,
+    #     "defaults.models_dir": DEFAULTS.MODELS_DIR,
+    #     "defaults.model": DEFAULTS.DEFAULT_MODEL,
+    #     "defaults.prompt_file": DEFAULTS.PROMPT_FILE,
+    #     "defaults.seed_file": DEFAULTS.SEED_FILE,
+    #     "defaults.taxonomy_dir": DEFAULTS.TAXONOMY_DIR,
+    #     "defaults.train_additional_options_dir": DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_DIR,
+    #     "defaults.train_config_dir": DEFAULTS.TRAIN_CONFIG_DIR,
+    #     "defaults.train_additional_options_file": DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_FILE,
+    #     "defaults.train_profile_dir": DEFAULTS.TRAIN_PROFILE_DIR,
+    # }
+    d = {
+        "defaults.cache_dir": DEFAULTS._cache_home,
+        "defaults.data_dir": DEFAULTS._data_dir,
+        "defaults.config_home": DEFAULTS._cache_home,
+    }
+    return d
+
+
 def get_sysinfo() -> typing.Dict[str, typing.Any]:
     """Get system information"""
     d = {}
@@ -139,6 +167,7 @@ def get_sysinfo() -> typing.Dict[str, typing.Any]:
     d.update(_torch_cuda_info())
     d.update(_torch_hpu_info())
     d.update(_llama_cpp_info())
+    d.update(_default_paths())
     return d
 
 


### PR DESCRIPTION
With the introduction of persistent storage, it has become easier for ilab to manage
data, but harder for the user to. This commit adds 3 fields to `ilab system info` which
display where the default cache, data, and config directories are.

Resolves #1858 

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.


This is how the output of `ilab system info` now looks with this PR:

```
(venv) osilkin:instructlab/ (list-default-dirs✗) $ ilab system info                                                                                                                                                                                                                                                          [0:25:47]
sys.version: 3.11.8 (main, Jul  3 2024, 13:50:00) [Clang 15.0.0 (clang-1500.3.9.4)]
sys.platform: darwin
os.name: posix
platform.release: 23.5.0
platform.machine: arm64
instructlab.version: 0.18.0a7.dev4
instructlab-dolomite.version: 0.0.1
instructlab-eval.version: 0.1.0
instructlab-quantize.version: 0.1.0
instructlab-schema.version: 0.3.1
instructlab-sdg.version: 0.2.0
instructlab-training.version: 0.3.0
torch.version: 2.3.1
torch.backends.cpu.capability: NO AVX
torch.version.cuda: None
torch.version.hip: None
torch.cuda.available: False
torch.backends.cuda.is_built: False
torch.backends.mps.is_built: True
torch.backends.mps.is_available: True
llama_cpp_python.version: 0.2.79
llama_cpp_python.supports_gpu_offload: True
defaults.cache_dir: /Users/osilkin/Library/Caches/instructlab
defaults.data_dir: /Users/osilkin/Library/Application Support/instructlab
defaults.config_home: /Users/osilkin/Library/Caches/instructlab
```

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
