### PR TITLE
do not re-create train profiles on fresh install

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -154,7 +154,7 @@ ilab --version
 ilab system info
 
 # pipe 3 carriage returns to ilab config init to get past the prompts
-echo -e "y\n\n\n\n" | ilab init
+echo -e "\n\n\n" | ilab init
 
 # Enable Debug in func tests with debug level 1
 sed -i.bak -e 's/log_level:.*/log_level: DEBUG/g;' "${ILAB_CONFIG_FILE}"

--- a/src/instructlab/clickext.py
+++ b/src/instructlab/clickext.py
@@ -15,6 +15,9 @@ from click.core import ParameterSource
 from click_didyoumean import DYMGroup
 import click
 
+# First Party
+from instructlab.configuration import DEFAULTS, storage_dirs_exist
+
 logger = logging.getLogger(__name__)
 
 
@@ -76,6 +79,17 @@ class ExpandAliasesGroup(LazyEntryPointGroup):
                 "in a future release. Please consider using "
                 f"`ilab {group} {primary}` instead"
             )
+            # if some storage dirs do not exist
+            # AND the command is not `ilab init`
+            # AND the --config flag is not customized, then we error
+            if not storage_dirs_exist() and (
+                primary != "init" and ctx.params["config_file"] == DEFAULTS.CONFIG_FILE
+            ):
+                click.secho(
+                    "Some ilab storage directories do not exist yet. Please run `ilab config init` before continuing.",
+                    fg="red",
+                )
+                raise click.exceptions.Exit(1)
             return cmd
         return super().get_command(ctx, cmd_name)
 

--- a/src/instructlab/config/config.py
+++ b/src/instructlab/config/config.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
+# Standard
+
 # Third Party
 import click
 
 # First Party
 from instructlab import clickext
