### PR TITLE
Refactor the CUDA container spec

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -1,4 +1,4 @@
-# Putting `ilab` in a Container AND making it go fast
+# Putting `ilab` in a container AND making it go fast
 
 Containerization of `ilab` allows for portability and ease of setup. With this,
 users can now run lab on OpenShift to test the speed of `ilab model train` and `generate`
@@ -6,22 +6,101 @@ using dedicated GPUs. This guide shows you how to put the `ilab` CLI, all of its
 dependencies, and your GPU into a container for an isolated and easily reproducible
 experience.
 
-## Steps to build an image then run a container
+## Build the `ilab` container image
 
-The [`Containerfile`](../containers/cuda/Containerfile)
-is based on Nvidia CUDA image, which plugs
-directly into Podman via their `nvidia-container-toolkit`! The `ubi9` base
-image does not have most packages installed. The bulk of the `Containerfile` is
-spent configuring your system so `ilab` can be installed and run properly.
-`ubi9` as compared to `ubuntu` cannot install the entire `nvidia-12-4` toolkit.
-This did not impact performance during testing.
+We encourage you to read the [Containerfile](../containers/cuda/Containerfile) to
+understand the following explanation.
 
-The CUDA Containerfile is located [here](../containers/cuda/Containerfile).
+To reduce the size of the final image, we do a multi-stage build with the _development_
+CUDA image for the build stage and a virtual environment. The base image for the final
+stage is the CUDA _runtime_ image, with no build tools and we copy the `site-packages`
+folder from the first stage.
 
-Voila! You now have a container with CUDA and GPUs enabled!
+You will also notice that the entry point of the container image is `/opt/app-root/bin/ilab`.
+This allows to call the `ilab` command with opening a new shell. See below how it
+is beneficial when combined with an alias.
 
-### Sources
+For convenience, we have created a `cuda` target in the `Makefile`, so building is
+as simple as `make cuda`.
 
