### PR TITLE
fix: allow chat to resolve the local model being served

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@
 
 * `ilab config`: Fixed a bug where `ilab` didn't recognize `train.lora_quantize_dtype: null` as a valid
    value.
+* `ilab model chat`: Fixed an issue where the default served model couldn't be resolved when running
+   model besides the default `merlinite-7b-lab-Q4_K_M.gguf`.
 
 ## v0.17
 

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -170,10 +170,10 @@ def generate(
     yaml_rules,
     chunk_word_count,
     server_ctx_size,
-    tls_insecure,
-    tls_client_cert,
-    tls_client_key,
-    tls_client_passwd,
+    tls_insecure: bool,
+    tls_client_cert: str | None,
+    tls_client_key: str | None,
+    tls_client_passwd: str | None,
     model_family,
     pipeline,
     enable_serving_output,
@@ -216,7 +216,15 @@ def generate(
         try:
             # Run the backend server
             api_base = backend_instance.run_detached(
-                http_client(ctx.params), background=not enable_serving_output
+                http_client(
+                    {
+                        "tls_client_cert": tls_client_cert,
+                        "tls_client_key": tls_client_key,
+                        "tls_client_passwd": tls_client_passwd,
+                        "tls_insecure": tls_insecure,
+                    }
+                ),
+                background=not enable_serving_output,
             )
         except Exception as exc:
             click.secho(f"Failed to start server: {exc}", fg="red")

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -335,7 +335,15 @@ def launch_server(
     try:
         # http_client is handling tls params
         api_base = backend_instance.run_detached(
-            http_client(ctx.params), background=not enable_serving_output
+            http_client(
+                {
+                    "tls_client_cert": ctx.params["tls_client_cert"],
+                    "tls_client_key": ctx.params["tls_client_key"],
+                    "tls_client_passwd": ctx.params["tls_client_passwd"],
+                    "tls_insecure": ctx.params["tls_insecure"],
+                }
+            ),
+            background=not enable_serving_output,
         )
     except Exception as exc:
         click.secho(f"Failed to start server: {exc}", fg="red")

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -76,6 +76,17 @@ class LegacyMessageSample(TypedDict):
     assistant: str
 
 
+class HttpClientParams(TypedDict):
+    """
+    Types the parameters used when initializing the HTTP client.
+    """
+
+    tls_client_cert: str | None
+    tls_client_key: str | None
+    tls_client_passwd: str | None
+    tls_insecure: bool
+
+
 def macos_requirement(echo_func, exit_exception):
     """Adds a check for MacOS before running a method.
 
@@ -532,7 +543,7 @@ def get_ssl_cert_config(tls_client_cert, tls_client_key, tls_client_passwd):
         return tls_client_cert, tls_client_key, tls_client_passwd
 
 
-def http_client(params):
+def http_client(params: HttpClientParams):
     return httpx.Client(
         cert=get_ssl_cert_config(
             params.get("tls_client_cert", None),


### PR DESCRIPTION
When `ilab model chat` is executed, it tries to find the default model being served
and use that when available. However; this behavior was not properly updated when
extending support for serving models via vLLM. As a result, the current code assumes that
the default model being served is the one which is specified as a default in the config.
Since users may instead download and serve a different model path, ilab model chat will
fail to detect and select this model when running ilab model chat.

This commit updates this behavior by introducing a default endpoint that ilab model serve
will commonly serve on (http://127.0.0.1:8000/v1), and checks to see if there is a
model being served at that endpoint when no other endpoint is specified. If the check
fails, then ilab model chat will proceed with the current behavior of seeking the default
model specified in the config for serve. If the check succeeds, then ilab model chat
simply proceeds using this endpoint for the remainder of the code.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
