### PR TITLE
fix: phased training fixes

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -497,7 +497,7 @@ class _train(BaseModel):
     num_epochs: int
     effective_batch_size: int
     save_samples: int
-    checkpoint_at_epoch: bool = False
+    checkpoint_at_epoch: bool = True
 
     deepspeed_cpu_offload_optimizer: bool
 
@@ -515,12 +515,16 @@ class _train(BaseModel):
     # TODO: could move into its own object.
     # Not strictly necessary for a correct training object.
     phased_phase1_num_epochs: int | None = OPTIONAL_POSITIVE_INTEGER
-    phased_phase1_samples_per_save: int | None = OPTIONAL_POSITIVE_INTEGER
-    phased_phase1_effective_batch_size: int | None = OPTIONAL_POSITIVE_INTEGER
+    # phased_phase1_samples_per_save is disabled when the value is 0.
+    # anything greater than 0 enables samples_per_save for the phase.
+    phased_phase1_samples_per_save: int = Field(ge=0, default=0)
+    phased_phase1_effective_batch_size: int | None = 128
 
     phased_phase2_num_epochs: int | None = OPTIONAL_POSITIVE_INTEGER
-    phased_phase2_samples_per_save: int | None = OPTIONAL_POSITIVE_INTEGER
-    phased_phase2_effective_batch_size: int | None = OPTIONAL_POSITIVE_INTEGER
+    # phased_phase2_samples_per_save is disabled when the value is 0.
+    # anything greater than 0 enables samples_per_save for the phase.
+    phased_phase2_samples_per_save: int = Field(ge=0, default=0)
+    phased_phase2_effective_batch_size: int | None = 3840
 
     phased_mt_bench_judge: str | None = None
 
@@ -670,10 +674,8 @@ def get_default_config() -> Config:
             additional_args={},
             is_padding_free=False,
             phased_phase1_num_epochs=10,
-            phased_phase1_samples_per_save=25000,
             phased_phase1_effective_batch_size=128,
             phased_phase2_num_epochs=10,
-            phased_phase2_samples_per_save=25000,
             phased_phase2_effective_batch_size=3840,
             phased_mt_bench_judge=DEFAULTS.DEFAULT_JUDGE_MODEL,
         ),

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -338,7 +338,7 @@ def clickpath_setup(is_dir: bool) -> click.Path:
 @click.option(
     "--phased-phase1-samples-per-save",
     cls=clickext.ConfigOption,
-    type=click.IntRange(min=1),
+    type=click.IntRange(min=0),
     help="Number of samples to train on between saves for first phase of end-to-end training.",
 )
 @click.option(
@@ -361,7 +361,7 @@ def clickpath_setup(is_dir: bool) -> click.Path:
 @click.option(
     "--phased-phase2-samples-per-save",
     cls=clickext.ConfigOption,
-    type=click.IntRange(min=1),
+    type=click.IntRange(min=0),
     help="Number of samples to train on between saves for second phase of end-to-end training.",
 )
 @click.option(
@@ -782,7 +782,7 @@ def _training_phase(
         )
         train_args.num_epochs = num_epochs
 
-    if samples_per_save:
+    if samples_per_save is not None:
         logger.debug(
             f"Phased Training -- training phase -- Overriding samples per save: {train_args.save_samples} with {samples_per_save}"
         )

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -68,7 +68,7 @@ serve:
     vllm_args: []
 train:
   additional_args: {}
-  checkpoint_at_epoch: false
+  checkpoint_at_epoch: true
   ckpt_output_dir: /data/instructlab/checkpoints
   data_output_dir: /data/instructlab/internal
   data_path: /data/instructlab/datasets
@@ -85,9 +85,9 @@ train:
   phased_mt_bench_judge: /cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
   phased_phase1_effective_batch_size: 128
   phased_phase1_num_epochs: 10
-  phased_phase1_samples_per_save: 25000
+  phased_phase1_samples_per_save: 0
   phased_phase2_effective_batch_size: 3840
   phased_phase2_num_epochs: 10
-  phased_phase2_samples_per_save: 25000
+  phased_phase2_samples_per_save: 0
   save_samples: 250000
 version: 1.0.0


### PR DESCRIPTION
set the defaults in pydantic for effective batch size
set the click flag range for save samples to be > 0 rather than > 1. Also change pydantic defaults
because save samples per phase is off by default, set checkpoint_at_each_epoch to true

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
