### PR TITLE
fix: log error if user supplies invalid repository for OCI download

### DIFF
--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -191,6 +191,15 @@ class OCIDownloader(Downloader):
             f"Downloading model from OCI registry: {self.repository}@{self.release} to {self.download_dest}..."
         )
 
+        # raise an exception if user specified tag/SHA embedded in repository instead of specifying --release
+        match = re.search(r"^(?:[^:]*:){2}(.*)$", self.repository)
+        if match:
+            click.secho(
+                f"Invalid repository supplied: Please specify tag/version '{match.group(1)}' via --release",
+                fg="red",
+            )
+            raise click.exceptions.Exit(1)
+
         model_name = self.repository.split("/")[-1]
         os.makedirs(os.path.join(self.download_dest, model_name), exist_ok=True)
         oci_dir = f"{DEFAULTS.OCI_DIR}/{model_name}"

--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -44,3 +44,34 @@ class TestLabDownload:
         )
         assert result.exit_code == 1, "command finished with an unexpected exit code"
         assert "Could not reach hugging face server" in result.output
+
+    @patch("instructlab.model.download.OCIDownloader.download")
+    def test_oci_download(self, mock_oci_download, cli_runner: CliRunner):
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "download",
+                "--repository=docker://quay.io/ai-lab/models/granite-7b-lab",
+                "--release=latest",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_oci_download.assert_called_once()
+
+    def test_oci_download_repository_error(self, cli_runner: CliRunner):
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "download",
+                "--repository=docker://quay.io/ai-lab/models/granite-7b-lab:latest",
+            ],
+        )
+        assert result.exit_code == 1
+        assert (
+            "Invalid repository supplied: Please specify tag/version 'latest' via --release"
+            in result.output
+        )


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

Raise an error if user tries to specify version/tag within the supplied `--repository` instead of specifying the tag/version via `--release` when downloading models from OCI registries 

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
