### PR TITLE
Add 'ilab config edit'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ issues = "https://github.com/instructlab/instructlab/issues"
 "taxonomy" = "instructlab.taxonomy.taxonomy:taxonomy"
 
 [project.entry-points."instructlab.command.config"]
+"edit" = "instructlab.config.edit:edit"
 "init" = "instructlab.config.init:init"
 "show" = "instructlab.config.show:show"
 

--- a/src/instructlab/config/edit.py
+++ b/src/instructlab/config/edit.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# Third Party
+import click
+
+# First Party
+from instructlab import clickext
+
+
+@click.command()
+@click.pass_context
+@clickext.display_params
+def edit(
+    ctx,
+):
+    """Launch $EDITOR to edit the configuration file."""
+    click.edit(filename=ctx.obj.config_file)

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -80,6 +80,7 @@ subcommands: list[Command] = [
     # first, second, extra args
     Command((), needs_config=False),
     Command(("config",), needs_config=False),
+    Command(("config", "edit")),
     Command(("config", "init"), needs_config=False),
     Command(("config", "show")),
     Command(("model",), needs_config=False),


### PR DESCRIPTION
This is a convenience command that will automatically launch your
${EDITOR} to edit the ilab configuration file. This saves typing out
the config storage location, or makes it so you don't have to remember
where it is.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
