### PR TITLE
exposes effective_batch_size for both of the training phases

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -37,6 +37,7 @@ from . import log
 ILAB_PACKAGE_NAME = "instructlab"
 CONFIG_FILENAME = "config.yaml"
 CONFIG_VERSION = "1.0.0"
+OPTIONAL_POSITIVE_INTEGER = Field(default=None, gt=0)
 
 
 class STORAGE_DIR_NAMES:
@@ -512,11 +513,13 @@ class _train(BaseModel):
     # lab-multiphase training.
     # TODO: could move into its own object.
     # Not strictly necessary for a correct training object.
-    phased_phase1_num_epochs: int | None = None
-    phased_phase1_samples_per_save: int | None = None
+    phased_phase1_num_epochs: int | None = OPTIONAL_POSITIVE_INTEGER
+    phased_phase1_samples_per_save: int | None = OPTIONAL_POSITIVE_INTEGER
+    phased_phase1_effective_batch_size: int | None = OPTIONAL_POSITIVE_INTEGER
 
-    phased_phase2_num_epochs: int | None = None
-    phased_phase2_samples_per_save: int | None = None
+    phased_phase2_num_epochs: int | None = OPTIONAL_POSITIVE_INTEGER
+    phased_phase2_samples_per_save: int | None = OPTIONAL_POSITIVE_INTEGER
+    phased_phase2_effective_batch_size: int | None = OPTIONAL_POSITIVE_INTEGER
 
     phased_mt_bench_judge: str | None = None
 
@@ -667,8 +670,10 @@ def get_default_config() -> Config:
             is_padding_free=False,
             phased_phase1_num_epochs=10,
             phased_phase1_samples_per_save=25000,
+            phased_phase1_effective_batch_size=128,
             phased_phase2_num_epochs=10,
             phased_phase2_samples_per_save=25000,
+            phased_phase2_effective_batch_size=3840,
             phased_mt_bench_judge=DEFAULTS.DEFAULT_JUDGE_MODEL,
         ),
         evaluate=_evaluate(

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -48,9 +48,9 @@ generate:
       max_ctx_size: 4096
     model_path: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
     vllm:
+      gpus: null
       llm_family: ''
       max_startup_attempts: 300
-      gpus: null
       vllm_args: []
 serve:
   backend: null
@@ -62,9 +62,9 @@ serve:
     max_ctx_size: 4096
   model_path: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
   vllm:
+    gpus: null
     llm_family: ''
     max_startup_attempts: 300
-    gpus: null
     vllm_args: []
 train:
   additional_args: {}
@@ -82,8 +82,10 @@ train:
   nproc_per_node: 1
   num_epochs: 10
   phased_mt_bench_judge: /cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
+  phased_phase1_effective_batch_size: 128
   phased_phase1_num_epochs: 10
   phased_phase1_samples_per_save: 25000
+  phased_phase2_effective_batch_size: 3840
   phased_phase2_num_epochs: 10
   phased_phase2_samples_per_save: 25000
   save_samples: 250000


### PR DESCRIPTION
steps of multiphase-training require different effective batch sizes.
This exposes that functionality and sets reasonable defaults.

Signed-off-by: James Kunstle <jkunstle@redhat.com>

EDIT: Blocker rationale:

`effective_batch_size` (ebs) needs to be a configurable parameter for each training phase. Phase 1 requires a very low ebs, 128, to parity the performance that was seen in testing, whereas Phase 2 accommodates a much higher ebs. Thus, we can't only pull a single ebs from general training config- the value has to be phase-specific.
