### PR TITLE
refactor: strictly require `qna.yaml` filename for `ilab taxonomy diff`

### DIFF
--- a/src/instructlab/taxonomy/diff.py
+++ b/src/instructlab/taxonomy/diff.py
@@ -50,11 +50,13 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
     # Local
     from ..utils import TaxonomyReadingException, get_taxonomy_diff, validate_taxonomy
 
+    # load defaults from config ctx obj if not specified via CLI arg
     if not taxonomy_base:
         taxonomy_base = ctx.obj.config.generate.taxonomy_base
     if not taxonomy_path:
         taxonomy_path = ctx.obj.config.generate.taxonomy_path
 
+    # get all new or changed taxonomy files to be validated and output to user
     if not quiet:
         is_file = os.path.isfile(taxonomy_path)
         if is_file:  # taxonomy_path is file
@@ -70,6 +72,8 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
                 raise SystemExit(1) from exc
             for f in updated_taxonomy_files:
                 click.echo(f)
+
+    # validate new or changed taxonomy files
     try:
         validate_taxonomy(None, taxonomy_path, taxonomy_base, yaml_rules)
     except (TaxonomyReadingException, yaml.YAMLError) as exc:

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -166,14 +166,18 @@ TAXONOMY_FOLDERS: List[str] = ["compositional_skills", "knowledge"]
 """Taxonomy folders which are also the schema names"""
 
 
-def istaxonomyfile(fn):
+def is_taxonomy_file(fn: str):
     path = Path(fn)
+    if path.suffix == ".yml" and path.parts[0] in TAXONOMY_FOLDERS:
+        logger.warning(
+            f"Found a '.yml' file: {path}: taxonomy files must have a '.yaml' extension. File will not be checked."
+        )
     return path.suffix == ".yaml" and path.parts[0] in TAXONOMY_FOLDERS
 
 
 def get_taxonomy_diff(repo="taxonomy", base="origin/main"):
     repo = git.Repo(repo)
-    untracked_files = [u for u in repo.untracked_files if istaxonomyfile(u)]
+    untracked_files = [u for u in repo.untracked_files if is_taxonomy_file(u)]
 
     branches = [b.name for b in repo.branches]
 
@@ -212,7 +216,7 @@ def get_taxonomy_diff(repo="taxonomy", base="origin/main"):
     modified_files = [
         d.b_path
         for d in head_commit.diff(None)
-        if not d.deleted_file and istaxonomyfile(d.b_path)
+        if not d.deleted_file and is_taxonomy_file(d.b_path)
     ]
 
     updated_taxonomy_files = list(set(untracked_files + modified_files))

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -170,12 +170,12 @@ def is_taxonomy_file(fn: str) -> bool:
     path = Path(fn)
     if path.parts[0] not in TAXONOMY_FOLDERS:
         return False
-    if path.suffix == ".yml":
+    if path.name == "qna.yml":
         logger.warning(
-            f"Found a '.yml' file: {path}: taxonomy files must have a '.yaml' extension. File will not be checked."
+            f"Found a 'qna.yml' file: {path}: taxonomy files must be named 'qna.yaml'. File will not be checked."
         )
         return False
-    return path.suffix == ".yaml"
+    return path.name == "qna.yaml"
 
 
 def get_taxonomy_diff(repo="taxonomy", base="origin/main"):

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -166,13 +166,16 @@ TAXONOMY_FOLDERS: List[str] = ["compositional_skills", "knowledge"]
 """Taxonomy folders which are also the schema names"""
 
 
-def is_taxonomy_file(fn: str):
+def is_taxonomy_file(fn: str) -> bool:
     path = Path(fn)
-    if path.suffix == ".yml" and path.parts[0] in TAXONOMY_FOLDERS:
+    if path.parts[0] not in TAXONOMY_FOLDERS:
+        return False
+    if path.suffix == ".yml":
         logger.warning(
             f"Found a '.yml' file: {path}: taxonomy files must have a '.yaml' extension. File will not be checked."
         )
