### PR TITLE
Adding checkpoint dir when batching enabled

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ httpx>=0.25.0
 instructlab-eval>=0.0.9
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.3.1
-instructlab-sdg>=0.2.0
+instructlab-sdg>=0.2.2
 instructlab-training>=0.3.1
 jsonschema>=4.21.1
 llama_cpp_python[server]==0.2.79

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -2,6 +2,7 @@
 
 # Standard
 import logging
+import os.path
 
 # Third Party
 import click
@@ -234,6 +235,12 @@ def generate(
                     "Disabling SDG batching - unsupported with llama.cpp serving"
                 )
             batch_size = 0
+
+    # Specify checkpoint dir if batching is enabled
+    checkpoint_dir = None
+    if batch_size > 0:
+        checkpoint_dir = os.path.join(output_dir, "checkpoints")
+
     try:
         click.echo(
             f"Generating synthetic data using '{model_path}' model, taxonomy:'{taxonomy_path}' against {api_base} server"
@@ -261,6 +268,7 @@ def generate(
             tls_client_passwd=tls_client_passwd,
             pipeline=pipeline,
             batch_size=batch_size,
+            checkpoint_dir=checkpoint_dir,
         )
     except GenerateException as exc:
         click.secho(


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

As a continuation of: https://github.com/instructlab/instructlab/pull/1889

Related to: https://github.com/instructlab/sdg/issues/195

By default this puts checkpoints under: ~/.local/share/instructlab/datasets/checkpoints/


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
