### PR TITLE
Fix the last train profile selection

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -119,7 +119,7 @@ def init(
             type=int,
             default=0,
         )
-        if 1 <= train_profile_selection < len(entries):
+        if 1 <= train_profile_selection <= len(entries):
             click.echo(f"You selected: {entries[train_profile_selection - 1]}")
             cfg.train = read_train_profile(
                 join(DEFAULTS.TRAIN_PROFILE_DIR, entries[train_profile_selection - 1])


### PR DESCRIPTION
An off-by-one bug made the last selection incorrectly considered out of bounds, which made the tool exit with an error.

Closes: #2015

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
