### PR TITLE
Model family vllm data generate & `get_model_family()` fixes

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -534,12 +534,15 @@ def get_api_base(host_port: str) -> str:
     return f"http://{host_port}/v1"
 
 
-def get_model_family(forced, model_path):
-    forced = MODEL_FAMILY_MAPPINGS.get(forced, forced)
-    if forced and forced.lower() not in MODEL_FAMILIES:
-        raise ConfigException(f"Unknown model family: {forced}")
+def get_model_family(family, model_path):
+    family = MODEL_FAMILY_MAPPINGS.get(family, family)
+    if family:
+        if family.lower() not in MODEL_FAMILIES:
+            raise ConfigException(f"Unknown model family: {family}")
 
-    # Try to guess the model family based on the model's filename
+        return family.lower()
+
+    # If family is not set try to guess the model family based on the model's filename
     guess = match(r"^\w*", path.basename(model_path)).group(0).lower()
     guess = MODEL_FAMILY_MAPPINGS.get(guess, guess)
 

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -137,6 +137,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--model-family",
+    type=click.STRING,
     help="Force model family to use when picking a generation template",
 )
 @click.option(
@@ -224,7 +225,12 @@ def generate(
 
         # TODO (cdoern): we really should not edit the cfg object
         gen_cfg = copy.deepcopy(ctx.obj.config)
-        gen_cfg.generate.teacher.llama_cpp.llm_family = model_family
+        gen_cfg.generate.teacher.llama_cpp.llm_family = (
+            model_family or gen_cfg.generate.teacher.llama_cpp.llm_family
+        )
+        gen_cfg.generate.teacher.vllm.llm_family = (
+            model_family or gen_cfg.generate.teacher.vllm.llm_family
+        )
         if gpus is not None:
             tps_prefix = "--tensor-parallel-size"
             if contains_argument(tps_prefix, gen_cfg.generate.teacher.vllm.vllm_args):

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -385,6 +385,10 @@ def get_model_template(
     bos_token = ""
     template = ""
     resolved_family = get_model_family(model_family, model_path)
+    logger.debug(
+        "Searching hard coded model templates for model family %s's template",
+        resolved_family,
+    )
     for template_dict in templates:
         if template_dict["model"] == resolved_family:
             template = template_dict["template"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -187,6 +187,8 @@ generate:
             "MERLINiTe": "merlinite",
             # mapping granite to merlinite
             "granite": "merlinite",
+            # default empty value of model_family will use name of model in model path to guess model_family
+            "": "merlinite",
         }
         bad_cases = [
             # unknown family


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
1st commit:

```
set teacher.vllm.llm_family from model_family flag.
This was only being set for the llama_cpp backend.
```
2nd commit:
    
    This commit changes the following with
    regard to get_model_family in configuration.py:
    
    1. rename "forced" to "family" in the function
     to make it more readable.
    
    2. get_model_family() was always guessing the
    model_family even if a valid family was input.
    Now if a valid family is input, it returns that.
    
    3. add debug logging in backend.py to see the
    result of get_model_family()
    
    4. add a case in test_get_model_family() for when
    model_family == "" which is it's default value
    in the serve config and in other places in the
    code base.


For anyone tracing through the code, here are the calls that lead to `get_model_family()`
```
1. data/generate.py -- model_family is assigned to teacher.vllm.llm_family
2. data/generate.py -- select_backend() is called with the teacher cfg
3. model/backends/backend.py -- a vllm_server is initialized with cfg.vllm.llm_family as the model_family
4. model/backends/vllm.py -- run_detached() calls run_vllm() with self.model_family
5. model/backends/vllm.py -- in run_vllm() model_family is passed into build_vllm_cmd()
6. model/backends/vllm.py -- in format_template(), model_family is passed into get_model_template()
7. model/backends/backend.py -- in get_model_template(), model_family is passed into get_model_family() which is in configuration.py
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
