### PR TITLE
Properly isolate tests from default config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,18 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install tox tox-gh>=1.2
 
+      # see https://github.com/instructlab/instructlab/issues/1886
+      - name: Verify test isolation
+        run: |
+          mkdir -p ~/.config/instructlab
+          echo "broken" > ~/.config/instructlab/config.yaml
+          
+          mkdir -p ~/.cache
+          echo "not a directory" > ~/.cache/instructlab
+          
+          mkdir -p ~/.local/share
+          echo "not a directory" > ~/.local/share/instructlab
+
       - name: Run unit and functional tests with tox
         run: |
           tox


### PR DESCRIPTION
Mock patch default setting for `--config-file` option in `tmp_path_home` to ensure that tests are properly isolated from the user's environment.

**Issue resolved by this Pull Request:**
Resolves #1886

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
