### PR TITLE
hotfix: fix circular dependency issue

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -32,7 +32,7 @@ import platformdirs
 import yaml
 
 # Local
-from . import log, utils
+from . import log
 
 ILAB_PACKAGE_NAME = "instructlab"
 CONFIG_FILENAME = "config.yaml"
@@ -749,7 +749,8 @@ def _expand_paths(content: dict | list):
 
 def _expand_value(value):
     if isinstance(value, str):
-        return utils.expand_path(value)
+        expanded_value = os.path.expanduser(value)
+        return os.path.expandvars(expanded_value)
     if isinstance(value, (dict, list)):
         _expand_paths(value)
     return None


### PR DESCRIPTION
Currently we have an issue with a circular dependency inside the configuration code,
where we cannot include util code that imports from ilabclient in the utils module.
The reason why this happens is ilabclient also imports from configuration. But if we
have code which is technically a util, we cannot move it there for this reason.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
