### PR TITLE
hotfix: fix issue where default lora rank is overwriting setting of 0

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1129,10 +1129,10 @@ def map_train_to_library(ctx, params):
         ],
     )
 
-    lora_args = LoraOptions()
+    lora_args = LoraOptions(rank=0)
     lora_enabled = False
     lora_options = False
-    if params["lora_rank"] not in [0, None]:
+    if params["lora_rank"]:
         lora_enabled = True
         lora_args.rank = params["lora_rank"]
     if params["lora_alpha"] is not None:


### PR DESCRIPTION
Today in the map_train_to_library function, we parse and set the lora options conditionally.
However; the LoraOptions class from instructlab/training has a default rank of 4.
Since we are not explicitly setting this value, when the ilab user sets this to 0, it will
retain the default of 0. This commit fixes this issue by explicitly initializing the rank to 0.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
