### PR TITLE
fix: make `model list` show correct size

### DIFF
--- a/src/instructlab/model/list.py
+++ b/src/instructlab/model/list.py
@@ -101,7 +101,7 @@ def _analyze_dir(
         for f in files:
             # stat each file in the dir, add the size in Bytes, then convert to proper magnitude
             full_file = os.path.join(root, f)
-            stat = Path(full_file).stat(follow_symlinks=False)
+            stat = Path(full_file).stat()
             all_files_sizes += stat.st_size
         adjusted_all_sizes, magnitude = convert_bytes_to_proper_mag(all_files_sizes)
         if add_model:


### PR DESCRIPTION
With the introduction of models using OCI images as the delivery mechanism, it is necessary to follow the symlinks in order to properly show the size of the image.
 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
