### PR TITLE
Fix --help return code when config is missing (Was: Don't expect Lab or Lab.config to be a None)

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -19,6 +19,7 @@ from instructlab import clickext, utils
 from instructlab.configuration import (
     DEFAULTS,
     Config,
+    Lab,
     ensure_storage_directories_exist,
     get_default_config,
     read_config,
@@ -400,11 +401,7 @@ def check_if_configs_exist(fresh_install) -> bool:
     return False
 
 
-def get_params_from_env(
-    obj: typing.Optional[typing.Any],
-) -> typing.Tuple[str, str, Config]:
-    if obj is None or not hasattr(obj, "config"):
-        raise ValueError("obj must not be None and must have a 'config' attribute")
+def get_params_from_env(obj: Lab) -> typing.Tuple[str, str, Config]:
     return (
         obj.config.generate.taxonomy_path,
         obj.config.generate.taxonomy_base,

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1417,7 +1417,6 @@ class Lab:
 def init(
     ctx: click.Context, config_file: str | os.PathLike[str], debug_level: int = 0
 ) -> None:
-    config_obj: Config
     error_msg: str | None = None
     if config_file == "DEFAULT":
         # if user passed --config DEFAULT we should ensure all proper dirs are created
@@ -1447,29 +1446,26 @@ def init(
         error_msg = None
 
     ctx.obj = Lab(config_obj, config_file, error_msg)
-    if config_obj is not None:
-        ctx.default_map = get_dict(config_obj)
+    ctx.default_map = get_dict(config_obj)
 
-        # --verbose option overrides config file
-        if debug_level > 0:
-            config_obj.general.log_level = "DEBUG"
-            config_obj.general.debug_level = debug_level
+    # --verbose option overrides config file
+    if debug_level > 0:
+        config_obj.general.log_level = "DEBUG"
+        config_obj.general.debug_level = debug_level
 
-        # setup logging
-        log.configure_logging(
-            log_level=config_obj.general.log_level.upper(),
-            debug_level=config_obj.general.debug_level,
-            fmt=config_obj.general.log_format,
-        )
+    # setup logging
+    log.configure_logging(
+        log_level=config_obj.general.log_level.upper(),
+        debug_level=config_obj.general.debug_level,
+        fmt=config_obj.general.log_format,
+    )
 
-        # subtly get the additional args per cfg section
-        # if any are missing, add in sane defaults
-        train_additional = ctx.default_map["train"]["additional_args"]
-        ctx.default_map["train"]["additional_args"] = finish_additional_train_args(
-            train_additional
-        )
-    else:
-        ctx.default_map = None
+    # subtly get the additional args per cfg section
+    # if any are missing, add in sane defaults
+    train_additional = ctx.default_map["train"]["additional_args"]
+    ctx.default_map["train"]["additional_args"] = finish_additional_train_args(
+        train_additional
+    )
 
 
 def map_train_to_library(ctx, params):


### PR DESCRIPTION
These cleanups were identified in https://github.com/instructlab/instructlab/pull/1842 and https://github.com/instructlab/instructlab/pull/1847#discussion_r1690148608

It also fixes scenario where --help was returning 2 or 0 depending on whether config file was present.