### PR TITLE
Add missing ilab model help screen descriptions

### DIFF
--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -168,7 +168,7 @@ def chat(
     tls_client_passwd,  # pylint: disable=unused-argument
     model_family,
 ):
-    """Run a chat using the modified model"""
+    """Runs a chat using the modified model"""
     # pylint: disable=import-outside-toplevel
     # First Party
     from instructlab.model.backends.llama_cpp import is_temp_server_running

--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -274,6 +274,7 @@ class OCIDownloader(Downloader):
 @click.pass_context
 @clickext.display_params
 def download(ctx, repository, release, filename, model_dir, hf_token):
+    """Downloads model from a specified repository"""
     downloader = None
 
     if is_oci_repo(repository):

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -500,6 +500,7 @@ def evaluate(
     tls_client_passwd,  # pylint: disable=unused-argument
     enable_serving_output,
 ):
+    """Evaluates a trained model"""
     # get appropriate evaluator class from Eval lib
     evaluator = get_evaluator(
         model,

--- a/src/instructlab/model/list.py
+++ b/src/instructlab/model/list.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
     is_flag=True,
 )
 def model_list(model_dirs: list[str], list_checkpoints: bool):
-    """lists models"""
+    """Lists models"""
     data = []
     for directory in model_dirs:
         for entry in Path(directory).iterdir():

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -107,7 +107,7 @@ def serve(
     backend: str | None,
     chat_template: str | None,
 ) -> None:
-    """Start a local server
+    """Starts a local server
 
     The vLLM backend accepts additional parameters in the form of extra
     arguments after "--" separator:


### PR DESCRIPTION
Adds missing descriptions on the evaluate and download commands in the ilab model help screen. Also, capitalizes the List help text to be consistent with the others.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
