### PR TITLE
evaluate: add stdout line to show what model is being evaluated

### DIFF
--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -100,6 +100,10 @@ def get_evaluator(
                     fg="red",
                 )
                 raise click.exceptions.Exit(1)
+            click.secho(
+                f"Using local model found at '{model}' for '--model'",
+                fg="blue",
+            )
         if benchmark == Benchmark.MT_BENCH:
             # Third Party
             from instructlab.eval.mt_bench import MTBenchEvaluator
@@ -148,6 +152,15 @@ def get_evaluator(
                     fg="red",
                 )
                 raise click.exceptions.Exit(1)
+            click.secho(
+                f"Using local safetensors found at '{model}' for '--model'",
+                fg="blue",
+            )
+        else:
+            click.secho(
+                f"Using safetensors from Hugging Face repo '{model}' for '--model'",
+                fg="blue",
+            )
         if benchmark == Benchmark.MMLU:
             # Third Party
             from instructlab.eval.mmlu import MMLUEvaluator

--- a/tests/test_lab_evaluate.py
+++ b/tests/test_lab_evaluate.py
@@ -94,9 +94,9 @@ def run_mt_bench(cli_runner, error_rate):
             "--benchmark",
             "mt_bench",
             "--model",
-            "models/instructlab/granite-7b-lab",
+            "instructlab/granite-7b-lab",
             "--judge-model",
-            "models/instructlab/merlinite-7b-lab",
+            "instructlab/merlinite-7b-lab",
         ],
     )
     assert result.exit_code == 0
@@ -107,7 +107,7 @@ def run_mt_bench(cli_runner, error_rate):
         # SKILL EVALUATION REPORT
 
         ## MODEL
-        models/instructlab/granite-7b-lab
+        instructlab/granite-7b-lab
 
         ### AVERAGE:
         1.5 (across 2)
@@ -140,11 +140,11 @@ def run_mt_bench_branch(cli_runner, error_rate):
             "--benchmark",
             "mt_bench_branch",
             "--model",
-            "models/instructlab/granite-7b-lab",
+            "instructlab/granite-7b-lab",
             "--judge-model",
-            "models/instructlab/merlinite-7b-lab",
+            "instructlab/merlinite-7b-lab",
             "--base-model",
-            "models/instructlab/granite-7b-lab",
+            "instructlab/granite-7b-lab",
             "--branch",
             "rc",
             "--base-branch",
@@ -163,10 +163,10 @@ def run_mt_bench_branch(cli_runner, error_rate):
         # SKILL EVALUATION REPORT
 
         ## BASE MODEL
-        models/instructlab/granite-7b-lab
+        instructlab/granite-7b-lab
 
         ## MODEL
-        models/instructlab/granite-7b-lab
+        instructlab/granite-7b-lab
 
         ### IMPROVEMENTS:
         1. category1/qna.yaml (+0.1)
@@ -266,17 +266,18 @@ def test_evaluate_mmlu(run_mock, cli_runner: CliRunner):
             "--benchmark",
             "mmlu",
             "--model",
-            "models/instructlab/granite-7b-lab",
+            "instructlab/granite-7b-lab",
         ],
     )
     run_mock.assert_called_once()
     assert result.exit_code == 0
     expected = textwrap.dedent(
         """\
+        Using safetensors from Hugging Face repo 'instructlab/granite-7b-lab' for '--model'
         # KNOWLEDGE EVALUATION REPORT
 
         ## MODEL
-        models/instructlab/granite-7b-lab
+        instructlab/granite-7b-lab
 
         ### AVERAGE:
         0.5 (across 2)
@@ -306,9 +307,9 @@ def test_evaluate_mmlu_branch(run_mock, cli_runner: CliRunner):
             "--benchmark",
             "mmlu_branch",
             "--model",
-            "models/instructlab/granite-7b-lab",
+            "instructlab/granite-7b-lab",
             "--base-model",
-            "models/instructlab/granite-7b-lab",
+            "instructlab/granite-7b-lab",
             "--tasks-dir",
             "generated",
         ],
@@ -317,13 +318,14 @@ def test_evaluate_mmlu_branch(run_mock, cli_runner: CliRunner):
     assert result.exit_code == 0
     expected = textwrap.dedent(
         """\
+        Using safetensors from Hugging Face repo 'instructlab/granite-7b-lab' for '--model'
         # KNOWLEDGE EVALUATION REPORT
 
         ## BASE MODEL
-        models/instructlab/granite-7b-lab
+        instructlab/granite-7b-lab
 
         ## MODEL
-        models/instructlab/granite-7b-lab
+        instructlab/granite-7b-lab
 
         ### AVERAGE:
         -0.1 (across 5)
@@ -386,7 +388,7 @@ def test_invalid_model_mt_bench(cli_runner: CliRunner):
             "--model",
             "invalid",
             "--judge-model",
-            "models/instructlab/merlinite-7b-lab",
+            "instructlab/merlinite-7b-lab",
         ],
     )
     assert "Failed to determine backend:" in result.output
@@ -424,11 +426,11 @@ def test_invalid_taxonomy_mt_bench_branch(launch_server_mock, cli_runner: CliRun
             "--benchmark",
             "mt_bench_branch",
             "--model",
-            "models/instructlab/granite-7b-lab",
+            "instructlab/granite-7b-lab",
             "--judge-model",
-            "models/instructlab/merlinite-7b-lab",
+            "instructlab/merlinite-7b-lab",
             "--base-model",
-            "models/instructlab/granite-7b-lab",
+            "instructlab/granite-7b-lab",
             "--branch",
             "rc",
             "--base-branch",
@@ -457,11 +459,11 @@ def test_invalid_branch_mt_bench_branch(launch_server_mock, cli_runner: CliRunne
             "--benchmark",
             "mt_bench_branch",
             "--model",
-            "models/instructlab/granite-7b-lab",
+            "instructlab/granite-7b-lab",
             "--judge-model",
-            "models/instructlab/merlinite-7b-lab",
+            "instructlab/merlinite-7b-lab",
             "--base-model",
-            "models/instructlab/granite-7b-lab",
+            "instructlab/granite-7b-lab",
             "--branch",
             "invalid",
             "--base-branch",
@@ -485,9 +487,9 @@ def test_invalid_tasks_dir(cli_runner: CliRunner):
             "--benchmark",
             "mmlu_branch",
             "--model",
-            "models/instructlab/granite-7b-lab",
+            "instructlab/granite-7b-lab",
             "--base-model",
-            "models/instructlab/granite-7b-lab",
+            "instructlab/granite-7b-lab",
             "--tasks-dir",
             "invalid",
         ],


### PR DESCRIPTION
currently there is no indication to users what model is being used when running evaluation. this PR exposes this so it is always clear to the user what is going on.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
