### PR TITLE
fix: remove useless try-expect

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -193,23 +193,20 @@ def determine_backend(model_path: pathlib.Path) -> Tuple[str, str]:
                         - The backend to use.
                         - The reason why the backend was selected.
     """
-    try:
-        if model_path.is_dir() and is_model_safetensors(model_path):
-            if sys.platform == "linux":
-                logger.debug(
-                    f"Model is huggingface safetensors and system is Linux, using {VLLM} backend."
-                )
-                return (
-                    VLLM,
-                    "model path is a directory containing huggingface safetensors files and running on Linux.",
-                )
-            raise ValueError(
-                "Model is a directory containing huggingface safetensors files but the system is not Linux. "
-                "Using a directory with safetensors file will activate the vLLM serving backend, vLLM is only supported on Linux. "
-                "If you want to run the model on a different system (e.g. macOS), please use a GGUF file."
+    if model_path.is_dir() and is_model_safetensors(model_path):
+        if sys.platform == "linux":
+            logger.debug(
+                f"Model is huggingface safetensors and system is Linux, using {VLLM} backend."
             )
-    except Exception as e:
-        raise ValueError from e
+            return (
+                VLLM,
+                "model path is a directory containing huggingface safetensors files and running on Linux.",
+            )
+        raise ValueError(
+            "Model is a directory containing huggingface safetensors files but the system is not Linux. "
+            "Using a directory with safetensors file will activate the vLLM serving backend, vLLM is only supported on Linux. "
+            "If you want to run the model on a different system (e.g. macOS), please use a GGUF file."
+        )
 
     # Check if the model is a GGUF file
     try:


### PR DESCRIPTION
We don't expect any `ValueError` coming from `is_model_safetensors()`.
So the try-expect is not needed.

Closes: https://github.com/instructlab/instructlab/issues/1866
Co-authored-by: Ihar Hrachyshka <ihrachys@redhat.com>
Signed-off-by: Sébastien Han <seb@redhat.com>


<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