-[Nvidia Container Toolkit Install Guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+The default image name is `localhost/instructlab`, but you can override it with
+the `CONTAINER_PREFIX` environment variable. The following command line will build an
+image tagged `quay.io/ai-labs/instructlab:cuda`:
 
-[Podman Support for Container Device Interface](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html)
+```shell
+make cuda CONTAINER_PREFIX=quay.io/ai-labs/instructlab
+```
+
+## Configure Podman with NVIDIA container runtime
+
+To configure your machine running RHEL 9.4+, you can follow NVIDIA's documentation to
+[install NVIDIA container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installing-with-yum-or-dnf)
+and to [configure Container Device Interface](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html)
+to expose the GPUs to Podman.
+
+Here is a quick procedure if you haven't.
+
+```shell
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
+sudo dnf config-manager --enable nvidia-container-toolkit-experimental
+sudo dnf install -y nvidia-container-toolkit
+```
+
+Then, you can verify that NVIDIA container toolkit can see your GPUs.
+
+```shell
+nvidia-ctk cdi list
+```
+
+Example output:
+
+```shell
+INFO[0000] Found 2 CDI devices
+nvidia.com/gpu=0
+nvidia.com/gpu=all
+```
+
+Finally, you can generate the Container Device Interface configuration for the NVIDIA devices:
+
+```shell
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+```
+
+## Run the GPU-accelerated `ilab` container
+
+When running our model, we want to create some paths that will be mounted in
+the container to provide data persistence. As an unprivileged user, you will
+run a rootless container, so you need to let the internal user
+access the files in the host. For that, we use `podman unshare chown`.
+
+```shell
+mkdir -p ${HOME}/.ilab
+podman unshare chown 1001:1001 -R ${HOME}/.ilab
+```
+
+Then, we can run the container, mounting the above folder and using the first
+NVIDIA GPU.
+
+```shell
+podman run --rm -it --user 1001 --device nvidia.com/gpu=0 --volume ${HOME}/.ilab:/opt/app-root/ilab:Z localhost/instructlab:cuda
+```
+
+The above command will print the help, as we didn't pass any argument.
+
+Let's initialize our configuration, download the model and start the chat bot.
+
+```shell
+podman run --rm -it --device nvidia.com/gpu=0 --volume ${HOME}/.ilab:/opt/appr-root/ilab:Z localhost/instructlab:cuda init
+podman run --rm -it --device nvidia.com/gpu=0 --volume ${HOME}/.ilab:/opt/app-root/ilab:Z localhost/instructlab:cuda download
+podman run --rm -it --device nvidia.com/gpu=0 --volume ${HOME}/.ilab:/opt/app-root/ilab:Z localhost/instructlab:cuda chat
+```
+
+## Creating an alias
+
+Now that you know how to run the container, you probably find it cumbersome
+to type the long `podman run` command, so we provide an alias definition in
+the [containers/cuda/instructlab-cuda.alias](../containers/cuda/instructlab-cuda.alias)
+file.
+
+You simply need to put it in your `${HOME}/.bashrc.d` folder and restart your
+bash shell to be able to call only `instructlab` or `ilab`.

--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -1,24 +1,243 @@
-# SPDX-License-Identifier: Apache-2.0
+# vim: syntax=dockerfile expandtab tabstop=4 shiftwidth=4
 
-FROM nvcr.io/nvidia/cuda:12.4.1-devel-ubi9
-RUN dnf install -y python3.11 python3.11-devel git python3-pip make automake gcc gcc-c++
+ARG OS_VERSION_MAJOR=9
+ARG BASE_IMAGE=quay.io/centos/centos:stream${OS_VERSION_MAJOR}
+
+FROM ${BASE_IMAGE}
+
+ARG OS_VERSION_MAJOR=9
+
+ENV LD_LIBRARY_PATH=/usr/lib64:/usr/lib
+
+ARG CUDA_VERSION=12.4.1
+ARG CUDA_DASHED_VERSION=12-4
+ARG CUDA_MAJOR_VERSION=12
+ARG CUDA_MINOR_VERSION=12.4
+ARG CUDNN_MAJOR_VERSION=8
+
+# /opt/app-root structure (same as s2i-core and ubi9/python-311)
+ENV APP_ROOT=/opt/app-root \
+    HOME=/opt/app-root/src \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Python, pip, and virtual env settings
+ARG PYTHON_VERSION=3.11
+ENV PYTHON_VERSION=${PYTHON_VERSION} \
+    PYTHON=python${PYTHON_VERSION} \
+    PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONIOENCODING=utf-8 \
+    VIRTUAL_ENV=${APP_ROOT} \
+    PS1="[instructlab \w]\$ "
+
+ARG PIP_INDEX_URL=https://pypi.org/simple
+
+ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+
+ENV TORCH_CUDA_ARCH_LIST="7.0 7.5 8.0 8.6 8.7 8.9 9.0+PTX"
+ENV TORCH_ALLOW_TF32_CUBLAS_OVERRIDE=1
+ENV TORCH_CUDNN_V8_API_ENABLED=1
+
+ARG INSTRUCTLAB_PKG="instructlab[cuda]"
+ARG INSTRUCTLAB_VERSION=''
+
+RUN dnf -y install --best --nodocs --setopt=install_weak_deps=False dnf-plugins-core \
+    && dnf config-manager --best --nodocs --setopt=install_weak_deps=False --save \
+    && dnf config-manager --enable crb \
+    && dnf install -y --nodocs \
+        alsa-lib \
+        asciidoc \
+        atlas \
+        bzip2 \
+        compat-openssl11 \
+        docbook-dtds \
+        docbook-style-xsl \
+        file \
+        findutils \
+        gdb \
+        git-core \
+        glibc-headers \
+        gnupg2 \
+        libjpeg-turbo \
+        libpng \
+        libsndfile \
+        libstdc++ \
+        jq \
+        libaio \
+        librdmacm \
+        libtiff \
+        libtool \
+        libuuid \
+        libyaml \
+        libxslt \
+        llvm \
+        make \
+        ncurses \
+        numactl \
+        openblas \
+        openblas-serial \
+        openmpi \
+        pango \
+        protobuf-compiler \
+        ${PYTHON} \
+        ${PYTHON}-devel \
+        ${PYTHON}-pip \
+        ${PYTHON}-setuptools-wheel \
+        skopeo \
+        snappy \
+        sudo \
+        tk \
+        unzip \
+        valgrind \
+        vim \
+        wget \
+        which \
+        lmdb \
+    && dnf clean all \
+    && ${PYTHON} -m venv --upgrade-deps ${VIRTUAL_ENV} \
+    && mkdir -p ${HOME}
+
+ENV OPENMPI_HOME="/usr/lib64/openmpi"
+
+ENV PATH="/${OPENMPI_HOME}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${OPENMPI_HOME}/lib64:${LD_LIBRARY_PATH}"
+ENV LIBRARY_PATH="${OPENMPI_HOME}/lib64:${LIBRARY_PATH}"
+ENV CMAKE_LIBRARY_PATH="${OPENMPI_HOME}/lib:${CUDA_HOME}/lib64:${CMAKE_LIBRARY_PATH}"
+ENV C_INCLUDE_PATH="${OPENMPI_HOME}/include:${C_INCLUDE_PATH}"
+ENV CPLUS_INCLUDE_PATH="${OPENMPI_HOME}/include:${CPLUS_INCLUDE_PATH}"
+ENV CMAKE_INCLUDE_PATH="${OPENMPI_HOME}/include:${CMAKE_INCLUDE_PATH}"
+
+# Install packages from EPEL
+RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OS_VERSION_MAJOR}.noarch.rpm \
+    && dnf config-manager --set-enabled epel \
+    && dnf install -y --nodocs \
+        --exclude=rust \
+        jemalloc \
+        llvm14-libs \
+        zeromq \
+    && dnf clean all
+
+ENV PATH=/root/.local/bin:${PATH}
+
+# Add NVIDIA repo for CUDA libraries
+RUN if [ "$(arch)" == "aarch64" ] ; then CUDA_REPO_ARCH="sbsa" ; else CUDA_REPO_ARCH=$(arch) ; fi \
+    && dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel${OS_VERSION_MAJOR}/${CUDA_REPO_ARCH}/cuda-rhel${OS_VERSION_MAJOR}.repo \
+    && dnf config-manager --set-enabled cuda-rhel9-${CUDA_REPO_ARCH}
+
+RUN dnf install -y --nodocs \
+        cuda-compat-${CUDA_DASHED_VERSION} \
+        cuda-minimal-build-${CUDA_DASHED_VERSION} \
+        cuda-toolkit-${CUDA_DASHED_VERSION} \
+        libcudnn${CUDNN_MAJOR_VERSION} \
+        libnccl \
+        libcutensor2 \
+    && dnf clean all \
+    && ln -s /usr/lib64/libcuda.so.1 /usr/lib64/libcuda.so
+
+# Define global NVIDIA environment variables
+
+ENV _CUDA_COMPAT_PATH=/usr/local/cuda/compat
+ENV CUDA_CACHE_DISABLE=1
+ENV CUDA_HOME="/usr/local/cuda"
+ENV CUDA_MODULE_LOADING="LAZY"
+ENV CUDA_SELECT_NVCC_ARCH_FLAGS=${TORCH_CUDA_ARCH_LIST}
+ENV CUDA_VERSION=${CUDA_VERSION}
+ENV LIBRARY_PATH="/usr/local/cuda/lib64/stubs"
+ENV NCCL_WORK_FIFO_DEPTH=4194304
+ENV NUMBA_CUDA_DRIVER="/usr/lib64/libcuda.so.1"
+ENV NVIDIA_CPU_ONLY=1
+ENV NVIDIA_DRIVER_CAPABILITIES="compute,utility,video"
+ENV NVIDIA_REQUIRE_CUDA=cuda>=9.0
+ENV NVIDIA_REQUIRE_JETPACK_HOST_MOUNTS=""
+ENV NVIDIA_VISIBLE_DEVICES="all"
+ENV USE_EXPERIMENTAL_CUDNN_V8_API=1
+
+ENV PATH="${CUDA_HOME}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${CUDA_HOME}/compat:${CUDA_HOME}/lib64:${CUDA_HOME}/lib64/stubs:${LD_LIBRARY_PATH}"
+ENV LIBRARY_PATH="${CUDA_HOME}/compat:${CUDA_HOME}/lib64:${CUDA_HOME}/lib64/stubs:${LIBRARY_PATH}"
+ENV CMAKE_LIBRARY_PATH="${CUDA_HOME}/compat:${CUDA_HOME}/lib64:${CUDA_HOME}/lib64/stubs:${CMAKE_LIBRARY_PATH}"
+ENV C_INCLUDE_PATH="${CUDA_HOME}/include:${C_INCLUDE_PATH}"
+ENV CPLUS_INCLUDE_PATH="${CUDA_HOME}/include:${CPLUS_INCLUDE_PATH}"
+ENV CMAKE_INCLUDE_PATH="${CUDA_HOME}/include:${CMAKE_INCLUDE_PATH}"
+
+# Install Intel oneAPI repository for Intel oneMKL
+COPY containers/cuda/intel-oneapi.repo /etc/yum.repos.d/oneapi.repo
+RUN dnf config-manager --set-enabled intel-oneapi
+
+RUN dnf -y install --nodocs \
+        intel-oneapi-mkl-core \
+    && dnf clean all
+
+# Define global Intel oneMKL environment variables
+ENV INTEL_MKL_HOME="/opt/intel/oneapi/mkl/latest"
+
+ENV PATH="${INTEL_MKL_HOME}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${INTEL_MKL_HOME}/lib:${LD_LIBRARY_PATH}"
+ENV LIBRARY_PATH="${INTEL_MKL_HOME}/lib:${LIBRARY_PATH}"
+ENV CMAKE_LIBRARY_PATH="${INTEL_MKL_HOME}/lib:${CMAKE_LIBRARY_PATH}"
+ENV C_INCLUDE_PATH="${INTEL_MKL_HOME}/include:${C_INCLUDE_PATH}"
+ENV CPLUS_INCLUDE_PATH="${INTEL_MKL_HOME}/include:${CPLUS_INCLUDE_PATH}"
+ENV CMAKE_INCLUDE_PATH="${INTEL_MKL_HOME}/include:${CMAKE_INCLUDE_PATH}"
+
+RUN source ${VIRTUAL_ENV}/bin/activate \
+    && if [ "${INSTRUCTLAB_VERSION}" != "" ] ; then \
+        INSTRUCTLAB_PKG="${INSTRUCTLAB_PKG}==${INSTRUCTLAB_VERSION}" ; \
+    fi \
+    && pip install torch psutil \
+    && pip install flash_attn --no-build-isolation \
+    && pip install "${INSTRUCTLAB_PKG}" -C cmake.args="-DLLAMA_CUDA=on" -C cmake.args="-DLLAMA_NATIVE=off" \
+    && pip install vllm@git+https://github.com/opendatahub-io/vllm@2024.08.01
+
+ENV TORCH_HOME="${VIRTUAL_ENV}/lib64/${PYTHON}/site-packages/torch"
+ENV PYTORCH_HOME="${VIRTUAL_ENV}/lib64/${PYTHON}/site-packages/torch"
+
+ENV PATH="${PYTORCH_HOME}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${PYTORCH_HOME}/lib:${LD_LIBRARY_PATH}"
+ENV LIBRARY_PATH="${PYTORCH_HOME}/lib:${LIBRARY_PATH}"
+ENV CMAKE_LIBRARY_PATH="${PYTORCH_HOME}/lib:${CMAKE_LIBRARY_PATH}"
+ENV C_INCLUDE_PATH="${PYTORCH_HOME}/include:${C_INCLUDE_PATH}"
+ENV CPLUS_INCLUDE_PATH="${PYTORCH_HOME}/include:${CPLUS_INCLUDE_PATH}"
+ENV CMAKE_INCLUDE_PATH="${PYTORCH_HOME}/include:${CMAKE_INCLUDE_PATH}"
+
+ENV PYTORCH_AUDIO_HOME="${VIRTUAL_ENV}/lib64/${PYTHON}/site-packages/torchaudio"
+
+ENV PATH="${PYTORCH_AUDIO_HOME}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${PYTORCH_AUDIO_HOME}/lib:${LD_LIBRARY_PATH}"
+ENV LIBRARY_PATH="${PYTORCH_AUDIO_HOME}/lib:${LIBRARY_PATH}"
+ENV CMAKE_LIBRARY_PATH="${PYTORCH_AUDIO_HOME}/lib:${CMAKE_LIBRARY_PATH}"
+ENV C_INCLUDE_PATH="${PYTORCH_AUDIO_HOME}/include:${C_INCLUDE_PATH}"
+ENV CPLUS_INCLUDE_PATH="${PYTORCH_AUDIO_HOME}/include:${CPLUS_INCLUDE_PATH}"
+ENV CMAKE_INCLUDE_PATH="${PYTORCH_AUDIO_HOME}/include:${CMAKE_INCLUDE_PATH}"
+
+ENV PYTORCH_DATA_HOME="${VIRTUAL_ENV}/lib64/${PYTHON}/site-packages/torchdata"
+
+ENV PATH="${PYTORCH_DATA_HOME}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${PYTORCH_DATA_HOME}/lib:${LD_LIBRARY_PATH}"
+ENV LIBRARY_PATH="${PYTORCH_DATA_HOME}/lib:${LIBRARY_PATH}"
+ENV CMAKE_LIBRARY_PATH="${PYTORCH_DATA_HOME}/lib:${CMAKE_LIBRARY_PATH}"
+ENV C_INCLUDE_PATH="${PYTORCH_DATA_HOME}/include:${C_INCLUDE_PATH}"
+ENV CPLUS_INCLUDE_PATH="${PYTORCH_DATA_HOME}/include:${CPLUS_INCLUDE_PATH}"
+ENV CMAKE_INCLUDE_PATH="${PYTORCH_DATA_HOME}/include:${CMAKE_INCLUDE_PATH}"
+
+ENV PYTORCH_TEXT_HOME="${VIRTUAL_ENV}/lib64/${PYTHON}/site-packages/torchtext"
+
+ENV PATH="${PYTORCH_TEXT_HOME}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${PYTORCH_TEXT_HOME}/lib:${LD_LIBRARY_PATH}"
+ENV LIBRARY_PATH="${PYTORCH_TEXT_HOME}/lib:${LIBRARY_PATH}"
+ENV CMAKE_LIBRARY_PATH="${PYTORCH_TEXT_HOME}/lib:${CMAKE_LIBRARY_PATH}"
+ENV C_INCLUDE_PATH="${PYTORCH_TEXT_HOME}/include:${C_INCLUDE_PATH}"
+ENV CPLUS_INCLUDE_PATH="${PYTORCH_TEXT_HOME}/include:${CPLUS_INCLUDE_PATH}"
+ENV CMAKE_INCLUDE_PATH="${PYTORCH_TEXT_HOME}/include:${CMAKE_INCLUDE_PATH}"
+
+ENV PYTORCH_VISION_HOME="${VIRTUAL_ENV}/lib64/${PYTHON}/site-packages/torchvision"
+
+ENV PATH="${PYTORCH_VISION_HOME}/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${PYTORCH_VISION_HOME}/lib:${LD_LIBRARY_PATH}"
+ENV LIBRARY_PATH="${PYTORCH_VISION_HOME}/lib:${LIBRARY_PATH}"
+ENV CMAKE_LIBRARY_PATH="${PYTORCH_VISION_HOME}/lib:${CMAKE_LIBRARY_PATH}"
+ENV C_INCLUDE_PATH="${PYTORCH_VISION_HOME}/include:${C_INCLUDE_PATH}"
+ENV CPLUS_INCLUDE_PATH="${PYTORCH_VISION_HOME}/include:${CPLUS_INCLUDE_PATH}"
+ENV CMAKE_INCLUDE_PATH="${PYTORCH_VISION_HOME}/include:${CMAKE_INCLUDE_PATH}"
+
 WORKDIR /instructlab
