### PR TITLE
chore: Bump vLLM version to 2024.07.24 on ODH branch

### DIFF
--- a/requirements-vllm-cuda.txt
+++ b/requirements-vllm-cuda.txt
@@ -2,4 +2,4 @@
 # Dependencies for installing vLLM on CUDA
 
 # vLLM only supports Linux platform (including WSL)
-vllm @git+https://github.com/opendatahub-io/vllm@2024.07.17 ; sys_platform == 'linux' and platform_machine == 'x86_64'
+vllm @git+https://github.com/opendatahub-io/vllm@2024.07.24 ; sys_platform == 'linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
Release includes 2 patches:
- Support for allowed_token_ids request parameter
  + Necessary for SDG
- bitsandbytes support for reading pre-quantized models
  + Necessary to serve quantized training library checkpoints

No tests are added since these will be covered by the e2e improvements