### PR TITLE
Increase default vllm startup attempts and make configurable

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -260,6 +260,7 @@ class _serve_vllm(BaseModel):
     """Class describing configuration of vllm serving backend."""
 
     llm_family: str = ""
+    max_startup_attempts: int | None = None
     # arguments to pass into vllm process
     vllm_args: list[str] | None = None
 
@@ -281,6 +282,7 @@ class _serve(BaseModel):
     # vllm configuration
     vllm: _serve_vllm = _serve_vllm(
         llm_family="",
+        max_startup_attempts=300,
         vllm_args=[],
     )
 
@@ -438,6 +440,7 @@ def get_default_config() -> Config:
             ),
             vllm=_serve_vllm(
                 llm_family="",
+                max_startup_attempts=300,
                 vllm_args=[],
             ),
         ),

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -310,6 +310,7 @@ def ensure_server(
     port=8000,
     background=True,
     server_process_func=None,
+    max_startup_attempts=None,
 ) -> Tuple[
     Optional[multiprocessing.Process], Optional[subprocess.Popen], Optional[str]
 ]:
@@ -331,9 +332,9 @@ def ensure_server(
         vllm_server_process = server_process_func(port, background)
         logger.info("Starting a temporary vLLM server at %s", temp_api_base)
         count = 0
-        # TODO should this be configurable?
-
-        vllm_startup_max_attempts = 80  # Each call to check_api_base takes >2s + 2s sleep = ~5 mins of wait time
+        # Each call to check_api_base takes >2s + 2s sleep
+        # Default to 300 if not specified (~20 mins of wait time)
+        vllm_startup_max_attempts = max_startup_attempts or 300
         start_time_secs = time()
         while count < vllm_startup_max_attempts:
             count += 1
@@ -455,6 +456,7 @@ def select_backend(
             vllm_args=cfg.vllm.vllm_args,
             host=host,
             port=port,
+            max_startup_attempts=cfg.vllm.max_startup_attempts,
         )
     click.secho(f"Unknown backend: {backend}", fg="red")
     raise click.exceptions.Exit(1)

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -44,6 +44,7 @@ class Server(BackendServer):
         port: int,
         background: bool = False,
         vllm_args: typing.Iterable[str] | None = (),
+        max_startup_attempts: int | None = None,
     ):
         super().__init__(model_family, model_path, chat_template, api_base, host, port)
         self.api_base = api_base
@@ -52,6 +53,7 @@ class Server(BackendServer):
         self.vllm_args: list[str]
         self.vllm_args = list(vllm_args) if vllm_args is not None else []
         self.process: subprocess.Popen | None = None
+        self.max_startup_attempts = max_startup_attempts
 
     def run(self):
         self.process, files = run_vllm(
@@ -101,6 +103,7 @@ class Server(BackendServer):
                 port=self.port,
                 background=background,
                 server_process_func=self.create_server_process,
+                max_startup_attempts=self.max_startup_attempts,
             )
             self.process = vllm_server_process or self.process
             self.api_base = api_base or self.api_base

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -49,6 +49,7 @@ generate:
     model_path: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
     vllm:
       llm_family: ''
+      max_startup_attempts: 300
       vllm_args: []
 serve:
   backend: null
@@ -61,6 +62,7 @@ serve:
   model_path: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
   vllm:
     llm_family: ''
+    max_startup_attempts: 300
     vllm_args: []
 train:
   additional_args: {}


### PR DESCRIPTION
With larger models, the existing ~5 mins timeout proved not to be sufficient on some hardware.  The longest startup times seen so far have been in the 8 min range.  This moves the default up to 20 mins and makes the retry attempts configurable.  The new config param is being added as optional so config changes aren't required.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
