### PR TITLE
lora followup to #1917

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -500,7 +500,7 @@ class _train(BaseModel):
     deepspeed_cpu_offload_optimizer: bool
 
     lora_rank: int | None = None
-    lora_quantize_dtype: str | None
+    lora_quantize_dtype: str | None = None
 
     is_padding_free: bool
 
@@ -535,7 +535,7 @@ class _train(BaseModel):
             "effective_batch_size": 3840,
             "save_samples": 250000,
             "lora_quantize_dtype": None,
-            "lora_rank": 4,
+            "lora_rank": None,
             "nproc_per_node": 1,
             "deepspeed_cpu_offload_optimizer": False,
             "additional_args": {},
@@ -1124,24 +1124,20 @@ def map_train_to_library(ctx, params):
     )
 
     lora_args = LoraOptions()
+    lora = False
     if params["lora_rank"] is not None:
         lora = True
-        lora_args.rank = params["lora_rank"]
     if params["lora_alpha"] is not None:
-        if not lora:
-            lora = True
+        lora = True
         lora_args.alpha = params["lora_alpha"]
     if params["lora_dropout"] is not None:
-        if not lora:
-            lora = True
+        lora = True
         lora_args.dropout = params["lora_dropout"]
     if params["lora_target_modules"] is not None:
-        if not lora:
-            lora = True
+        lora = True
         lora_args.target_modules = params["lora_target_modules"]
     if params["lora_quantize_dtype"] is not None:
-        if not lora:
-            lora = True
+        lora = True
         lora_args.quantize_data_type = params["lora_quantize_dtype"]
     if lora and params["is_padding_free"]:
         ctx.fail("Cannot combine LoRA with a padding free model.")


### PR DESCRIPTION
This commit fixes the lora mappings to the train options and
sets the 'lora_quantize_dytpe' to a default of None.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
