### PR TITLE
Fail fast when vllm errors out and exits

### DIFF
--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -262,6 +262,7 @@ def generate(
                     }
                 ),
                 background=not enable_serving_output,
+                foreground_allowed=True,
             )
         except Exception as exc:
             click.secho(f"Failed to start server: {exc}", fg="red")

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -95,7 +95,10 @@ class Server(BackendServer):
         return server_process
 
     def run_detached(
-        self, http_client: httpx.Client | None = None, background: bool = True
+        self,
+        http_client: httpx.Client | None = None,
+        background: bool = True,
+        foreground_allowed: bool = False,
     ) -> str:
         logger.info(f"Trying to connect to model server at {self.api_base}")
         if check_api_base(self.api_base, http_client):

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -90,7 +90,10 @@ class Server(BackendServer):
         return server_process
 
     def run_detached(
-        self, http_client: httpx.Client | None = None, background: bool = True
+        self,
+        http_client: httpx.Client | None = None,
+        background: bool = True,
+        foreground_allowed: bool = False,
     ) -> str:
         try:
             _, vllm_server_process, api_base = ensure_server(
@@ -100,6 +103,7 @@ class Server(BackendServer):
                 host=self.host,
                 port=self.port,
                 background=background,
+                foreground_allowed=foreground_allowed,
                 server_process_func=self.create_server_process,
             )
             self.process = vllm_server_process or self.process

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -344,6 +344,7 @@ def launch_server(
                 }
             ),
             background=not enable_serving_output,
+            foreground_allowed=True,
         )
     except Exception as exc:
         click.secho(f"Failed to start server: {exc}", fg="red")

--- a/tests/test_lab_model_test.py
+++ b/tests/test_lab_model_test.py
@@ -26,7 +26,10 @@ class TestLabModelTest:
             super().__init__("", "", "", "", "", 0)
 
         def run_detached(
-            self, http_client: httpx.Client | None = None, background: bool = True
+            self,
+            http_client: httpx.Client | None = None,
+            background: bool = True,
+            foreground_allowed: bool = False,
         ) -> str:
             return "api_base_mock"
 


### PR DESCRIPTION
Previously, if vllm failed to start and raised an exception, the logic would have tried until its max attempts ran out to connect to a server that had already died.  This new logic detects if the server process is stopped, and if so outputs a message to use --enable-serving-output to debug further if the option is available.  So users will get a quick failure and guidance on debugging.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
