### PR TITLE
Use real model names to allow adapter selection to function

### DIFF
--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -27,11 +27,6 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-JUDGE_MODEL_NAME = "judge_model"
-TEST_MODEL_NAME = "test_model"
-BASE_TEST_MODEL_NAME = "base_test_model"
-
-
 # Python 3.10 does not have StrEnum
 class Benchmark(str, enum.Enum):
     MMLU = "mmlu"
@@ -109,8 +104,8 @@ def get_evaluator(
             from instructlab.eval.mt_bench import MTBenchEvaluator
 
             return MTBenchEvaluator(
-                TEST_MODEL_NAME,
-                JUDGE_MODEL_NAME,
+                get_model_name(model),
+                get_model_name(judge_model),
                 output_dir,
                 max_workers,
                 merge_system_user_message=merge_system_user_message,
@@ -119,8 +114,8 @@ def get_evaluator(
         from instructlab.eval.mt_bench import MTBenchBranchEvaluator
 
         return MTBenchBranchEvaluator(
-            TEST_MODEL_NAME,
-            JUDGE_MODEL_NAME,
+            get_model_name(model),
+            get_model_name(judge_model),
             taxonomy_path,
             branch,
             output_dir,
@@ -269,6 +264,10 @@ def qa_pairs_to_qna_to_avg_scores(qa_pairs: list[dict]) -> dict[str, float]:
     for qna, scores in qna_to_scores.items():
         qna_to_avg_scores[qna] = sum(scores) / len(scores)
     return qna_to_avg_scores
+
+
+def get_model_name(model_path):
+    return os.path.basename(os.path.normpath(model_path))
 
 
 def launch_server(
@@ -540,7 +539,7 @@ def evaluate(
                 server, api_base = launch_server(
                     ctx,
                     model,
-                    TEST_MODEL_NAME,
+                    get_model_name(model),
                     max_workers,
                     gpus,
                     backend,
@@ -556,7 +555,7 @@ def evaluate(
                 server, api_base = launch_server(
                     ctx,
                     judge_model,
-                    JUDGE_MODEL_NAME,
+                    get_model_name(judge_model),
                     max_workers,
                     gpus,
                     judge_backend,
@@ -589,8 +588,8 @@ def evaluate(
             evaluators = [
                 evaluator,
                 MTBenchBranchEvaluator(
-                    BASE_TEST_MODEL_NAME,
-                    JUDGE_MODEL_NAME,
+                    get_model_name(base_model),
+                    get_model_name(judge_model),
                     taxonomy_path,
                     base_branch,
                     output_dir,
@@ -600,7 +599,7 @@ def evaluate(
             ]
             branches = [branch, base_branch]
             m_paths = [model, base_model]
-            m_names = [TEST_MODEL_NAME, BASE_TEST_MODEL_NAME]
+            m_names = [get_model_name(model), get_model_name(base_model)]
             qa_pairs_and_errors = []
             server = None
 
@@ -632,7 +631,7 @@ def evaluate(
                 server, api_base = launch_server(
                     ctx,
                     judge_model,
-                    JUDGE_MODEL_NAME,
+                    get_model_name(judge_model),
                     max_workers,
                     gpus,
                     judge_backend,


### PR DESCRIPTION
Previously, the eval library was defaulting to a base model adapter rather than selecting the specific one for the model.  Ideally this logic can be further improved to not rely on the correct name to be passed in.  Or at least separate the name from the type.

Resolves #2057

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
