### PR TITLE
doc: remove "testing doesn't work on Linux"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
 
 ## 📋 Requirements
 
-- **🍎 Apple M1/M2/M3 Mac or 🐧 Linux system** (tested on Fedora). Note Linux
- is not fully supported (testing a trained model does not currently work on Linux).
+- **🍎 Apple M1/M2/M3 Mac or 🐧 Linux system** (tested on Fedora).
   We anticipate support for more operating systems in the future.
 - C++ compiler
 - Python 3.10 or Python 3.11


### PR DESCRIPTION
Already supported, see #1337
