### PR TITLE
chore: reorder location of config profiles

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -805,8 +805,8 @@ def ensure_storage_directories_exist():
     }
 
     TRAIN_DIR_EXPECTED_FILES = {
-        "A100_H100_x4.yaml",
         "A100_H100_x8.yaml",
+        "A100_H100_x4.yaml",
         "A100_H100_x2.yaml",
         "L40_x8.yaml",
         "L40_x4.yaml",


### PR DESCRIPTION
We introduced a few training profiles in an earlier PR. This commit updates the ordering of the
profile files so that the A100_H100_x8.yaml file is on the top to be consistent with the other
orderings, which are also in descending order.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
