### PR TITLE
add --gpus to `ilab data generate`

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -326,6 +326,7 @@ class _generate(BaseModel):
     output_dir: StrictStr = Field(default_factory=lambda: DEFAULTS.DATASETS_DIR)
     prompt_file: StrictStr = Field(default_factory=lambda: DEFAULTS.PROMPT_FILE)
     seed_file: StrictStr = Field(default_factory=lambda: DEFAULTS.SEED_FILE)
+    gpus: Optional[int] = None
 
 
 class _mmlu(BaseModel):

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -105,6 +105,10 @@ class BackendServer(abc.ABC):
     def register_resources(self, resources: typing.Iterable[Closeable]) -> None:
         self.resources.extend(resources)
 
+    @abc.abstractmethod
+    def get_backend_type(self):
+        """Return which type of backend this is, llama-cpp or vllm"""
+
 
 def safe_close_all(resources: typing.Iterable[Closeable]):
     for resource in resources:

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -24,6 +24,7 @@ from .backends import (
     API_ROOT_WELCOME_MESSAGE,
     CHAT_TEMPLATE_AUTO,
     CHAT_TEMPLATE_TOKENIZER,
+    LLAMA_CPP,
     BackendServer,
     ServerException,
     UvicornServer,
@@ -141,6 +142,9 @@ class Server(BackendServer):
             self.process.join(timeout=30)
             self.queue.close()
             self.queue.join_thread()
+
+    def get_backend_type(self):
+        return LLAMA_CPP
 
 
 def server(

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -118,6 +118,9 @@ class Server(BackendServer):
         if self.process is not None:
             shutdown_process(self.process, 20)
 
+    def get_backend_type(self):
+        return VLLM
+
 
 def format_template(model_family: str, model_path: pathlib.Path) -> str:
     template, eos_token, bos_token = get_model_template(model_family, model_path)

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -426,7 +426,7 @@ def launch_server(
 )
 @click.option(
     "--gpus",
-    type=click.INT,
+    type=click.IntRange(min=0),
     help="Number of GPUs to utilize for evaluation (not applicable to llama-cpp)",
 )
 @click.option(

--- a/src/instructlab/model/linux_test.py
+++ b/src/instructlab/model/linux_test.py
@@ -56,7 +56,7 @@ def test_model(ctx, res, ds, model: Path, create_params: dict):
     try:
         ctx.obj.config.serve.llama_cpp.llm_family = ctx.params["model_family"]
         backend_instance = backends.select_backend(
-            ctx.obj.config.serve, model_path=model
+            cfg=ctx.obj.config.serve, model_path=model
         )
         try:
             api_base = backend_instance.run_detached(http_client(ctx.params))

--- a/tests/test_lab_model_test.py
+++ b/tests/test_lab_model_test.py
@@ -30,6 +30,9 @@ class TestLabModelTest:
         ) -> str:
             return "api_base_mock"
 
+        def get_backend_type(self):
+            return None
+
         def run(self):
             pass
 
@@ -39,7 +42,8 @@ class TestLabModelTest:
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=False)
     @patch("instructlab.model.linux_test.response", return_value="answer!")
     @patch(
-        "instructlab.model.backends.backends.select_backend", return_value=ServerMock()
+        "instructlab.model.backends.backends.select_backend",
+        return_value=ServerMock(),
     )
     def test_model_test_linux(
         self,

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -29,6 +29,7 @@ general:
   log_level: INFO
 generate:
   chunk_word_count: 1000
+  gpus: null
   model: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
   num_cpus: 10
   output_dir: /data/instructlab/datasets


### PR DESCRIPTION
since generation can implicitly start servers, it at the very least needs to be able to set the amount of GPUs to run generation on when using vllm

resolves #1921

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
