### PR TITLE
replace 6 arguments of generate_data() with client

### DIFF
--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -7,6 +7,7 @@ import os.path
 
 # Third Party
 import click
+import openai
 
 # First Party
 from instructlab import clickext
@@ -275,6 +276,9 @@ def generate(
                     "Disabling SDG batching - unsupported with llama.cpp serving"
                 )
             batch_size = 0
+    client = openai.OpenAI(
+        base_url=api_base, api_key=api_key, http_client=http_client(ctx.params)
+    )
 
     # Specify checkpoint dir if batching is enabled
     checkpoint_dir = None
@@ -287,8 +291,7 @@ def generate(
         )
         generate_data(
             logger=logging.getLogger("instructlab.sdg"),  # TODO: remove
-            api_base=api_base,
-            api_key=api_key,
+            client=client,
             model_family=model_family,
             model_name=model_path,
             num_cpus=num_cpus,
@@ -302,10 +305,6 @@ def generate(
             yaml_rules=yaml_rules,
             chunk_word_count=chunk_word_count,
             server_ctx_size=server_ctx_size,
-            tls_insecure=tls_insecure,
-            tls_client_cert=tls_client_cert,
-            tls_client_key=tls_client_key,
-            tls_client_passwd=tls_client_passwd,
             pipeline=pipeline,
             batch_size=batch_size,
             checkpoint_dir=checkpoint_dir,


### PR DESCRIPTION
The `generate_data` argument list has become quite large.
It's necessary to refactor the code to maintain cleanliness and readability.