+from instructlab.configuration import storage_dirs_exist
 
 
 @click.group(
@@ -19,4 +22,10 @@ def config(ctx):
     ctx.obj = ctx.parent.obj
     if ctx.invoked_subcommand not in {"init"}:
         ctx.obj.ensure_config(ctx)
+        if not storage_dirs_exist():
+            click.secho(
+                "Some ilab storage directories do not exist yet. Please run `ilab config init` before continuing.",
+                fg="red",
+            )
+            raise click.exceptions.Exit(1)
     ctx.default_map = ctx.parent.default_map

--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -93,12 +93,12 @@ def init(
     config_file,
 ):
     """Initializes environment for InstructLab"""
-    ensure_storage_directories_exist()
+    fresh_install = ensure_storage_directories_exist()
     param_source = ctx.get_parameter_source("config_file")
     try:
-        overwrite = False
+        overwrite_profile = False
         if interactive:
-            overwrite = check_if_configs_exist()
+            overwrite_profile = check_if_configs_exist(fresh_install)
     except click.exceptions.Exit as e:
         ctx.exit(e.exit_code)
     else:
@@ -114,7 +114,7 @@ def init(
             )
         except click.exceptions.Exit as e:
             ctx.exit(e.exit_code)
-    if overwrite:
+    if overwrite_profile:
         click.echo(
             f"Generating `{DEFAULTS.CONFIG_FILE}` and `{DEFAULTS.TRAIN_PROFILE_DIR}`..."
         )
@@ -165,18 +165,19 @@ def init(
     )
 
 
-def check_if_configs_exist() -> bool:
+def check_if_configs_exist(fresh_install) -> bool:
     if exists(DEFAULTS.CONFIG_FILE):
         overwrite = click.confirm(
             f"Found {DEFAULTS.CONFIG_FILE}, do you still want to continue?"
         )
         if not overwrite:
             raise click.exceptions.Exit(0)
-    if exists(DEFAULTS.TRAIN_PROFILE_DIR):
+    if exists(DEFAULTS.TRAIN_PROFILE_DIR) and not fresh_install:
         return click.confirm(
             f"Found {DEFAULTS.TRAIN_PROFILE_DIR}, do you also want to reset existing profiles?"
         )
-    return True
+    # default behavior should be do NOT overwrite files that could have just been created
+    return False
 
 
 def get_params_from_env(

--- a/src/instructlab/data/data.py
+++ b/src/instructlab/data/data.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Standard
+
 # Third Party
 import click
 
 # First Party
 from instructlab import clickext
+from instructlab.configuration import storage_dirs_exist
 
 
 @click.group(
@@ -19,4 +22,10 @@ def data(ctx):
     """
     ctx.obj = ctx.parent.obj
     ctx.obj.ensure_config(ctx)
+    if not storage_dirs_exist():
+        click.secho(
+            "Some ilab storage directories do not exist yet. Please run `ilab config init` before continuing.",
+            fg="red",
+        )
+        raise click.exceptions.Exit(1)
     ctx.default_map = ctx.parent.default_map

--- a/src/instructlab/model/model.py
+++ b/src/instructlab/model/model.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # pylint: disable=redefined-builtin
+# Standard
+
 # Third Party
 import click
 
 # First Party
 from instructlab import clickext
+from instructlab.configuration import storage_dirs_exist
 
 
 @click.group(
@@ -20,5 +23,11 @@ def model(ctx):
     If this is your first time running ilab, it's best to start with `ilab config init` to create the environment.
     """
     ctx.parent.obj.ensure_config(ctx)
+    if not storage_dirs_exist():
+        click.secho(
+            "Some ilab storage directories do not exist yet. Please run `ilab config init` before continuing.",
+            fg="red",
+        )
+        raise click.exceptions.Exit(1)
     ctx.obj = ctx.parent.obj
     ctx.default_map = ctx.parent.default_map

--- a/src/instructlab/system/system.py
+++ b/src/instructlab/system/system.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+
 # Standard
 import logging
 

--- a/src/instructlab/taxonomy/taxonomy.py
+++ b/src/instructlab/taxonomy/taxonomy.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# Standard
+
 # Third Party
 import click
 
 # First Party
 from instructlab import clickext
+from instructlab.configuration import storage_dirs_exist
 
 
 @click.group(
@@ -19,4 +22,10 @@ def taxonomy(ctx):
     """
     ctx.obj = ctx.parent.obj
     ctx.obj.ensure_config(ctx)
+    if not storage_dirs_exist():
+        click.secho(
+            "Some ilab storage directories do not exist yet. Please run `ilab config init` before continuing.",
+            fg="red",
+        )
+        raise click.exceptions.Exit(1)
     ctx.default_map = ctx.parent.default_map

--- a/tests/test_lab_init.py
+++ b/tests/test_lab_init.py
@@ -29,7 +29,7 @@ class TestLabInit:
 
     @patch("instructlab.config.init.Repo.clone_from")
     def test_init_interactive(self, mock_clone_from, cli_runner: CliRunner):
-        result = cli_runner.invoke(lab.ilab, ["init"], input="y\n\nn")
+        result = cli_runner.invoke(lab.ilab, ["init"], input="\nn")
         assert result.exit_code == 0
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         assert "taxonomy" not in os.listdir()
@@ -66,16 +66,14 @@ class TestLabInit:
         self, mock_clone_from, cli_runner: CliRunner
     ):
         os.makedirs(f"{DEFAULTS.TAXONOMY_DIR}/contents")
-        result = cli_runner.invoke(lab.ilab, ["init"], input="y\n\n")
+        result = cli_runner.invoke(lab.ilab, ["init"], input="\n\n")
         assert result.exit_code == 0
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         assert "taxonomy" in os.listdir(DEFAULTS._data_dir)
         mock_clone_from.assert_not_called()
 
     def test_init_interactive_with_preexisting_config(self, cli_runner: CliRunner):
-        result = cli_runner.invoke(
-            lab.ilab, ["init"], input="y\nnon-default-taxonomy\nn"
-        )
+        result = cli_runner.invoke(lab.ilab, ["init"], input="non-default-taxonomy\nn")
         assert result.exit_code == 0
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         config = read_config(DEFAULTS.CONFIG_FILE)


### PR DESCRIPTION
since creation of the train profiles is handled by `ilab config init` as well as
the persistent storage dir creation process, on a new system the train profiles dir
is always detected as existing. This creates a double re-write and prompts the user
asking them if they want to overwrite train profiles they didn't know existed.

Fix this by checking if ANY of the train profiles DNE when being created. If this scenario is
detected, do not prompt the user to recreate the profiles since they have just been created for the first time.

Also, `ilab config init` should be the only place that persistent storage dirs are created. Currently each time ANY ilab command is run, the ~/.local and ~/.config dirs are created if they do not exist. This PR makes it so that only `ilab config init` creates the persistent storage dirs and any other ilab command errors out if `ilab config init` has not been run

some exceptions to this are:

if you specify --config DEFAULT or --config <some_non_default>.yaml
certain commands that dont need the dirs ex:
just running `ilab model` or any top level cmd
`ilab system info`

Some test fixes were needed since in most scenarios we are testing, we no longer prompt the user to override their profiles since they are fresh systems

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
