### PR TITLE
fix: wrong phased_phase2_data path into _run_phased_training

### DIFF
--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -668,7 +668,7 @@ def train(
                 phase1_num_epochs=phased_phase1_num_epochs,
                 phase1_samples_per_save=phased_phase1_samples_per_save,
                 phase1_checkpoints_dir=phased_base_dir / "phase1" / "checkpoints",
-                phase2_data=phased_phase1_data,
+                phase2_data=phased_phase2_data,
                 phase2_num_epochs=phased_phase2_num_epochs,
                 phase2_samples_per_save=phased_phase2_samples_per_save,
                 phase2_checkpoints_dir=phased_base_dir / "phase2" / "checkpoints",


### PR DESCRIPTION
@bbrowning caught that we were passing `phased_phase1_data` into `_run_phased_training` where it should have been `phased_phase2_data`
