### PR TITLE
Fix training lora arg checking and exiting

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1130,24 +1130,29 @@ def map_train_to_library(ctx, params):
     )
 
     lora_args = LoraOptions()
-    lora = False
-    if params["lora_rank"] is not None:
-        lora = True
+    lora_enabled = False
+    lora_options = False
+    if params["lora_rank"] not in [0, None]:
+        lora_enabled = True
         lora_args.rank = params["lora_rank"]
     if params["lora_alpha"] is not None:
-        lora = True
+        lora_options = True
         lora_args.alpha = params["lora_alpha"]
     if params["lora_dropout"] is not None:
-        lora = True
+        lora_options = True
         lora_args.dropout = params["lora_dropout"]
     if params["lora_target_modules"] is not None:
-        lora = True
+        lora_options = True
         lora_args.target_modules = params["lora_target_modules"]
     if params["lora_quantize_dtype"] is not None:
-        lora = True
+        lora_options = True
         lora_args.quantize_data_type = params["lora_quantize_dtype"]
-    if lora and params["is_padding_free"]:
-        ctx.fail("Cannot combine LoRA with a padding free model.")
+    if lora_enabled and params["is_padding_free"]:
+        ctx.fail(
+            "Cannot combine LoRA with a padding free model. Set lora_rank to 0 or disable is_padding_free"
+        )
+    if lora_options and not lora_enabled:
+        click.secho("LoRA is disabled (rank=0), ignoring all additional LoRA args")
 
     train_args.deepspeed_options = ds_args
     train_args.lora = lora_args


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->
Currently is_padding_free is broken (will always exit) due to current lora arg processing. This PR fixes that.
<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
