### PR TITLE
feat: Add more robust config defaulting

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ import yaml
 
 # First Party
 from instructlab import configuration as config
+from instructlab.configuration import DEFAULTS
 from instructlab.log import configure_logging
 
 
@@ -92,13 +93,12 @@ class TestConfig:
 
         assert cfg.evaluate is not None
         assert cfg.evaluate.base_model == "instructlab/granite-7b-lab"
-        assert cfg.evaluate.model is None
 
         assert cfg.generate is not None
-        assert cfg.generate.model == default_model
+        assert cfg.generate.model == DEFAULTS.DEFAULT_MODEL
 
         assert cfg.serve is not None
-        assert cfg.serve.model_path == default_model
+        assert cfg.serve.model_path == DEFAULTS.DEFAULT_MODEL
 
         assert cfg.train is not None
         assert cfg.train.model_path == "instructlab/granite-7b-lab"
@@ -109,7 +109,7 @@ class TestConfig:
         self._assert_defaults(cfg)
         self._assert_model_defaults(cfg)
 
-    def test_config_missing_required_field_groups(self, tmp_path_home):
+    def test_cfg_auto_fill(self, tmp_path_home):
         config_path = tmp_path_home / "config.yaml"
         with open(config_path, "w", encoding="utf-8") as config_file:
             config_file.write(
@@ -117,26 +117,17 @@ class TestConfig:
   log_level: INFO
 """
             )
-        with pytest.raises(
-            config.ConfigException,
-            match=r"""5 errors in [\/\w-]+config.yaml:
-- missing chat: field required
-- missing generate: field required
-- missing serve: field required
-- missing version: field required
-- missing evaluate: field required
-""",
-        ):
-            config.read_config(config_path)
+        cfg = config.read_config(config_path)
+        self._assert_defaults(cfg)
+        self._assert_model_defaults(cfg)
 
-    def test_config_missing_required_fields(self, tmp_path_home):
+    def test_cfg_auto_fill_with_large_config(self, tmp_path_home):  # pylint: disable=unused-argument
         config_path = tmp_path_home / "config.yaml"
         with open(config_path, "w", encoding="utf-8") as config_file:
             config_file.write(
                 """general:
   log_level: INFO
 generate:
-  model: models/merlinite-7b-lab-Q4_K_M.gguf
   teacher:
     model_path: models/granite-7b-lab-Q4_K_M.gguf
     chat_template: tokenizer
@@ -149,18 +140,10 @@ generate:
          - --tensor-parallel-size=8
 """
             )
-        with pytest.raises(
-            config.ConfigException,
-            match=r"""6 errors in [\/\w-]+config.yaml:
-- missing chat: field required
-- missing generate->taxonomy_path: field required
-- missing generate->taxonomy_base: field required
-- missing serve: field required
-- missing version: field required
-- missing evaluate: field required
-""",
-        ):
-            config.read_config(config_path)
+        cfg = config.read_config(config_path)
+        # make sure the generate cfg passed is preserved
+        assert cfg.generate.teacher.llama_cpp.max_ctx_size == 2048
+        self._assert_model_defaults(cfg)
 
     def test_validate_log_level_invalid(self):
         cfg = config.get_default_config()
@@ -323,8 +306,8 @@ def test_compare_default_config_testdata(
     [
         ("nf4", {}, False),
         (None, {}, False),
-        ("nf4", None, True),
-        (None, None, True),
+        ("nf4", None, False),
+        (None, None, False),
         ("valid-for-cli-but-not-for-training-library", {}, False),
         ("nf4", {"lora_alpha": 32}, False),
     ],
@@ -366,4 +349,5 @@ def test_read_train_profile(
         for k, v in result.dict().items():
             if k not in profile_data:
                 continue
-            assert v == profile_data[k]
+            if profile_data[k] is not None:
+                assert v == profile_data[k]


### PR DESCRIPTION
Currently,  one cannot specify a partial config. This is a useful thing to do when you don't care about some/most fields in the cfg, just GPU related ones.

pydantic has a `@model_validator` which allows a pre-check to be run before erroring out for missing fields. What I did in this commit is for each class and nested sub-class in `ilab`
the user can now pass little to no entires and we will fill out the rest of the config for them using the defaults in `get_default_config`. This differs from the current behavior which only allows the `Optional` fields to be omitted.

This config format will be useful in the following scenario:

A user can specify a config like the following:

```
serve:
  backend: null
  chat_template: null
  host_port: 127.0.0.1:8000
  llama_cpp:
    gpu_layers: -1
    llm_family: ''
    max_ctx_size: 4096
  model_path: /home/cdoern/.cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
  vllm:
    llm_family: ''
    vllm_args: [--tensor-parallel-size, 8]

```

if all they care about is serving in this scenario. `ilab` previously would error and tell them to fill out the entire cfg yaml with all mandatory fields. This level of strict enforcing makes sense for the `Config` class in code but not in everyday practice when passing yaml files. Now, ilab will fill out the entire config with sane defaults.


<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
