### PR TITLE
ux: update init output for training profiles

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -111,20 +111,21 @@ def init(
     elif interactive:
         entries = listdir(DEFAULTS.TRAIN_PROFILE_DIR)
         click.echo("Please choose a train profile to use:")
+        click.echo("[0] No profile (CPU-only)")
         for i, value in enumerate(entries):
-            click.echo(f"{i}. {value}")
+            click.echo(f"[{i+1}] {value}")
         train_profile_selection = click.prompt(
-            "Enter the number of your choice [hit enter for the default]",
+            "Enter the number of your choice [hit enter for the default CPU-only profile]",
             type=int,
-            default=-1,
+            default=0,
         )
-        if 0 <= train_profile_selection < len(entries):
-            click.echo(f"You selected: {entries[train_profile_selection]}")
+        if 1 <= train_profile_selection < len(entries):
+            click.echo(f"You selected: {entries[train_profile_selection - 1]}")
             cfg.train = read_train_profile(
-                join(DEFAULTS.TRAIN_PROFILE_DIR, entries[train_profile_selection])
+                join(DEFAULTS.TRAIN_PROFILE_DIR, entries[train_profile_selection - 1])
             )
-        elif train_profile_selection == -1:
-            click.echo("Using default train profile.")
+        elif train_profile_selection == 0:
+            click.echo("Using default CPU-only train profile.")
         else:
             click.secho(
                 "Invalid selection. Please select a valid train profile option.",


### PR DESCRIPTION
This PR updates the formatting of the train profile init output:

Current:
```bash
Please choose a train profile to use:
0. A100_H100_x4.yaml
1. A100_H100_x8.yaml
2. A100_H100_x2.yaml
3. L40_x8.yaml
4. L40_x4.yaml
5. L4_x8.yaml
Enter the number of your choice [hit enter for the default] [-1]: 
Using default train profile.
Initialization completed successfully, you're ready to start using `ilab`. Enjoy!
```

After this PR:
```bash
Please choose a train profile to use:
[0] No profile (CPU-only)
[1] A100_H100_x4.yaml
[2] A100_H100_x8.yaml
[3] A100_H100_x2.yaml
[4] L40_x8.yaml
[5] L40_x4.yaml
[6] L4_x8.yaml
Enter the number of your choice [hit enter for the default CPU-only profile] [0]: 
Using default CPU-only train profile.
Initialization completed successfully, you're ready to start using `ilab`. Enjoy!
```

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
