### PR TITLE
feat: improve management of downloaded models 

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -26,6 +26,7 @@ Gmail
 HPU
 Habana
 Heimes
+Hugging Face
 ISA
 Inferencing
 JIT
@@ -124,6 +125,7 @@ gpu
 gpus
 habana
 hipBLAS
+huggingface
 ibmcloud
 ilab
 impactful

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v0.22
+
+### Breaking Changes
+
+* `ilab model list` will not automatically show previously downloaded GGUF model files present in the directory `~/.cache/instructlab/models`. Users will need to move these GGUF files into individual folders for them to appear in `ilab model list`.
+
+### Features
+
+* `ilab model download` now creates sub-directories for each downloaded model, that match the model's repository URL. Users can now download and store multiple versions of the same model. Each model is tracked with a new metadata file that is written out to disk.
+Users can now also supply GGUF models as directories instead of files, similar to how Safetensors models are handled. Users can now also specify a tag embedded in the repository and optionally prefix Huggingface downloads with "huggingface.co/"
+(e.g.: `ilab model download --repository huggingface.co/instructlab/granite-7b-lab:main` or `ilab model download --repository docker://registry.redhat.io/rhelai1/granite-7b-redhat-lab:latest`).
+* `ilab model list` has been updated to include version and SHA information for models.
+
 ## v0.21
 
 ### Breaking Changes

--- a/scripts/e2e-ci.sh
+++ b/scripts/e2e-ci.sh
@@ -32,6 +32,9 @@ MERLINITE_GGUF_MODEL="merlinite-7b-lab-Q4_K_M.gguf"
 MISTRAL_GGUF_REPO="TheBloke/Mistral-7B-Instruct-v0.2-GGUF"
 MISTRAL_GGUF_MODEL="mistral-7b-instruct-v0.2.Q4_K_M.gguf"
 
+HUGGINGFACE_DIR="huggingface.co"
+
+
 # t-shirt size globals
 SMALL=0
 MEDIUM=0
