### PR TITLE
Bump min version for training to 0.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ instructlab-eval>=0.1.1
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.3.1
 instructlab-sdg>=0.2.4
-instructlab-training>=0.3.1
+instructlab-training>=0.3.2
 jsonschema>=4.21.1
 llama_cpp_python[server]==0.2.79
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,2 +1,2 @@
 # Extra dependencies for NVIDIA CUDA
-instructlab-training[cuda]>=0.3.1
+instructlab-training[cuda]>=0.3.2


### PR DESCRIPTION
This release includes a fix for the broken --lora-target-modules CLI option.

Closes: #2021

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
