### PR TITLE
LoRA Adjustments

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1085,7 +1085,7 @@ def init(
         ctx.default_map = None
 
 
-def map_train_to_library(params):
+def map_train_to_library(ctx, params):
     # first do a lazy unwrap into the respective options
     train_args = TrainingArgs(**params)
     torch_args = TorchrunArgs(**params)
@@ -1105,6 +1105,9 @@ def map_train_to_library(params):
         target_modules=params["lora_target_modules"],
         quantize_data_type=params["lora_quantize_dtype"],
     )
+
+    if params["lora_quantize_dtype"] is not None and params["is_padding_free"]:
+        ctx.fail("Cannot combine LoRA with a padding free model.")
 
     train_args.deepspeed_options = ds_args
     train_args.lora = lora_args

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -627,8 +627,7 @@ def train(
 
         # pull the trainrandom.randinting and torch args from the flags
         # the flags are populated from the config as a base.
-        params = ctx.params
-        train_args, torch_args = map_train_to_library(params)
+        train_args, torch_args = map_train_to_library(ctx, ctx.params)
 
         if strategy == SupportedTrainingStrategies.LAB_MULTIPHASE.value:
             if not (phased_phase1_data and phased_phase2_data):

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -228,7 +228,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     "--lora-rank",
     type=int,
     cls=clickext.ConfigOption,
-    required=True,  # default from config
     # config_section="lora",
     help="rank of update matricies",
 )
@@ -236,7 +235,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     "--lora-alpha",
     type=int,
     cls=clickext.ConfigOption,
-    required=True,  # default from config
     config_sections=ADDITIONAL_ARGUMENTS,
     help="how influential/strong lora tune will be",
 )
@@ -244,7 +242,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     "--lora-dropout",
     type=float,
     cls=clickext.ConfigOption,
-    required=True,  # default from config
     config_sections=ADDITIONAL_ARGUMENTS,
     help="dropout for LoRA layers",
 )
@@ -259,6 +256,7 @@ def clickpath_setup(is_dir: bool) -> click.Path:
 @click.option(
     "--lora-quantize-dtype",
     type=str,
+    cls=clickext.ConfigOption,
     default=None,
     help="quantization data type to use when training a LoRA.",
 )


### PR DESCRIPTION
add the ability to turn LoRA off. Currently all of the LoRA config fields are mandatory and have strict defaults meaning LoRA is always on when called via the CLI.
Also make it so that if LoRA is used with --is-padding-free=True, we fail. In testing these two do not work together

resolves #1906

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
