### PR TITLE
init: adjust config found prompt

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -76,7 +76,7 @@ def init(
     if interactive:
         if exists(DEFAULTS.CONFIG_FILE):
             overwrite = click.confirm(
-                f"Found {DEFAULTS.CONFIG_FILE} in the current directory, do you still want to continue?"
+                f"Found {DEFAULTS.CONFIG_FILE}, do you still want to continue?"
             )
             if not overwrite:
                 return


### PR DESCRIPTION
Since 3c73191ebd6bda30f760456769e092d8a2467bbe the message doesn't make sense, as it's not in the current directory. The message needs to be adjusted.