### PR TITLE
honor ~/.config/instructlab/config.yaml

### DIFF
--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -27,7 +27,6 @@ multiprocessing.set_start_method(cfg.DEFAULTS.MULTIPROCESSING_START_METHOD, forc
     "config_file",
     type=click.Path(),
     default=cfg.DEFAULTS.CONFIG_FILE,
-    envvar=cfg.DEFAULTS.ILAB_GLOBAL_CONFIG,
     show_default=True,
     help="Path to a configuration file.",
 )


### PR DESCRIPTION
currently if $ILAB_GLOBAL_CONFIG is set, it supercedes the ~/.config/instructlab/config.yaml in ALL scenarios. We only want $ILAB_GLOBAL_CONFIG to win when running `ilab config init`.

Therefore the `envvar=` should only be used on the command itself, and ignored everywhere else. This makes it so that `init` (a different function from ilab config init`) sets the ctx.obj.cfg value to the LOCAL file rather than the global one when running other commands

resolves #2042

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
