### PR TITLE
Dont read default config in tests

### DIFF
--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -189,7 +189,7 @@ def test_ilab_missing_config(command: Command, cli_runner: CliRunner) -> None:
     result = cli_runner.invoke(lab.ilab, cmd)
 
     if command.needs_config:
-        assert result.exit_code == 2, result
+        assert result.exit_code == 2, result.stdout
         assert "does not exist or is not a readable file" in result.stdout
     else:
-        assert result.exit_code == 0, result
+        assert result.exit_code == 0, result.stdout

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -180,6 +180,12 @@ def test_ilab_commands_tested():
 def test_ilab_missing_config(command: Command, cli_runner: CliRunner) -> None:
     cmd = command.get_args(default_config=False)
     assert "--config" not in cmd
+
+    # make sure cli doesn't attempt to read config from the default location
+    # (which may actually exist)
+    if command.needs_config:
+        cmd = ["--config", "./non-existing.yaml"] + cmd
+
     result = cli_runner.invoke(lab.ilab, cmd)
 
     if command.needs_config:


### PR DESCRIPTION
The tests were failing depending on whether the config file existed in the usual location.