### PR TITLE
chore: update vllm tag to 2024.08.01

### DIFF
--- a/requirements-vllm-cuda.txt
+++ b/requirements-vllm-cuda.txt
@@ -2,4 +2,4 @@
 # Dependencies for installing vLLM on CUDA
 
 # vLLM only supports Linux platform (including WSL)
-vllm @git+https://github.com/opendatahub-io/vllm@2024.07.24 ; sys_platform == 'linux' and platform_machine == 'x86_64'
+vllm @git+https://github.com/opendatahub-io/vllm@2024.08.01 ; sys_platform == 'linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
- includes punica kernels required by LoRA adapters


