### PR TITLE
train: Remove cli options that are not used

### DIFF
--- a/scripts/basic-workflow-tests.sh
+++ b/scripts/basic-workflow-tests.sh
@@ -278,7 +278,9 @@ test_train() {
         DATA=$(find "${DATA_HOME}"/instructlab/datasets -name 'messages_*' | head -n 1)
         # TODO Only cuda for now
         # the train profile specified in test_init overrides the majority of TRAIN_ARGS, including things like num_epochs. While it looks like much of those settings are being lost, they just have different values here.
-        TRAIN_ARGS=("--device=cuda" "--model-path=${GRANITE_SAFETENSOR_REPO}" "--data-path=${DATA}" "--lora-quantize-dtype=nf4" "--4-bit-quant" "--effective-batch-size=4" "--is-padding-free=False")
+        TRAIN_ARGS=("--device=cuda" "--model-path=${GRANITE_SAFETENSOR_REPO}" "--data-path=${DATA}" "--4-bit-quant")
+	# TODO: Should some of these options be configured via train profile?
+        #TRAIN_ARGS=("--device=cuda" "--model-path=${GRANITE_SAFETENSOR_REPO}" "--data-path=${DATA}" "--lora-quantize-dtype=nf4" "--4-bit-quant" "--effective-batch-size=4" "--is-padding-free=False")
         if [ "${BACKEND}" != "vllm" ]; then
             TRAIN_ARGS+=("--gguf-model-path" "${CACHE_HOME}/instructlab/models/${GRANITE_GGUF_MODEL}")
         fi

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -38,14 +38,6 @@ ADDITIONAL_ARGUMENTS = "additional_args"
     help="output directory to store checkpoints in during training",
 )
 @click.option(
-    "--data-output-dir",
-    type=click.Path(),
-    cls=clickext.ConfigOption,
-    required=True,  # default from config
-    default=lambda: DEFAULTS.INTERNAL_DIR,
-    help="output directory to store training data in",
-)
-@click.option(
     "--input-dir",
     type=click.Path(),
     show_default=True,  # TODO: set to None and change help message
@@ -125,158 +117,6 @@ ADDITIONAL_ARGUMENTS = "additional_args"
     ),
 )
 @click.option(
-    "--max-seq-len",
-    type=int,
-    cls=clickext.ConfigOption,
-    required=True,  # default from config
-    help="maximum length, in tokens, of a single sample.",
-)
-@click.option(
-    "--max-batch-len",
-    type=int,
-    cls=clickext.ConfigOption,
-    required=True,  # default from config
-    help="maximum overall length of samples processed in a given batch.",
-)
-@click.option(
-    "--effective-batch-size",
-    type=int,
-    cls=clickext.ConfigOption,
-    required=True,  # default from config
-    help="total batch size across all GPUs",
-)
-@click.option(
-    "--save-samples",
-    type=int,
-    cls=clickext.ConfigOption,
-    required=True,  # default from config
-    help="The number of samples processed in between checkpoints.",
-)
-@click.option(
-    "--learning-rate",
-    type=float,
-    cls=clickext.ConfigOption,
-    config_sections=ADDITIONAL_ARGUMENTS,
-    required=True,  # default from config
-    help="learning rate for training",
-)
-@click.option(
-    "--warmup-steps",
-    type=int,
-    cls=clickext.ConfigOption,
-    config_sections=ADDITIONAL_ARGUMENTS,
-    required=True,  # default from config
-    help="warmup steps for training",
-)
-@click.option(
-    "--deepspeed-cpu-offload-optimizer",
-    type=bool,
-    cls=clickext.ConfigOption,
-    required=True,  # default from config
-    # config_section="deepspeed_options",
-    help="if true enables optimizer offload",
-)
-@click.option(
-    "--deepspeed-cpu-offload-optimizer-ratio",
-    type=float,
-    cls=clickext.ConfigOption,
-    required=True,  # default from config
-    config_sections=ADDITIONAL_ARGUMENTS,
-    help="cpu offload optimizer ratio",
-)
-@click.option(
-    "--deepspeed-cpu-offload-optimizer-pin-memory",
-    type=bool,
-    cls=clickext.ConfigOption,
-    required=True,  # default from config
-    config_sections=ADDITIONAL_ARGUMENTS,
-    help="if true pin memory when using cpu optimizer",
-)
-# below flags are invalid if lora == false
-@click.option(
-    "--lora-rank",
-    type=int,
-    cls=clickext.ConfigOption,
-    required=True,  # default from config
-    # config_section="lora",
-    help="rank of update matricies",
-)
-@click.option(
-    "--lora-alpha",
-    type=int,
-    cls=clickext.ConfigOption,
-    required=True,  # default from config
-    config_sections=ADDITIONAL_ARGUMENTS,
-    help="how influential/strong lora tune will be",
-)
-@click.option(
-    "--lora-dropout",
-    type=float,
-    cls=clickext.ConfigOption,
-    required=True,  # default from config
-    config_sections=ADDITIONAL_ARGUMENTS,
-    help="dropout for LoRA layers",
-)
-@click.option(
-    "--lora-target-modules",
-    cls=clickext.ConfigOption,
-    config_sections=ADDITIONAL_ARGUMENTS,
-    multiple=True,
-    default=[],
-    help="LoRA modules to use",
-)
-@click.option(
-    "--lora-quantize-dtype",
-    type=str,
-    default=None,
-    help="quantization data type to use when training a LoRA.",
-)
-@click.option(
-    "--is-padding-free",
-    cls=clickext.ConfigOption,
-    type=bool,
-    help="whether or not we are training a padding free transformer.",
-)
-@click.option(
-    "--gpus",
-    "nproc_per_node",
-    cls=clickext.ConfigOption,
-    type=int,
-    help="this is the number of GPUs to use. This is a torch specific arg and must be called nproc-per-node",
-)
-@click.option(
-    "--nnodes",
-    type=int,
-    cls=clickext.ConfigOption,
-    config_sections=ADDITIONAL_ARGUMENTS,
-    required=True,  # default from config
-    help="number of machines in the training pool.",
-)
-@click.option(
-    "--node-rank",
-    type=int,
-    cls=clickext.ConfigOption,
-    config_sections=ADDITIONAL_ARGUMENTS,
-    required=True,  # default from config
-    help="the rank of this machine in the training group.",
-)
-@click.option(
-    "--rdzv-id",
-    type=int,
-    cls=clickext.ConfigOption,
-    config_sections=ADDITIONAL_ARGUMENTS,
-    required=True,  # default from config
-    help="this is the training group ID. So, if there are multiple matching endpoints, only the machines with matching IDs can connect.",
-)
-@click.option(
-    "--rdzv-endpoint",
-    type=str,
-    cls=clickext.ConfigOption,
-    config_sections=ADDITIONAL_ARGUMENTS,
-    required=True,  # default from config
-    help="this is the rendezvous endpoint which other torchrun jobs will join on.",
-)
-@click.option(
     "--legacy",
     is_flag=True,
     default=False,
@@ -299,7 +139,7 @@ def train(
     device: str,
     four_bit_quant: bool,
     legacy,
-    **kwargs,
+    ckpt_output_dir,
 ):
     """
     Takes synthetic data generated locally with `ilab data generate` and the previous model and learns a new model using the MLX API.
@@ -315,7 +155,6 @@ def train(
     effective_data_dir = Path(data_path if data_path else DEFAULTS.DATASETS_DIR)
     train_file = Path(effective_data_dir / "train_gen.jsonl")
     test_file = Path(effective_data_dir / "test_gen.jsonl")
-    ckpt_output_dir = Path(kwargs["ckpt_output_dir"])
 
     # NOTE: If given a data_dir, input-dir is ignored in favor of existing!
     if not data_path or data_path.strip() == DEFAULTS.DATASETS_DIR:


### PR DESCRIPTION
These options seem dead end? Not read by anything. Is it a remnant of migration to train profiles or something else?

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
