### PR TITLE
make `ilab config init` clone taxonomy by default

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -168,7 +168,8 @@ def get_params_default(
         clone_taxonomy_repo = False
     elif interactive:
         clone_taxonomy_repo = click.confirm(
-            f"`{taxonomy_path}` seems to not exist or is empty. Should I clone {repository} for you?"
+            f"`{taxonomy_path}` seems to not exist or is empty. Should I clone {repository} for you?",
+            default=True,
         )
 
     # clone taxonomy repo if it needs to be cloned


### PR DESCRIPTION
If you pressed enter without specifying `y` or `N` when asked to clone taxonomy, it would by default not clone it, which would result in an empty taxonomy directory if you used the default taxonomy path. This change makes it so that the taxonomy is cloned unless you specify `n`.

**Issue resolved by this Pull Request:**
Resolves #1951 
