### PR TITLE
fix: introduce vram stability waiting

### DIFF
--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -125,6 +125,7 @@ class Server(BackendServer):
         # Needed when a temporary server is started
         if self.process is not None:
             shutdown_process(self.process, 20)
+            self.process = None
 
     def get_backend_type(self):
         return VLLM

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ passenv =
 setenv =
     PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
     CMAKE_ARGS={env:CMAKE_ARGS:-DLLAMA_NATIVE=off}
+    ILAB_MAX_STABLE_VRAM_WAIT=0
 package = wheel
 wheel_build_env = pkg
 # equivalent to `pip install instructlab[cpu]`


### PR DESCRIPTION
vLLM requires GPU vram usage to be stable when calculating its memory pools. A hard failure on start occurs when it detects this is not the case. This creates a racy failure condition for various InstructLab facilities, such as evaluation, which rely on multiple successive restarts.

Address the problem by introducing a cool down period after process termination. This will complete as early as 10s if VRAM stability is detected. In the event of in-flight reclamation this will wait as long as 30s.

Additionally address an issue where shutdown was being run twice.

No tests are included in this PR since the condition is racy. Coverage is provided by standard CI. In the future we should introduce a stress harness. 