### PR TITLE
Updating default location for judge model to be a local model in the cache

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -125,6 +125,10 @@ class _InstructlabDefaults:
         return path.join(self.MODELS_DIR, self.GGUF_MODEL_NAME)
 
     @property
+    def DEFAULT_JUDGE_MODEL(self) -> str:
+        return path.join(self.MODELS_DIR, self.JUDGE_MODEL_MT)
+
+    @property
     def TAXONOMY_DIR(self) -> str:
         return path.join(self._data_dir, STORAGE_DIR_NAMES.TAXONOMY)
 
@@ -457,7 +461,7 @@ def get_default_config() -> Config:
         evaluate=_evaluate(
             base_model=DEFAULTS.MODEL_REPO,
             mt_bench=_mtbench(
-                judge_model=DEFAULTS.JUDGE_MODEL_MT,
+                judge_model=DEFAULTS.DEFAULT_JUDGE_MODEL,
                 output_dir=DEFAULTS.EVAL_DATA_DIR,
                 max_workers=16,
             ),

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -376,7 +376,7 @@ def launch_server(
     type=click.STRING,
     cls=clickext.ConfigOption,
     config_sections="mt_bench",
-    help="Model to be used as a judge for running mt_bench or mt_bench_branch - can be a local path or the name of a Hugging Face repository",
+    help="Model to be used as a judge for running mt_bench or mt_bench_branch - must be a local path to a downloaded model",
 )
 @click.option(
     "--output-dir",

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -19,7 +19,7 @@ evaluate:
     tasks_dir: /data/instructlab/datasets
   model: null
   mt_bench:
-    judge_model: prometheus-eval/prometheus-8x7b-v2.0
+    judge_model: /cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: 16
     output_dir: /data/instructlab/internal/eval_data
   mt_bench_branch:


### PR DESCRIPTION
Along the way we disabled the ability for vllm to download the model.  This default config change is reccognizing where the model should be when downloaded if using prometheus.  If we want to enable the auto download feature in the future, we should instead use the ilab download capability so the model ends up in the model cache.

Thanks to @JamesKunstle for pointing out this issue!

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
