### PR TITLE
fix: downgrade skopeo log msgs to warning level from error level

### DIFF
--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -341,10 +341,10 @@ def check_skopeo_version():
         if version.parse(installed_version) < version.parse(
             _RECOMMENDED_SCOPEO_VERSION
         ):
-            logger.error(
+            logger.warning(
                 f"skopeo version {installed_version} is lower than {_RECOMMENDED_SCOPEO_VERSION}. Consider upgrading. Downloading the model might fail."
             )
     else:
-        logger.error(
+        logger.warning(
             f"Failed to determine skopeo version. Recommended version is {_RECOMMENDED_SCOPEO_VERSION}. Downloading the model might fail."
         )


### PR DESCRIPTION
Change skopeo error messages to warning when recommending a version upgrade or unable to determine version. Only emit error logs if skopeo is not installed on the system

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
