### PR TITLE
Fix Traceback when `--gpus` is used and `vllm_args` is `null` in config file

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -302,7 +302,7 @@ class _serve_vllm(BaseModel):
     max_startup_attempts: int | None = None
     gpus: Optional[int] = None
     # arguments to pass into vllm process
-    vllm_args: list[str] | None = None
+    vllm_args: list[str] | None = Field(default_factory=lambda: [])
 
 
 class _serve_llama_cpp(BaseModel):
@@ -323,7 +323,6 @@ class _serve(BaseModel):
     vllm: _serve_vllm = _serve_vllm(
         llm_family="",
         max_startup_attempts=300,
-        vllm_args=[],
     )
 
     # llama-cpp configuration
@@ -654,7 +653,6 @@ def get_default_config() -> Config:
             vllm=_serve_vllm(
                 llm_family="",
                 max_startup_attempts=300,
-                vllm_args=[],
             ),
         ),
         train=_train(

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -244,6 +244,9 @@ def generate(
         gen_cfg.generate.teacher.vllm.llm_family = (
             model_family or gen_cfg.generate.teacher.vllm.llm_family
         )
+        gen_cfg.generate.teacher.vllm.vllm_args = (
+            gen_cfg.generate.teacher.vllm.vllm_args or []
+        )
         if gpus is not None:
             tps_prefix = "--tensor-parallel-size"
             if contains_argument(tps_prefix, gen_cfg.generate.teacher.vllm.vllm_args):

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -289,6 +289,7 @@ def launch_server(
             raise click.exceptions.Exit(1)
 
     if backend == backends.VLLM:
+        eval_serve.vllm.vllm_args = eval_serve.vllm.vllm_args or []
         eval_serve.vllm.vllm_args.extend(["--served-model-name", model_name])
         # Recommend max-workers based on hardware configuration. #cpus +- 50%
         cpu_count = multiprocessing.cpu_count()

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -170,6 +170,7 @@ def serve(
         # Warn if unsupported backend parameters are passed
         warn_for_unsuported_backend_param(ctx)
 
+        ctx.obj.config.serve.vllm.vllm_args = ctx.obj.config.serve.vllm.vllm_args or []
         if gpus:
             if contains_argument(
                 "--tensor-parallel-size", ctx.obj.config.serve.vllm.vllm_args


### PR DESCRIPTION
This should fix the following Traceback from data generate and similar commands:

```
INFO 2024-08-09 17:44:41,707 numexpr.utils:161: NumExpr defaulting to 4 threads.
INFO 2024-08-09 17:44:42,097 datasets:58: PyTorch version 2.3.1+cpu available.
Traceback (most recent call last):
  File "/home/vagrant/git/instructlab/.tox/py311-unit/bin/ilab", line 8, in <module>
    sys.exit(ilab())
             ^^^^^^
  File "/home/vagrant/git/instructlab/.tox/py311-unit/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/git/instructlab/.tox/py311-unit/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/vagrant/git/instructlab/.tox/py311-unit/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/git/instructlab/.tox/py311-unit/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/git/instructlab/.tox/py311-unit/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/git/instructlab/.tox/py311-unit/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/git/instructlab/.tox/py311-unit/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/git/instructlab/src/instructlab/clickext.py", line 292, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/git/instructlab/src/instructlab/data/generate.py", line 237, in generate
    if contains_argument(tps_prefix, gen_cfg.generate.teacher.vllm.vllm_args):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vagrant/git/instructlab/src/instructlab/model/backends/vllm.py", line 147, in contains_argument
    return any(s == prefix or s.startswith(prefix + "=") for s in arg)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable

```

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