@@ -69,6 +72,8 @@ init_e2e_tests() {
     CONFIG_HOME=$(python -c 'import platformdirs; print(platformdirs.user_config_dir())')
     DATA_HOME=$(python -c 'import platformdirs; print(platformdirs.user_data_dir())')
     CACHE_HOME=$(python -c 'import platformdirs; print(platformdirs.user_cache_dir())')
+    MODEL_CACHE="${CACHE_HOME}/instructlab/models"
+
     # ensure that our mock e2e dirs exist
     for dir in "${CONFIG_HOME}" "${DATA_HOME}" "${CACHE_HOME}"; do
         mkdir -p "${dir}"
@@ -147,10 +152,10 @@ test_list() {
     task List the Downloaded Models
     if [ "$SMALL" -eq 1 ]; then
         ilab model list | grep ${GRANITE_7B_MODEL}
-        ilab model list | grep ${MERLINITE_GGUF_MODEL}    
+        ilab model list | grep ${MERLINITE_GGUF_REPO}
     elif [ "$MEDIUM" -eq 1 ]; then
         ilab model list | grep ${GRANITE_7B_MODEL}
-        ilab model list | grep ${MISTRAL_GGUF_MODEL}
+        ilab model list | grep ${MISTRAL_GGUF_REPO}
     elif [ "$LARGE" -eq 1 ]; then
         ilab model list | grep ${GRANITE_7B_MODEL}
         ilab model list | grep ${PROMETHEUS_8X7B_MODEL}
@@ -263,7 +268,7 @@ test_serve() {
     # https://github.com/instructlab/instructlab/issues/579
     # so we skip trying to test the result and just ensure that serve works in general
     if [ "$SMALL" -eq 1 ]; then
-        model_path="${CACHE_HOME}/instructlab/models/${MERLINITE_GGUF_MODEL}"
+        model_path="${MODEL_CACHE}/${HUGGINGFACE_DIR}/${MERLINITE_GGUF_REPO}/main/"
     # use trained gguf for medium-size job
     elif [ "$MEDIUM" -eq 1 ]; then
         model_path="${TRAINED_MODEL_PATH}/pytorch_model-Q4_K_M.gguf"

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -167,10 +167,10 @@ test_oci_model_download_with_vllm_backend(){
     REGISTRY_AUTH_FILE=$HOME/auth.json ilab model download --repository docker://quay.io/instructlab/granite-7b-lab --release latest --model-dir models/instructlab
 
     patterns=(
-        "models/instructlab/granite-7b-lab/config.json"
-        "models/instructlab/granite-7b-lab/tokenizer.json"
-        "models/instructlab/granite-7b-lab/tokenizer_config.json"
-        "models/instructlab/granite-7b-lab/*.safetensors"
+        "models/instructlab/quay.io/ai-lab/models/granite-7b-lab/latest/config.json"
+        "models/instructlab/quay.io/ai-lab/models/granite-7b-lab/latest/tokenizer.json"
+        "models/instructlab/quay.io/ai-lab/models/granite-7b-lab/latest/tokenizer_config.json"
+        "models/instructlab/quay.io/ai-lab/models/granite-7b-lab/latest/*.safetensors"
     )
 
     match_count=0

--- a/src/instructlab/cli/model/train.py
+++ b/src/instructlab/cli/model/train.py
@@ -91,7 +91,7 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     type=click.Path(),
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    default=DEFAULTS.MODEL_REPO,
+    default=DEFAULTS.GRANITE_MODEL_REPO,
 )
 @click.option(
     "--iters",

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -368,7 +368,7 @@ class _evaluate(BaseModel):
         description="Model to be evaluated",
     )
     base_model: str = Field(
-        default=DEFAULTS.MODEL_REPO,
+        default_factory=lambda: DEFAULTS.DEFAULT_MODEL,
         description="Base model to compare with 'model' for mt_bench_branch and mmlu_branch.",
     )
     branch: Optional[str] = Field(
@@ -413,7 +413,7 @@ class _train(BaseModel):
         pattern="simple|full|accelerated",
     )
     model_path: str = Field(
-        default=DEFAULTS.MODEL_REPO,
+        default_factory=lambda: DEFAULTS.DEFAULT_MODEL,
         description="Directory where the model to be trained is stored.",
     )
     device: str = Field(

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -61,7 +61,7 @@ class _InstructlabDefaults:
     GRANITE_GGUF_MODEL_NAME = "granite-7b-lab-Q4_K_M.gguf"
     MERLINITE_GGUF_MODEL_NAME = "merlinite-7b-lab-Q4_K_M.gguf"
     MISTRAL_GGUF_MODEL_NAME = "mistral-7b-instruct-v0.2.Q4_K_M.gguf"
-    MODEL_REPO = "instructlab/granite-7b-lab"
+    GRANITE_MODEL_REPO = "instructlab/granite-7b-lab"
     JUDGE_MODEL_MT = "prometheus-eval/prometheus-8x7b-v2.0"
     TAXONOMY_REPO = "https://github.com/instructlab/taxonomy.git"
     TAXONOMY_BASE = "origin/main"
@@ -75,6 +75,9 @@ class _InstructlabDefaults:
     SDG_PIPELINE = "full"
     SDG_SCALE_FACTOR = 30
     SDG_MAX_NUM_TOKENS = 4096
+
+    HUGGINGFACE_DOMAIN = "huggingface.co"
+    DEFAULT_MODEL_BRANCH = "main"
 
     # When otherwise unknown, ilab uses this as the default family
     MODEL_FAMILY = "granite"
@@ -128,15 +131,39 @@ class _InstructlabDefaults:
 
     @property
     def DEFAULT_CHAT_MODEL(self) -> str:
-        return path.join(self.MODELS_DIR, self.GRANITE_GGUF_MODEL_NAME)
+        return path.join(
+            self.MODELS_DIR,
+            self.HUGGINGFACE_DOMAIN,
+            self.MERLINITE_GGUF_REPO,
+            self.DEFAULT_MODEL_BRANCH,
+        )
+
+    @property
+    def DEFAULT_MODEL(self) -> str:
+        return path.join(
+            self.MODELS_DIR,
+            self.HUGGINGFACE_DOMAIN,
+            self.GRANITE_MODEL_REPO,
+            self.DEFAULT_MODEL_BRANCH,
+        )
 
     @property
     def DEFAULT_TEACHER_MODEL(self) -> str:
-        return path.join(self.MODELS_DIR, self.MISTRAL_GGUF_MODEL_NAME)
+        return path.join(
+            self.MODELS_DIR,
+            self.HUGGINGFACE_DOMAIN,
+            self.MISTRAL_GGUF_REPO,
+            self.DEFAULT_MODEL_BRANCH,
+        )
 
     @property
     def DEFAULT_JUDGE_MODEL(self) -> str:
-        return path.join(self.MODELS_DIR, self.JUDGE_MODEL_MT)
+        return path.join(
+            self.MODELS_DIR,
+            self.HUGGINGFACE_DOMAIN,
+            self.JUDGE_MODEL_MT,
+            self.DEFAULT_MODEL_BRANCH,
+        )
 
     @property
     def TAXONOMY_DIR(self) -> str:

--- a/src/instructlab/model/backends/common.py
+++ b/src/instructlab/model/backends/common.py
@@ -166,7 +166,7 @@ def get_model_template(
 
     # pylint: disable=broad-exception-caught
     except Exception as e:
-        logger.warning(
+        logger.debug(
             f"Unable to read tokenizer config for model: {model_path}: {e}. Falling back to in-memory chat template mapping"
         )
         template, eos_token, bos_token = get_in_memory_model_template(

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -118,12 +118,10 @@ def validate_model(model: str, model_arg: str = "--model", allow_gguf: bool = Tr
     if os.path.exists(model):
         model_path = pathlib.Path(model)
         valid_model = False
-        if model_path.is_dir():
-            valid_model = is_model_safetensors(model_path)
-        elif model_path.is_file():
-            if allow_gguf:
-                valid_model = is_model_gguf(model_path)
-            else:
+        valid_model = is_model_safetensors(model_path)
+        if not valid_model:
+            valid_model = is_model_gguf(model_path)[0]
+            if valid_model and not allow_gguf:
                 click.secho(
                     "MMLU and MMLUBranch can currently only be used with a safetensors directory",
                     fg="red",
@@ -131,7 +129,7 @@ def validate_model(model: str, model_arg: str = "--model", allow_gguf: bool = Tr
                 raise click.exceptions.Exit(1)
         if not valid_model:
             click.secho(
-                f"Evaluate '{model_arg}' needs to be passed either a safetensors directory or a GGUF file",
+                f"Evaluate '{model_arg}' needs to be passed a valid safetensors or GGUF model",
                 fg="red",
             )
             raise click.exceptions.Exit(1)

--- a/src/instructlab/model/list.py
+++ b/src/instructlab/model/list.py
@@ -4,6 +4,8 @@
 from pathlib import Path
 from typing import List
 import logging
+import os
+import re
 
 # Third Party
 import click
@@ -11,7 +13,12 @@ import click
 # First Party
 from instructlab import clickext
 from instructlab.configuration import DEFAULTS
-from instructlab.utils import list_models, print_table
+from instructlab.utils import (
+    convert_bytes_to_proper_mag,
+    get_model_metadata,
+    list_models,
+    print_table,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,9 +39,53 @@ logger = logging.getLogger(__name__)
 )
 def model_list(model_dirs: List[str], list_checkpoints: bool):
     """Lists models"""
+    print(f"All listed models can be found at: {DEFAULTS.MODELS_DIR}")
+
     # click converts lists into tuples when using multiple
     model_path_dirs = [Path(m) for m in model_dirs]
 
-    data = list_models(model_path_dirs, list_checkpoints)
-    data_as_lists = [list(item) for item in data]  # this is to satisfy mypy
-    print_table(["Model Name", "Last Modified", "Size"], data_as_lists)
+    valid_models = list_models(model_path_dirs, list_checkpoints)
+
+    # populate model_info as a dictionary with model name as key
+    # and value as a list of dictionaries. Each dictionary represents
+    # metadata info for a specific version of the model.
+    model_info: dict[str, List[dict]] = {}
+    for model in valid_models:
+        model_metadata, file_found = get_model_metadata(Path(model[0]))
+
+        # calculate model name as the model's path relative to ~/.cache/instructlab/models
+        model_name = os.path.relpath(model[0], model[1])
+
+        # remove version subfolder from model name if metadata
+        # file was found
+        if file_found:
+            model_name = re.sub(r"/[^/]*$", "", model_name)
+
+        if model_name not in model_info:
+            model_info[model_name] = []
+
+        adjusted_all_sizes, magnitude = convert_bytes_to_proper_mag(
+            int(model_metadata["size"])
+        )
+        model_metadata["size"] = f"{adjusted_all_sizes:.1f} {magnitude}"
+        model_info[model_name].append(model_metadata)
+
+    # convert model_info into a list of lists to feed it into the table
+    # each unique model version becomes its own list
+    model_info_as_lists: List[List[str]] = []
+    for key, value in model_info.items():
+        # populate the list for the first version of any model with the model name
+        # this will represent the first row for that model in the table
+        metadata_list = [list(dict.values()) for dict in value]
+        metadata_list[0].insert(0, key)
+
+        # subsequent versions of that model will have empty string as model name to leave a gap
+        # in the table
+        for sublist in metadata_list[1:]:
+            sublist.insert(0, "")
+
+        model_info_as_lists += metadata_list
+
+    print_table(
+        ["Model Name", "Size", "Last Modified", "Version", "SHA"], model_info_as_lists
+    )

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -86,19 +86,18 @@ def test_get_backend_auto_detection_fail_not_gguf(tmp_path: pathlib.Path):
         invalid_header + bytes([0] * 4093)
     )  # Fill the rest of the file with zeros
     with pytest.raises(ValueError) as exc_info:
-        backends.get(tmp_gguf, None)
-    assert "is not a GGUF format" in str(exc_info.value)
+        backends.get(tmp_path, None)
+    assert "is not a GGUF" in str(exc_info.value)
 
 
 # this test succeeds because the model_path is a valid GGUF file (is_model_gguf mocked to returns True)
-@patch("instructlab.model.backends.backends.is_model_gguf", return_value=True)
+@patch("instructlab.model.backends.backends.is_model_gguf", return_value=[True, ""])
 def test_get_backend_auto_detection_success_gguf(
     m_is_model_gguf, tmp_path: pathlib.Path
 ):
-    tmp_gguf = tmp_path / "test.gguf"
-    backend = backends.get(tmp_gguf, None)
+    backend = backends.get(tmp_path, None)
     assert backend == "llama-cpp"
-    m_is_model_gguf.assert_called_once_with(tmp_gguf)
+    m_is_model_gguf.assert_called_once_with(tmp_path)
 
 
 # this tests both cases where a valid and invalid safetensors model directory is supplied

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,8 +30,10 @@ class TestConfig:
         internal_dirname = "internal"
         cache_dir = os.path.join(xdg_cache_home(), package_name)
         data_dir = os.path.join(xdg_data_home(), package_name)
-        default_chat_model = f"{cache_dir}/models/granite-7b-lab-Q4_K_M.gguf"
-        default_sdg_model = f"{cache_dir}/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf"
+        default_chat_model = (
+            f"{cache_dir}/models/huggingface.co/instructlab/merlinite-7b-lab-GGUF/main"
+        )
+        default_sdg_model = f"{cache_dir}/models/huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/main"
 
         assert cfg.general is not None
         assert cfg.version is not None
@@ -90,13 +92,18 @@ class TestConfig:
     def _assert_model_defaults(self, cfg):
         package_name = "instructlab"
         cache_dir = os.path.join(xdg_cache_home(), package_name)
-        default_chat_model = f"{cache_dir}/models/granite-7b-lab-Q4_K_M.gguf"
+        default_chat_model = (
+            f"{cache_dir}/models/huggingface.co/instructlab/merlinite-7b-lab-GGUF/main"
+        )
+        base_model = (
+            f"{cache_dir}/models/huggingface.co/instructlab/granite-7b-lab/main"
+        )
 
         assert cfg.chat is not None
         assert cfg.chat.model == default_chat_model
 
         assert cfg.evaluate is not None
-        assert cfg.evaluate.base_model == "instructlab/granite-7b-lab"
+        assert cfg.evaluate.base_model == base_model
 
         assert cfg.generate is not None
         assert cfg.generate.model == DEFAULTS.DEFAULT_TEACHER_MODEL
@@ -105,7 +112,7 @@ class TestConfig:
         assert cfg.serve.model_path == DEFAULTS.DEFAULT_CHAT_MODEL
 
         assert cfg.train is not None
-        assert cfg.train.model_path == "instructlab/granite-7b-lab"
+        assert cfg.train.model_path == base_model
 
     def test_default_config(self, cli_runner):  # pylint: disable=unused-argument
         cfg = config.get_default_config()

--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -63,7 +63,10 @@ class TestLabDownload:
         assert result.exit_code == 0
         mock_oci_download.assert_called_once()
 
-    def test_oci_download_repository_error(self, cli_runner: CliRunner):
+    @patch("instructlab.model.download.OCIDownloader.download")
+    def test_oci_download_repository_with_tag(
+        self, mock_oci_download, cli_runner: CliRunner
+    ):
         result = cli_runner.invoke(
             lab.ilab,
             [
@@ -73,8 +76,5 @@ class TestLabDownload:
                 "--repository=docker://quay.io/ai-lab/models/granite-7b-lab:latest",
             ],
         )
-        assert result.exit_code == 1
-        assert (
-            "\nInvalid repository supplied:\n    Please specify tag/version 'latest' via --release"
-            in result.output
-        )
+        assert result.exit_code == 0
+        mock_oci_download.assert_called_once()

--- a/tests/test_lab_evaluate.py
+++ b/tests/test_lab_evaluate.py
@@ -460,8 +460,10 @@ def test_invalid_model_mmlu(cli_runner: CliRunner):
 
 
 def test_invalid_gguf_model_mmlu(cli_runner: CliRunner):
-    with open("model.gguf", "w", encoding="utf-8") as gguf_file:
-        gguf_file.write("")
+    # Write a valid GGUF magic number to the file to simulate a real GGUF model
+    with open("model.gguf", "wb") as gguf_file:
+        # Writing 'gguf' as the magic number in bytes (valid GGUF header)
+        gguf_file.write(b"GGUF")
     result = cli_runner.invoke(
         lab.ilab,
         [
@@ -613,7 +615,7 @@ def test_invalid_model_path_mmlu(cli_runner: CliRunner, tmp_path):
         ],
     )
     assert (
-        "Evaluate '--model' needs to be passed either a safetensors directory or a GGUF file"
+        "Evaluate '--model' needs to be passed a valid safetensors or GGUF model"
         in result.output
     )
     assert result.exit_code != 0
@@ -635,7 +637,7 @@ def test_invalid_model_path_mt_bench(cli_runner: CliRunner, tmp_path):
         ],
     )
     assert (
-        "Evaluate '--model' needs to be passed either a safetensors directory or a GGUF file"
+        "Evaluate '--model' needs to be passed a valid safetensors or GGUF model"
         in result.output
     )
     assert result.exit_code != 0

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -14,12 +14,13 @@ chat:
   # Default: None
   max_tokens:
   # Model to be used for chatting with.
-  # Default: /cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
-  model: /cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
+  # Default: /cache/instructlab/models/huggingface.co/instructlab/merlinite-7b-lab-GGUF/main
+  model: /cache/instructlab/models/huggingface.co/instructlab/merlinite-7b-lab-GGUF/main
   # Filepath of a dialog session file.
   # Default: None
   session:
-  # Controls the randomness of the model's responses.
+  # Controls the randomness of the model's responses. Lower values make the output
+  # more deterministic, while higher values produce more random results.
   # Default: 1.0
   temperature: 1.0
   # Enable vim keybindings for chat.
@@ -34,8 +35,8 @@ evaluate:
   # Default: None
   base_branch:
   # Base model to compare with 'model' for mt_bench_branch and mmlu_branch.
-  # Default: instructlab/granite-7b-lab
-  base_model: instructlab/granite-7b-lab
+  # Default: /cache/instructlab/models/huggingface.co/instructlab/granite-7b-lab/main
+  base_model: /cache/instructlab/models/huggingface.co/instructlab/granite-7b-lab/main
   # Taxonomy branch containing custom skills/knowledge that should be used for
   # evaluation runs.
   # Default: None
@@ -102,8 +103,9 @@ generate:
   # Default: 4096
   max_num_tokens: 4096
   # Teacher model that will be used to synthetically generate training data.
-  # Default: /cache/instructlab/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf
-  model: /cache/instructlab/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf
+  # Default: /cache/instructlab/models/huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/main
+  model: 
+    /cache/instructlab/models/huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/main
   # Number of CPU cores to use for generation.
   # Default: 10
   num_cpus: 10
@@ -166,8 +168,9 @@ generate:
       # Default: 4096
       max_ctx_size: 4096
     # Directory where model to be served is stored.
-    # Default: /cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
-    model_path: /cache/instructlab/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf
+    # Default: /cache/instructlab/models/huggingface.co/instructlab/merlinite-7b-lab-GGUF/main
+    model_path: 
+      /cache/instructlab/models/huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/main
     # vLLM serving settings.
     vllm:
       # Number of GPUs to use.
@@ -223,8 +226,8 @@ serve:
     # Default: 4096
     max_ctx_size: 4096
   # Directory where model to be served is stored.
-  # Default: /cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
-  model_path: /cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
+  # Default: /cache/instructlab/models/huggingface.co/instructlab/merlinite-7b-lab-GGUF/main
+  model_path: /cache/instructlab/models/huggingface.co/instructlab/merlinite-7b-lab-GGUF/main
   # vLLM serving settings.
   vllm:
     # Number of GPUs to use.
@@ -318,8 +321,8 @@ train:
   # Default: 4096
   max_seq_len: 4096
   # Directory where the model to be trained is stored.
-  # Default: instructlab/granite-7b-lab
-  model_path: instructlab/granite-7b-lab
+  # Default: /cache/instructlab/models/huggingface.co/instructlab/granite-7b-lab/main
+  model_path: /cache/instructlab/models/huggingface.co/instructlab/granite-7b-lab/main
   # Number of GPUs to use for training. This value is not supported in legacy
   # training or MacOS.
   # Default: 1
@@ -331,8 +334,9 @@ train:
   # Default: /data/instructlab/phased
   phased_base_dir: /data/instructlab/phased
   # Judge model path for phased MT-Bench evaluation.
-  # Default: /cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
-  phased_mt_bench_judge: /cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
+  # Default: /cache/instructlab/models/huggingface.co/prometheus-eval/prometheus-8x7b-v2.0/main
+  phased_mt_bench_judge: 
+    /cache/instructlab/models/huggingface.co/prometheus-eval/prometheus-8x7b-v2.0/main
   # Phased phase1 effective batch size.
   # Default: 128
   phased_phase1_effective_batch_size: 128


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->
This PR makes the following changes:

*model downloading & storage*
- Makes sure all HF and OCI downloads result in subdirectories for models that follow the same structure as the supplied repository URL
- moves `is_huggingface_repo` and `is_oci_repo` helper functions into their respective classes since they are closely tied to download
- allows users to specify tag embedded in the repository and allows prefixing huggingface downloads with "huggingface.co/"
(eg: `ilab model download --repository huggingface.co/instructlab/granite-7b-lab:main` or `ilab model download --repository docker://registry.redhat.io/rhelai1/granite-7b-redhat-lab:latest`)
- adds version support to allow management of multiple model versions at the same time 
- adds ability to store and write model metadata to disk


*GGUF model check*
- extends GGUF model detection check to accomodate folders in addition to files to account for the new metadata file creation for GGUF models, and to align it with how safetensor models are handled internally
- updates serve/chat logic to handle both files and directories supplied as models for llamacpp 
- updates the default model paths in the config to be directories for GGUF models


*`ilab model list`*
- updates `ilab model list` logic to work with the new model directory structure and display version + SHA information
- simplifies model listing logic by leveraging the metadata file information when available
- previously downloaded models not containing a `metadata.json` file will show `unknown` for version fields

**NOTE**
Recognizing GGUF models as both folders and files leads to an issue within `ilab model list` logic where GGUF models get counted twice as we traverse down the directory tree - once as a folder and then again as a file, once we step into that folder. To avoid this we must ignore any files in the traversal. The downside of that is we will be ignoring any loose GGUF files that were downloaded previously and are present at the top level where traversal starts from.
Therefore this is a breaking change that GGUF models previously downloaded by users that are present directly in `~/.cache/instructlab/models` will not show up in the output of `ilab model list` unless they are moved into a folder 



```
╭─    ~/instructlab/instructlab    fix-model-pathing *10 ········································································································································································································· ✔  instructlab   20:31:52  ─╮
╰─ ilab model list                                                                                                                                                                                                                                                                                        ─╯
All listed models can be found at: /Users/jrao/.cache/instructlab/models
+--------------------------------------------------+---------+---------------------+---------+------------------------------------------------------------------+
| Model Name                                       | Size    | Last Modified       | Version | SHA                                                              |
+--------------------------------------------------+---------+---------------------+---------+------------------------------------------------------------------+
| registry.redhat.io/rhelai1/granite-7b-redhat-lab | 12.6 GB | 2024-10-11 13:03:08 | latest  | a6b02869a78625811455db7727b8fdda6a52cc88845a9596784ed446e11502c5 |
+--------------------------------------------------+---------+---------------------+---------+------------------------------------------------------------------+
| quay.io/ai-lab/models/granite-7b-lab             | 12.6 GB | 2024-10-11 13:15:08 | latest  | a237f5bfdaa0abf3f98d11a51c520e36e41f1edbcc9de7c0facee123c21563ad |
+--------------------------------------------------+---------+---------------------+---------+------------------------------------------------------------------+
| instructlab/granite-7b-lab                       | 12.6 GB | 2024-10-11 16:59:05 | unknown | unknown                                                          |
+--------------------------------------------------+---------+---------------------+---------+------------------------------------------------------------------+
| huggingface.co/instructlab/granite-7b-lab-GGUF   | 3.8 GB  | 2024-10-11 17:42:10 | main    | bbf0879378d71866bd17fc2c742fac0af2d4a326                         |
+--------------------------------------------------+---------+---------------------+---------+------------------------------------------------------------------+
| huggingface.co/instructlab/granite-7b-lab        | 12.6 GB | 2024-10-10 11:19:44 | main    | 4fb6a018d68ab813b95c7f470e424a70f2f7e561                         |
+--------------------------------------------------+---------+---------------------+---------+------------------------------------------------------------------+
| huggingface.co/instructlab/merlinite-7b-lab-GGUF | 4.1 GB  | 2024-10-11 12:33:05 | main    | 4bb27da133fc4888d687ab731ac7faf0ed804c6d                         |
+--------------------------------------------------+---------+---------------------+---------+------------------------------------------------------------------+
```

**Issue resolved by this Pull Request:**
Resolves #2371  #1980 




**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
