### PR TITLE
Expand env vars and user dirs read from config

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -32,7 +32,7 @@ import platformdirs
 import yaml
 
 # Local
-from . import log
+from . import log, utils
 
 ILAB_PACKAGE_NAME = "instructlab"
 CONFIG_FILENAME = "config.yaml"
@@ -690,6 +690,7 @@ def read_train_profile(train_file) -> _train:
     try:
         with open(train_file, "r", encoding="utf-8") as yamlfile:
             content = yaml.safe_load(yamlfile)
+            _expand_paths(content)
             return _train(**content)
     except ValidationError as exc:
         msg = f"{exc.error_count()} errors in {train_file}:\n"
@@ -714,6 +715,7 @@ def read_config(
     try:
         with open(config_file, "r", encoding="utf-8") as yamlfile:
             content = yaml.safe_load(yamlfile)
+            _expand_paths(content)
             return Config(**content)
     except ValidationError as exc:
         msg = f"{exc.error_count()} errors in {config_file}:\n"
@@ -728,6 +730,27 @@ def read_config(
                 + "\n"
             )
         raise ConfigException(msg) from exc
+
+
+def _expand_paths(content: dict | list):
+    if isinstance(content, dict):
+        for key, value in content.items():
+            expanded_value = _expand_value(value)
+            if expanded_value is not None:
+                content[key] = expanded_value
+    elif isinstance(content, list):
+        for i, value in enumerate(content):
+            expanded_value = _expand_value(value)
+            if expanded_value is not None:
+                content[i] = expanded_value
+
+
+def _expand_value(value):
+    if isinstance(value, str):
+        return utils.expand_path(value)
+    if isinstance(value, (dict, list)):
+        _expand_paths(value)
+    return None
 
 
 def get_dict(cfg: Config) -> dict[str, typing.Any]:
@@ -1117,6 +1140,7 @@ def finish_additional_train_args(current_additional):
         DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_FILE, "r", encoding="utf-8"
     ) as yamlfile:
         content = yaml.safe_load(yamlfile)
+        _expand_paths(content)
     for key, val in content.items():
         if key not in current_additional:
             current_additional[key] = val

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -160,6 +160,58 @@ generate:
         assert cfg.general.validate_log_level("ERROR") == "ERROR"
         assert cfg.general.validate_log_level("NOTSET") == "NOTSET"
 
+    def test_expand_paths(self, tmp_path_home):
+        config_path = tmp_path_home / "config.yaml"
+        with open(config_path, "w", encoding="utf-8") as config_file:
+            config_file.write(
+                """\
+version: 1.0.0
+chat:
+  model: $HOME/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
+generate:
+  model: ~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
+  taxonomy_base: upstream/main
+  taxonomy_path: mytaxonomy
+  teacher:
+    model_path: ~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
+    chat_template: tokenizer
+    llama_cpp:
+      gpu_layers: 1
+      max_ctx_size: 2048
+      llm_family: ''
+    vllm:
+      gpus: 8
+serve:
+  model_path: models/granite-7b-lab-Q4_K_M.gguf
+  chat_template: tokenizer
+  llama_cpp:
+    gpu_layers: 1
+    max_ctx_size: 2048
+    llm_family: ''
+  vllm:
+    gpus: 8
+    vllm_args:
+       - --qlora-adapter-name-or-path=$HOME/qlora-adapter-name-or-path
+"""
+            )
+        cfg = config.read_config(config_path)
+        assert cfg.chat.model.startswith("/")
+        assert cfg.chat.model == os.path.expandvars(
+            "$HOME/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf"
+        )
+        assert cfg.generate.model.startswith("/")
+        assert cfg.generate.model == os.path.expanduser(
+            "~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf"
+        )
+        # Validate multi level dict
+        assert cfg.generate.teacher.model_path.startswith("/")
+        assert cfg.generate.teacher.model_path == os.path.expanduser(
+            "~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf"
+        )
+        assert cfg.serve.vllm.vllm_args[0] == os.path.expandvars(
+            "--qlora-adapter-name-or-path=$HOME/qlora-adapter-name-or-path"
+        )
+
     def test_get_model_family(self):
         good_cases = {
             # two known families


### PR DESCRIPTION
Expands env vars (Ex: $HOME) and user vars (Ex: ~) for config and training profiles.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
