### PR TITLE
fix: modify diff exception wording to accurately reflect number of errors

### DIFF
--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -523,7 +523,9 @@ def validate_taxonomy(_logger, taxonomy, taxonomy_base, yaml_rules):
             )
         if total_errors:
             raise TaxonomyReadingException(
-                yaml.YAMLError(f"{total_errors} taxonomy files with errors!")
+                yaml.YAMLError(
+                    f"{total_errors} total errors found across {len(updated_taxonomy_files)} updated taxonomy files!"
+                )
             )
 
 


### PR DESCRIPTION
`ilab taxonomy diff` currently claims the total number of errors is the equivalent of the number of files with errors. This is sometimes but not always the case. Updated the message to paint a more accurate picture.

**Issue resolved by this Pull Request:**
Resolves #1898

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
