### PR TITLE
Use instructlab-schema package to parse qna.yaml files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,9 @@ GitPython>=3.1.42
 httpx>=0.25.0
 instructlab-eval>=0.1.1
 instructlab-quantize>=0.1.0
-instructlab-schema>=0.3.1
+instructlab-schema>=0.4.0
 instructlab-sdg>=0.2.6
 instructlab-training>=0.4.1
-jsonschema>=4.21.1
 llama_cpp_python[server]==0.2.79
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 # HabanaLabs / Intel Gaudi env comes with Python 3.10 and slightly older
@@ -41,7 +40,3 @@ transformers>=4.40.0 ; python_version == '3.10'
 transformers>=4.41.2 ; python_version >= '3.11'
 trl>=0.9.4
 wandb>=0.16.4
-# the below library should NOT be imported into any python files
-# it is for CLI usage ONLY
-yamllint>=1.35.1
-referencing>=0.35.0

--- a/src/instructlab/taxonomy/diff.py
+++ b/src/instructlab/taxonomy/diff.py
@@ -45,13 +45,11 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
     and checks that taxonomy is valid. Similar to 'git diff <ref>'.
     """
     # pylint: disable=import-outside-toplevel
+    # Third Party
+    from instructlab.schema.taxonomy import TaxonomyReadingException
+
     # Local
-    from ..utils import (
-        TaxonomyReadingException,
-        get_taxonomy,
-        get_taxonomy_diff,
-        validate_taxonomy,
-    )
+    from ..utils import get_taxonomy, get_taxonomy_diff, validate_taxonomy
 
     # load defaults from config ctx obj if not specified via CLI arg
     if not taxonomy_base:
@@ -83,7 +81,7 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
 
     # validate new or changed taxonomy files
     try:
-        validate_taxonomy(None, taxonomy_path, taxonomy_base, yaml_rules)
+        validate_taxonomy(taxonomy_path, taxonomy_base, yaml_rules)
     except (TaxonomyReadingException, yaml.YAMLError) as exc:
         if not quiet:
             click.secho(

--- a/tests/testdata/knowledge_unsupported.yaml
+++ b/tests/testdata/knowledge_unsupported.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+created_by: test-bot
+version: 2
+domain: test-domain
+seed_examples:
+- question: What is this knowledge about?
+  answer: It's a knowledge that makes the tests more knowledgeable
+- answer: "answer2"
+  question: "question2"
+- answer: "answer3"
+  question: "question3"
+- answer: "answer4"
+  question: "question4"
+- answer: "answer5"
+  question: "question5"
+task_description: For knowledge tests
+document:
+  repo: https://github.com/example-org/example-repo
+  commit: a0c3c8e
+  patterns:
+  - "*.md"
+  - docs/*.md

--- a/tox.ini
+++ b/tox.ini
@@ -139,7 +139,6 @@ description = Python type checking with mypy
 basepython = {[testenv:py3]basepython}
 deps =
   mypy>=1.10.0,<2.0
-  types-jsonschema
   types-PyYAML
   types-requests
   types-tqdm


### PR DESCRIPTION
We replace parsing/validation code to use the shared code from instructlab-schema package.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
