### PR TITLE
Fixing venv wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,11 +224,7 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
       train: model train
    ```
 
-   > **IMPORTANT:** every `ilab` command needs to be run from within your Python virtual environment. To enter the Python environment, run the following command:
-
-   ```shell
-   source venv/bin/activate
-   ```
+   > **IMPORTANT** Every `ilab` command needs to be run from within your Python virtual environment. You can enter the Python environment by running the `source venv/bin/activate` command.
 
 5. Optional: You can enable tab completion for the `ilab` command.
 


### PR DESCRIPTION
**Issue:** #1874 

**Description:** Fix the wording and formating in the README about the venv python environment