-    return path.suffix == ".yaml" and path.parts[0] in TAXONOMY_FOLDERS
+        return False
+    return path.suffix == ".yaml"
 
 
 def get_taxonomy_diff(repo="taxonomy", base="origin/main"):

--- a/tests/test_lab_diff.py
+++ b/tests/test_lab_diff.py
@@ -204,9 +204,9 @@ class TestLabDiff:
         assert result.output == ""
         assert result.exit_code == 0
 
-    def test_diff_invalid_yaml(self, cli_runner: CliRunner, testdata_path):
+    def test_diff_invalid_yaml_content(self, cli_runner: CliRunner, testdata_path):
         qna = testdata_path.joinpath("invalid_yaml.yaml").read_bytes()
-        self.taxonomy.create_untracked("compositional_skills/qna_invalid.yaml", qna)
+        self.taxonomy.create_untracked("compositional_skills/qna.yaml", qna)
         result = cli_runner.invoke(
             lab.ilab,
             [
@@ -222,9 +222,11 @@ class TestLabDiff:
         assert "Reading taxonomy failed" in result.output
         assert result.exit_code == 1
 
-    def test_diff_invalid_yaml_quiet(self, cli_runner: CliRunner, testdata_path):
+    def test_diff_invalid_yaml_content_quiet(
+        self, cli_runner: CliRunner, testdata_path
+    ):
         qna = testdata_path.joinpath("invalid_yaml.yaml").read_bytes()
-        self.taxonomy.create_untracked("compositional_skills/qna_invalid.yaml", qna)
+        self.taxonomy.create_untracked("compositional_skills/qna.yaml", qna)
         result = cli_runner.invoke(
             lab.ilab,
             [
@@ -285,3 +287,42 @@ class TestLabDiff:
         )
         assert "Reading taxonomy failed" in result.output
         assert result.exit_code == 1
+
+    def test_diff_invalid_yaml_filename(self, cli_runner: CliRunner, testdata_path):
+        qna = testdata_path.joinpath("invalid_yaml.yaml").read_bytes()
+        self.taxonomy.create_untracked("compositional_skills/qna_invalid.yaml", qna)
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        assert f"Taxonomy in {self.taxonomy.root} is valid :)" in result.output
+        assert result.exit_code == 0
+
+    def test_diff_invalid_yaml_filename_quiet(
+        self, cli_runner: CliRunner, testdata_path
+    ):
+        qna = testdata_path.joinpath("invalid_yaml.yaml").read_bytes()
+        self.taxonomy.create_untracked("compositional_skills/qna_invalid.yaml", qna)
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                TAXONOMY_BASE,
+                "--taxonomy-path",
+                self.taxonomy.root,
+                "--quiet",
+            ],
+        )
+        assert result.output == ""
+        assert result.exit_code == 0


### PR DESCRIPTION
As discussed in https://github.com/instructlab/instructlab/issues/1899 and https://github.com/instructlab/instructlab/issues/1306 there is currently no indication to CLI users that `.yml` files are not supported for the taxonomy. This PR adds a warning log line to the CLI output to communicate that any files in the taxonomy not named `qna.yaml` are invalid and won't be checked as part of `ilab taxonomy diff`.

Example output:
```bash
(venv) [ec2-user@ip-10-0-7-10 instructlab]$ ilab taxonomy diff
WARNING 2024-07-30 19:18:27,919 instructlab.utils:174: Found a 'qna.yml' file: compositional_skills/writing/freeform/foo-lang/qna.yml: taxonomy files must be named 'qna.yaml'. File will not be checked.
WARNING 2024-07-30 19:18:27,937 instructlab.utils:174: Found a 'qna.yml' file: compositional_skills/writing/freeform/foo-lang/qna.yml: taxonomy files must be named 'qna.yaml'. File will not be checked.
Taxonomy in /home/ec2-user/.local/share/instructlab/taxonomy is valid :)
```

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