-RUN python3.11 -m ensurepip
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo && dnf repolist && dnf config-manager --set-enabled cuda-rhel9-x86_64 && dnf config-manager --set-enabled cuda && dnf config-manager --set-enabled epel && dnf update -y
-RUN dnf install -y libcudnn8 nvidia-driver-NVML nvidia-driver-cuda-libs
-RUN python3.11 -m pip install --force-reinstall nvidia-cuda-nvcc-cu12
-RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64" \
-    && export CUDA_HOME=/usr/local/cuda \
-    && export PATH="/usr/local/cuda/bin:$PATH" \
-    && export XLA_TARGET=cuda120 \
-    && export XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
-
-ARG GIT_TAG=stable
-RUN if [[ "$(uname -m)" != "aarch64" ]]; then export CFLAGS="-mno-avx"; fi && \
-    CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install -r https://raw.githubusercontent.com/instructlab/instructlab/${GIT_TAG}/requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
-RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@${GIT_TAG}
-
-CMD ["/bin/bash"]
-
-LABEL com.redhat.component="instructlab"
+ENTRYPOINT ["/bin/bash"]

--- a/containers/cuda/intel-oneapi.repo
+++ b/containers/cuda/intel-oneapi.repo
@@ -1,0 +1,7 @@
+[intel-oneapi]
+name=Intel® oneAPI repository
+baseurl=https://yum.repos.intel.com/oneapi
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB


### PR DESCRIPTION
This change modifies the Containerfile for NVIDIA CUDA to:
- Use CentOS Stream 9 as the default base image. UBI9 also works
- Install the NVIDIA packages from NVIDIA repository for exact CUDA version
- Add NVIDIA scripts from `nvcr.io/nvidia/cuda` image for copyrights...
- Install the Python packages in a Python 3.11 virtualenv
- Install instructlab package from PyPI
- Allow specifying the instructlab version at build time
- Make the final container rootless

Resolves #899
Replaces #932
Replaces #994