### PR TITLE
Check if a model server is already running when doing ilab data generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@
    value.
 * `ilab model chat`: Fixed an issue where the default served model couldn't be resolved when running
    model besides the default `merlinite-7b-lab-Q4_K_M.gguf`.
+* `ilab data generate`: Fixed a bug where ilab wasn't correctly checking if the user was actively serving
+   a model before serving its own.
 
 ## v0.17
 

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -26,7 +26,7 @@ import openai
 from instructlab import clickext
 from instructlab import client as ilabclient
 from instructlab import configuration as cfg
-from instructlab.utils import HttpClientParams
+from instructlab.utils import is_openai_server_and_serving_model
 
 # Local
 from ..utils import get_sysprompt, http_client
@@ -63,22 +63,6 @@ PROMPT_HISTORY_FILEPATH = os.path.expanduser("~/.local/chat-cli.history")
 PROMPT_PREFIX = ">>> "
 
 DEFAULT_ENDPOINT = cfg.get_api_base(cfg._serve().host_port)
-
-
-def is_openai_server_and_serving_model(
-    endpoint: str, api_key: str, http_params: HttpClientParams
-) -> bool:
-    """
-    Given an endpoint, returns whether or not the server is OpenAI-compatible
-    and is actively serving at least one model.
-    """
-    try:
-        models = ilabclient.list_models(
-            endpoint, api_key=api_key, http_client=http_client(http_params)
-        )
-        return len(models.data) > 0
-    except ilabclient.ClientException:
-        return False
 
 
 @click.command()

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -28,6 +28,9 @@ import gitdb
 import httpx
 import yaml
 
+# First Party
+from instructlab import client as ilabclient
+
 # Local
 from . import common
 
@@ -833,3 +836,31 @@ def clear_directory(path: pathlib.Path) -> None:
     if path.exists():
         shutil.rmtree(path)
     os.makedirs(path)
+
+
+def is_openai_server_and_serving_model(
+    endpoint: str, api_key: str, http_params: HttpClientParams
+) -> bool:
+    """
+    Given an endpoint, returns whether or not the server is OpenAI-compatible
+    and is actively serving at least one model.
+    """
+    try:
+        models = ilabclient.list_models(
+            endpoint, api_key=api_key, http_client=http_client(http_params)
+        )
+        return len(models.data) > 0
+    except ilabclient.ClientException:
+        return False
+
+
+def is_valid_path(p: str) -> bool:
+    """
+    Determines whether the given string is a valid path or not.
+    This allows us to safely cast it into a `Path` object and perform Path operations on it.
+    """
+    try:
+        Path(p)
+    except Exception:
+        return False
+    return True


### PR DESCRIPTION
Resolves #1882

Today in ilab model serve, it is required to provide an endpoint url in order to override the
default behavior of ilab launching a separate model server to generate data. The other
alternative is to specify the model we are generating from, which is redundant since
the user had to have already done this when they initially served the model.

Therefore; this PR uses the users host port to check if a server at that address
is running, OpenAI-compliant, and actively serving a model. If all of these checks
succeed, we default to the user-provided endpoint URL when no other endpoint URL
is passed.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
