### PR TITLE
hotfix: set lora alpha when detected

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1133,6 +1133,7 @@ def map_train_to_library(ctx, params):
     lora = False
     if params["lora_rank"] is not None:
         lora = True
+        lora_args.rank = params["lora_rank"]
     if params["lora_alpha"] is not None:
         lora = True
         lora_args.alpha = params["lora_alpha"]


### PR DESCRIPTION
In the current LoRA parsing code, we do not set the lora_rank value from params into the lora
options object when we detect it. This commit fixes that issue.


<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

