### PR TITLE
fix: update recommended skopeo version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
         if: startsWith(matrix.platform, 'ubuntu')
         run: |
           sudo apt-get install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config -y
-          git clone --depth 1 https://github.com/containers/skopeo -b v1.15.0 "$GITHUB_WORKSPACE"/src/github.com/containers/skopeo
+          git clone --depth 1 https://github.com/containers/skopeo -b v1.9.0 "$GITHUB_WORKSPACE"/src/github.com/containers/skopeo
           cd "$GITHUB_WORKSPACE"/src/github.com/containers/skopeo
           make bin/skopeo
           sudo install -D -m 755 bin/skopeo /usr/bin/skopeo
@@ -128,10 +128,10 @@ jobs:
         run: |
           mkdir -p ~/.config/instructlab
           echo "broken" > ~/.config/instructlab/config.yaml
-          
+
           mkdir -p ~/.cache
           echo "not a directory" > ~/.cache/instructlab
-          
+
           mkdir -p ~/.local/share
           echo "not a directory" > ~/.local/share/instructlab
 

--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -205,7 +205,7 @@ class OCIDownloader(Downloader):
         oci_dir = f"{DEFAULTS.OCI_DIR}/{model_name}"
         os.makedirs(oci_dir, exist_ok=True)
 
-        # Check if skopeo is installed and the version is at least 1.15
+        # Check if skopeo is installed and the version is at least 1.9
         check_skopeo_version()
 
         command = [
@@ -316,15 +316,13 @@ def download(ctx, repository, release, filename, model_dir, hf_token):
         raise click.exceptions.Exit(1)
 
 
-_RECOMMENDED_SCOPEO_VERSION = "1.15.0"
+_RECOMMENDED_SCOPEO_VERSION = "1.9.0"
 
 
 def check_skopeo_version():
     """
-    Check if skopeo is installed and the version is at least 1.15.0
+    Check if skopeo is installed and the version is at least 1.9.0
     This is required for downloading models from OCI registries.
-    The function intentionally does not raise an exception if the version is lower than 1.15, other
-    versions might work as well, but it is recommended to use at least 1.15.0
     """
     # Run the 'skopeo --version' command and capture the output
     try:
@@ -350,8 +348,8 @@ def check_skopeo_version():
         if version.parse(installed_version) < version.parse(
             _RECOMMENDED_SCOPEO_VERSION
         ):
-            logger.warning(
-                f"skopeo version {installed_version} is lower than {_RECOMMENDED_SCOPEO_VERSION}. Consider upgrading. Downloading the model might fail."
+            raise ValueError(
+                f"skopeo version {installed_version} is lower than {_RECOMMENDED_SCOPEO_VERSION}. Please upgrade it."
             )
     else:
         logger.warning(


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

Currently we emit a warning message when we detect users trying to download models from OCI registries using skopeo < `v1.14.3`. We recommend they upgrade to `v1.15.0` out of an abundance of caution. It was determined through some manual effort that users only need to have skopeo >= `v1.9.0`. This is misleading to users as they think their model download might fail even though it won't, and might cause unnecessary confusion. This PR updates the recommended version to `v1.9.0` 

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
