### PR TITLE
Add training profiles for GPU configs

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -457,6 +457,8 @@ disable=raw-checker-failed,
         logging-fstring-interpolation,  # FIXME
         duplicate-code,
         import-outside-toplevel,
+        too-many-lines,
+        too-many-public-methods,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@
 * Legacy Linux training now supports the new messages format. When a dataset is provided in the
   HuggingFace messages format, `ilab` will automatically convert it back into the legacy format.
 * Legacy Linux training is now compatible with the phase07 pretraining format.
+* Add support for `ILAB_TRAIN_PROFILE_DIR` which will point to the template train profiles to be brought into the `train_configuration` directory.
+* Add interactive prompt for users to choose their train profile.
 
 ### Breaking Changes
 

--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -2,7 +2,7 @@
 
 # Standard
 from os import listdir
-from os.path import dirname, exists
+from os.path import dirname, exists, join
 import pathlib
 import typing
 
@@ -103,6 +103,29 @@ def init(
     click.echo(f"Generating `{DEFAULTS.CONFIG_FILE}`...")
     if train_profile is not None:
         cfg.train = read_train_profile(train_profile)
+    elif interactive:
+        entries = listdir(DEFAULTS.TRAIN_PROFILE_DIR)
+        click.echo("Please choose a train profile to use:")
+        for i, value in enumerate(entries):
+            click.echo(f"{i}. {value}")
+        train_profile_selection = click.prompt(
+            "Enter the number of your choice [hit enter for the default]",
+            type=int,
+            default=-1,
+        )
+        if 0 <= train_profile_selection < len(entries):
+            click.echo(f"You selected: {entries[train_profile_selection]}")
+            cfg.train = read_train_profile(
+                join(DEFAULTS.TRAIN_PROFILE_DIR, entries[train_profile_selection])
+            )
+        elif train_profile_selection == -1:
+            click.echo("Using default train profile.")
+        else:
+            click.secho(
+                "Invalid selection. Please select a valid train profile option.",
+                fg="red",
+            )
+            raise click.exceptions.Exit(1)
 
     cfg.chat.model = model_path
     cfg.generate.model = model_path


### PR DESCRIPTION
Add training profiles for the following GPU configs:

4x/8x A100/H100

2x A100/H100

4x L40

8x L40

8x L4

these are rendered into ~/.local/share/instructlab/internal/train_configuration/

also introduce ILAB_TRAIN_PROIFLE_DIR, and env var which when set will be used as the template dir to render the initial train profiles into ~/.local/share

The user will also now see an interactive menu on initialization to choose their train profile.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
