### PR TITLE
feat: add pipeline into generate config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 * Legacy Linux training is now compatible with the phase07 pretraining format.
 * Add support for `ILAB_TRAIN_PROFILE_DIR` which will point to the template train profiles to be brought into the `train_configuration` directory.
 * Add interactive prompt for users to choose their train profile.
+* The `generate` section of the config now has a `pipeline` value. This value sets a default value
+  and can be overridden by the `--pipeline` flag. The default for this value is 'simple'.
 
 ### Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Before following these instructions, ensure the existing model you are adding sk
    (venv) $ ilab data generate
    INFO 2024-07-30 19:57:44,093 numexpr.utils:161: NumExpr defaulting to 8 threads.
    INFO 2024-07-30 19:57:44,452 datasets:58: PyTorch version 2.3.1 available.
-   Generating synthetic data using '$HOME/.cache/instructlab/models/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf' model, taxonomy:'./taxonomy' against http://localhost:8000/v1 server
+   Generating synthetic data using 'simple' pipeline, '$HOME/.cache/instructlab/models/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf' model, './taxonomy' taxonomy, against http://localhost:8000/v1 server
    INFO 2024-07-30 19:57:45,084 instructlab.sdg:375: Synthesizing new instructions. If you aren't satisfied with the generated instructions, interrupt training (Ctrl-C) and try adjusting your YAML files. Adding more examples may help.
    INFO 2024-07-30 19:57:45,090 instructlab.sdg.pipeline:153: Running pipeline single-threaded
    INFO 2024-07-30 19:57:47,820 instructlab.sdg.llmblock:51: LLM server supports batched inputs: False

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -84,6 +84,7 @@ class _InstructlabDefaults:
     CONNECTION_TIMEOUT = httpx.Timeout(timeout=30.0)
     # use spawn start method, fork is not thread-safe
     MULTIPROCESSING_START_METHOD = "spawn"
+    SDG_PIPELINE = "simple"
     SDG_SCALE_FACTOR = 30
 
     # When otherwise unknown, ilab uses this as the default family
@@ -363,6 +364,7 @@ class _generate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     # required fields
+    pipeline: StrictStr = DEFAULTS.SDG_PIPELINE
     model: StrictStr
     taxonomy_path: StrictStr
     taxonomy_base: StrictStr

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -364,7 +364,7 @@ class _generate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     # required fields
-    pipeline: StrictStr = DEFAULTS.SDG_PIPELINE
+    pipeline: Optional[str] = DEFAULTS.SDG_PIPELINE
     model: StrictStr
     taxonomy_path: StrictStr
     taxonomy_base: StrictStr

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -143,7 +143,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--pipeline",
     type=click.STRING,
-    default="simple",
+    cls=clickext.ConfigOption,
     help="Data generation pipeline to use. Available: simple, full, or a valid path to a directory of pipeline workflow YAML files. Note that 'full' requires a larger teacher model, Mixtral-8x7b.",
 )
 @click.option(
@@ -284,7 +284,7 @@ def generate(
 
     try:
         click.echo(
-            f"Generating synthetic data using '{model_path}' model, taxonomy:'{taxonomy_path}' against {api_base} server"
+            f"Generating synthetic data using '{pipeline}' pipeline, '{model_path}' model, '{taxonomy_path}' taxonomy, against {api_base} server"
         )
         generate_data(
             logger=logging.getLogger("instructlab.sdg"),  # TODO: remove

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -198,6 +198,18 @@ def generate(
     from instructlab.sdg.generate_data import generate_data
     from instructlab.sdg.utils import GenerateException
 
+    # if --pipeline is not used, pipeline defaults to the value of ctx.obj.config.generate.pipeline
+    # set in the config file. A user could intentionally set this to 'null' in the config file
+    # if they want to ensure --pipeline needs to be used.
+    # This would happen if the type of pipeline needs to be different across different runs of
+    # `ilab data generate`.
+    if not pipeline:
+        click.secho(
+            "Pipeline not set. Please use the --pipeline flag or set it in the config file.",
+            fg="red",
+        )
+        raise click.exceptions.Exit(1)
+
     if num_instructions != -1:
         click.secho(
             "The --num-instructions flag is deprecated. Please use --sdg-scale-factor instead.",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,6 +59,7 @@ class TestConfig:
         assert cfg.generate.teacher.host_port == "127.0.0.1:8000"
         assert cfg.generate.teacher.backend is None
         assert cfg.generate.teacher.chat_template is None
+        assert cfg.generate.pipeline == "simple"
         assert cfg.generate.model == default_model
         assert cfg.generate.taxonomy_path == f"{data_dir}/taxonomy"
         assert cfg.generate.taxonomy_base == "origin/main"
@@ -128,6 +129,7 @@ class TestConfig:
                 """general:
   log_level: INFO
 generate:
+  pipeline: simple
   teacher:
     model_path: models/granite-7b-lab-Q4_K_M.gguf
     chat_template: tokenizer
@@ -194,6 +196,7 @@ version: 1.0.0
 chat:
   model: models/granite-7b-lab-Q4_K_M.gguf
 generate:
+  pipeline: simple
   model: models/granite-7b-lab-Q4_K_M.gguf
   taxonomy_base: upstream/main
   taxonomy_path: mytaxonomy
@@ -239,6 +242,7 @@ general:
         cfg = config.read_config(config_path)
         assert cfg is not None
         assert cfg.chat.model == "models/granite-7b-lab-Q4_K_M.gguf"
+        assert cfg.generate.pipeline == "simple"
         assert cfg.generate.model == "models/granite-7b-lab-Q4_K_M.gguf"
         assert cfg.serve.llama_cpp.gpu_layers == 1
         assert cfg.serve.llama_cpp.max_ctx_size == 2048

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -32,6 +32,7 @@ generate:
   model: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
   num_cpus: 10
   output_dir: /data/instructlab/datasets
+  pipeline: simple
   prompt_file: /data/instructlab/internal/prompt.txt
   sdg_scale_factor: 30
   seed_file: /data/instructlab/internal/seed_tasks.json


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

Most flags have config variable associated with them. The --pipeline flag for the `ilab data generate` command does not have a config variable associated with it. Ideally the `ilab data generate` command should need as few flags as possible once the config file is set.

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
