### PR TITLE
`ilab` global config fixes

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -154,7 +154,7 @@ ilab --version
 ilab system info
 
 # pipe 3 carriage returns to ilab config init to get past the prompts
-echo -e "\n\n\n" | ilab init
+echo -e "y\n\n\n\n" | ilab init
 
 # Enable Debug in func tests with debug level 1
 sed -i.bak -e 's/log_level:.*/log_level: DEBUG/g;' "${ILAB_CONFIG_FILE}"

--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -92,7 +92,9 @@ def init(
     else:
         param_source = ctx.parent.parent.get_parameter_source("config_file")
     try:
-        overwrite = check_if_configs_exist()
+        overwrite = False
+        if interactive:
+            overwrite = check_if_configs_exist()
     except click.exceptions.Exit as e:
         ctx.exit(e.exit_code)
     if param_source == click.core.ParameterSource.ENVIRONMENT:

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -830,6 +830,18 @@ def ensure_storage_directories_exist():
         "lora_target_modules": ["q_proj", "k_proj", "v_proj", "o_proj"],
     }
 
+    recreate_train_profiles()
+
+    # create expert_args file for users to see/edit
+    if not os.path.isfile(DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_FILE):
+        with open(
+            DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_FILE, "w", encoding="utf-8"
+        ) as outfile:
+            yaml.dump(additional_args_and_defaults, outfile)
+
+
+# recreate_train_profiles creates all train profiles in the proper directory and takes an argument, overwrite, which will write to the files even if they already exist
+def recreate_train_profiles(overwrite: bool = False):
     TRAIN_DIR_EXPECTED_FILES = {
         "A100_H100_x8.yaml",
         "A100_H100_x4.yaml",
@@ -1020,18 +1032,11 @@ def ensure_storage_directories_exist():
         }
 
         for file, train_cfg in to_write.items():
-            if not os.path.isfile(file):
+            if not os.path.isfile(file) or overwrite:
                 with open(file, "w", encoding="utf-8") as outfile:
                     d = train_cfg.model_dump_json()
                     loaded = yaml.load(d, Loader=yaml.SafeLoader)
                     yaml.dump(loaded, outfile)
-
-    # create expert_args file for users to see/edit
-    if not os.path.isfile(DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_FILE):
-        with open(
-            DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_FILE, "w", encoding="utf-8"
-        ) as outfile:
-            yaml.dump(additional_args_and_defaults, outfile)
 
 
 class Lab:

--- a/tests/test_lab_config.py
+++ b/tests/test_lab_config.py
@@ -26,9 +26,9 @@ def test_ilab_config_show(cli_runner: CliRunner) -> None:
 @pytest.mark.parametrize(
     "command",
     [
-        (["config", "init"]),
+        (["config", "init", "--non-interactive"]),
         (
-            ["init"]
+            ["init", "--non-interactive"]
         ),  # TODO: remove this test once the deprecated alias 'ilab init' is removed
     ],
 )

--- a/tests/test_lab_init.py
+++ b/tests/test_lab_init.py
@@ -29,7 +29,7 @@ class TestLabInit:
 
     @patch("instructlab.config.init.Repo.clone_from")
     def test_init_interactive(self, mock_clone_from, cli_runner: CliRunner):
-        result = cli_runner.invoke(lab.ilab, ["init"], input="\nn")
+        result = cli_runner.invoke(lab.ilab, ["init"], input="y\n\nn")
         assert result.exit_code == 0
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         assert "taxonomy" not in os.listdir()
@@ -40,14 +40,14 @@ class TestLabInit:
         MagicMock(side_effect=GitError("Authentication failed")),
     )
     def test_init_interactive_git_error(self, cli_runner: CliRunner):
-        result = cli_runner.invoke(lab.ilab, ["init"], input="\ny")
+        result = cli_runner.invoke(lab.ilab, ["init"], input="y\n\ny")
         assert result.exit_code == 1, "command finished with an unexpected exit code"
         assert "Failed to clone taxonomy repo: Authentication failed" in result.output
         assert "manually run" in result.output
 
     @patch("instructlab.config.init.Repo.clone_from")
     def test_init_interactive_clone(self, mock_clone_from, cli_runner: CliRunner):
-        result = cli_runner.invoke(lab.ilab, ["init"], input="\ny")
+        result = cli_runner.invoke(lab.ilab, ["init"], input="y\n\ny")
         assert result.exit_code == 0
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         mock_clone_from.assert_called_once()
@@ -66,21 +66,25 @@ class TestLabInit:
         self, mock_clone_from, cli_runner: CliRunner
     ):
         os.makedirs(f"{DEFAULTS.TAXONOMY_DIR}/contents")
-        result = cli_runner.invoke(lab.ilab, ["init"], input="\n")
+        result = cli_runner.invoke(lab.ilab, ["init"], input="y\n\n")
         assert result.exit_code == 0
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         assert "taxonomy" in os.listdir(DEFAULTS._data_dir)
         mock_clone_from.assert_not_called()
 
     def test_init_interactive_with_preexisting_config(self, cli_runner: CliRunner):
-        result = cli_runner.invoke(lab.ilab, ["init"], input="non-default-taxonomy\nn")
+        result = cli_runner.invoke(
+            lab.ilab, ["init"], input="y\nnon-default-taxonomy\nn"
+        )
         assert result.exit_code == 0
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         config = read_config(DEFAULTS.CONFIG_FILE)
         assert config.generate.taxonomy_path == "non-default-taxonomy"
 
         # second invocation should ask if we want to overwrite - yes, and change taxonomy path
-        result = cli_runner.invoke(lab.ilab, ["init"], input="y\ndifferent-taxonomy\nn")
+        result = cli_runner.invoke(
+            lab.ilab, ["init"], input="y\ny\ndifferent-taxonomy\nn"
+        )
         assert result.exit_code == 0
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         config = read_config(DEFAULTS.CONFIG_FILE)


### PR DESCRIPTION
`ILAB_GLOBAL_CONFIG` and `ILAB_TRAIN_PROFILE_DIR` had two unexpected behaviors:

1. `ilab config init` overwrites the cfg without warning the user when the env is set
2. get_params_from_env would overwrite all model paths with the serve model which it should not
3. `ilab config init` did NOT overwrite the train profiles, prompt the user that this is going to happen and add the functionality to overwrite

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
