### PR TITLE
chore: delete redundant model config variable in generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   * `list`
   * `sysinfo`
   * `test`
+* Removed the `model` field under the `generate` config in favor of
+  `teacher.model_path`.
 * Intel Gaudi software has been updated to 1.17.1 with Python 3.11 and
   Torch 2.3.1 support.
 

--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -168,7 +168,6 @@ def init(
     # we should not override all paths with the serve model if special ENV vars exist
     if param_source != click.core.ParameterSource.ENVIRONMENT:
         cfg.chat.model = model_path
-        cfg.generate.model = model_path
         cfg.generate.teacher.model_path = model_path
         cfg.serve.model_path = model_path
         cfg.evaluate.model = model_path

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -216,10 +216,7 @@ class _generate(BaseModel):
         default=DEFAULTS.SDG_PIPELINE,
         description="Data generation pipeline to use. Available: 'simple', 'full', or a valid path to a directory of pipeline workflow YAML files. Note that 'full' requires a larger teacher model, Mixtral-8x7b.",
     )
-    model: StrictStr = Field(
-        default_factory=lambda: DEFAULTS.DEFAULT_MODEL,
-        description="Teacher model that will be used to synthetically generate training data.",
-    )
+    teacher: _serve = Field(default_factory=_serve, description="Teacher configuration")
     taxonomy_path: StrictStr = Field(
         default_factory=lambda: DEFAULTS.TAXONOMY_DIR,
         description="Directory where taxonomy is stored and accessed from.",
@@ -228,8 +225,8 @@ class _generate(BaseModel):
         default=DEFAULTS.TAXONOMY_BASE,
         description="Branch of taxonomy used to calculate diff against.",
     )
+
     # additional fields with defaults
-    teacher: _serve = Field(default_factory=_serve, description="Teacher configuration")
     num_cpus: PositiveInt = Field(
         default=DEFAULTS.NUM_CPUS,
         description="Number of CPU cores to use for generation.",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,7 +64,6 @@ class TestConfig:
         assert cfg.generate.teacher.backend is None
         assert cfg.generate.teacher.chat_template is None
         assert cfg.generate.pipeline == "simple"
-        assert cfg.generate.model == default_model
         assert cfg.generate.taxonomy_path == f"{data_dir}/taxonomy"
         assert cfg.generate.taxonomy_base == "origin/main"
         assert cfg.generate.num_cpus == 10
@@ -99,7 +98,7 @@ class TestConfig:
         assert cfg.evaluate.base_model == "instructlab/granite-7b-lab"
 
         assert cfg.generate is not None
-        assert cfg.generate.model == DEFAULTS.DEFAULT_MODEL
+        assert cfg.generate.teacher.model_path == DEFAULTS.DEFAULT_MODEL
 
         assert cfg.serve is not None
         assert cfg.serve.model_path == DEFAULTS.DEFAULT_MODEL
@@ -125,7 +124,7 @@ class TestConfig:
         self._assert_defaults(cfg)
         self._assert_model_defaults(cfg)
 
-    def test_cfg_auto_fill_with_large_config(self, tmp_path_home):  # pylint: disable=unused-argument
+    def test_cfg_auto_fill_with_large_config(self, tmp_path_home):
         config_path = tmp_path_home / "config.yaml"
         with open(config_path, "w", encoding="utf-8") as config_file:
             config_file.write(
@@ -134,7 +133,6 @@ class TestConfig:
 generate:
   pipeline: simple
   teacher:
-    model_path: models/granite-7b-lab-Q4_K_M.gguf
     chat_template: tokenizer
     llama_cpp:
       gpu_layers: 1
@@ -174,7 +172,6 @@ version: 1.0.0
 chat:
   model: $HOME/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
 generate:
-  model: ~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
   taxonomy_base: upstream/main
   taxonomy_path: mytaxonomy
   teacher:
@@ -203,10 +200,6 @@ serve:
         assert cfg.chat.model.startswith("/")
         assert cfg.chat.model == os.path.expandvars(
             "$HOME/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf"
-        )
-        assert cfg.generate.model.startswith("/")
-        assert cfg.generate.model == os.path.expanduser(
-            "~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf"
         )
         # Validate multi level dict
         assert cfg.generate.teacher.model_path.startswith("/")
@@ -252,7 +245,6 @@ chat:
   model: models/granite-7b-lab-Q4_K_M.gguf
 generate:
   pipeline: simple
-  model: models/granite-7b-lab-Q4_K_M.gguf
   taxonomy_base: upstream/main
   taxonomy_path: mytaxonomy
   teacher:
@@ -298,7 +290,7 @@ general:
         assert cfg is not None
         assert cfg.chat.model == "models/granite-7b-lab-Q4_K_M.gguf"
         assert cfg.generate.pipeline == "simple"
-        assert cfg.generate.model == "models/granite-7b-lab-Q4_K_M.gguf"
+        assert cfg.generate.teacher.model_path == "models/granite-7b-lab-Q4_K_M.gguf"
         assert cfg.serve.llama_cpp.gpu_layers == 1
         assert cfg.serve.llama_cpp.max_ctx_size == 2048
         assert cfg.serve.chat_template == "tokenizer"

--- a/tests/test_lab_config.py
+++ b/tests/test_lab_config.py
@@ -66,6 +66,5 @@ def test_ilab_config_init_with_model_path(cli_runner: CliRunner) -> None:
     with config_path.open(encoding="utf-8") as f:
         parsed = yaml.safe_load(f)
     assert parsed
-    assert configuration.Config(**parsed).generate.model == "path/to/model"
     assert configuration.Config(**parsed).generate.teacher.model_path == "path/to/model"
     assert configuration.Config(**parsed).serve.model_path == "path/to/model"

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -91,9 +91,6 @@ generate:
   # Maximum number of words per chunk.
   # Default: 1000
   chunk_word_count: 1000
-  # Teacher model that will be used to synthetically generate training data.
-  # Default: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
-  model: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
   # Number of CPU cores to use for generation.
   # Default: 10
   num_cpus: 10


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->
Currently, there are two config fields used for the default model path which are redundant with each other. This change deletes the `generate > model` field in favor of `generate > teacher > model_path`.

**Issue resolved by this Pull Request:**
Resolves #2167
Resolves #1230 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
