### PR TITLE
fix: allow for lora_qunatize_dtype to be null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@
   See `--sdg-scale-factor` for an updated option providing similar
   functionality.
 
+### Fixes
+
+* `ilab config`: Fixed a bug where `ilab` didn't recognize `train.lora_quantize_dtype: null` as a valid
+   value.
+
 ## v0.17
 
 ### Features

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -381,7 +381,7 @@ class _train(BaseModel):
     deepspeed_cpu_offload_optimizer: bool
 
     lora_rank: int
-    lora_quantize_dtype: str
+    lora_quantize_dtype: str | None
 
     is_padding_free: bool
 
@@ -470,7 +470,7 @@ def get_default_config() -> Config:
     )
 
 
-def read_train_profile(train_file):
+def read_train_profile(train_file) -> _train:
     try:
         with open(train_file, "r", encoding="utf-8") as yamlfile:
             content = yaml.safe_load(yamlfile)
@@ -482,7 +482,7 @@ def read_train_profile(train_file):
                 "- "
                 + err.get("type", "")
                 + " "
-                + "->".join(err.get("loc", ""))
+                + "->".join(err.get("loc", ""))  # type: ignore
                 + ": "
                 + err.get("msg", "").lower()
                 + "\n"


### PR DESCRIPTION
There is a bug currently where lora_quantize_dtype under the training config cannot take on
values of null. The valid range of values for this field are either "nf4" or null,
however; the CLI only permits nf4 as valid input - ensuring that all models
will be quantize during training. This commit fixes that bug so now the valid
values will be "nf4" or null

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
