### PR TITLE
fix: remove custom spellcheck job name

### DIFF
--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -25,7 +25,6 @@ permissions:
 
 jobs:
   spellcheck:
-    name: Spellcheck (en_US)
     runs-on: ubuntu-latest
     steps:
       - name: "Harden Runner"


### PR DESCRIPTION
We need to remove the custom job name for the Spellcheck action so that it's compatible with the changes made here https://github.com/instructlab/instructlab/pull/1941

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
