### PR TITLE
chore: remove unecessary @model_validator

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -361,8 +361,6 @@ def test_compare_default_config_testdata(
     [
         ("nf4", {}, False),
         (None, {}, False),
-        ("nf4", None, False),
-        (None, None, False),
         ("valid-for-cli-but-not-for-training-library", {}, False),
         ("nf4", {"lora_alpha": 32}, False),
     ],

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -65,7 +65,7 @@ evaluate:
   mt_bench:
     # Directory where model to be used as judge is stored.
     # Default: prometheus-eval/prometheus-8x7b-v2.0
-    judge_model: /cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
+    judge_model: prometheus-eval/prometheus-8x7b-v2.0
     # Number of workers to use for evaluation.
     # Default: 16
     max_workers: 16
@@ -273,12 +273,12 @@ train:
   is_padding_free: false
   # The data type for quantization in LoRA training. Valid options are 'None' and
   # 'nf4'.
-  # Default: None
+  # Default: nf4
   # Examples:
   #   - nf4
   lora_quantize_dtype: nf4
   # Rank of low rank matrices to be used during training.
-  # Default: None
+  # Default: 4
   lora_rank: 4
   # Maximum tokens per gpu for each batch that will be handled in a single step. If
   # running into out-of-memory errors, this value can be lowered but not below the
@@ -300,13 +300,13 @@ train:
   # Default: 10
   num_epochs: 10
   # Judge model path for phased MT-Bench evaluation.
-  # Default: None
+  # Default: /cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
   phased_mt_bench_judge: /cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
   # Phased phase1 effective batch size.
   # Default: 128
   phased_phase1_effective_batch_size: 128
   # Number of epochs to run training for during phase1.
-  # Default: None
+  # Default: 10
   phased_phase1_num_epochs: 10
   # Number of samples the model should see before saving a checkpoint during phase1.
   # Disabled when set to 0.
@@ -316,7 +316,7 @@ train:
   # Default: 3840
   phased_phase2_effective_batch_size: 3840
   # Number of epochs to run training for during phase2.
-  # Default: None
+  # Default: 10
   phased_phase2_num_epochs: 10
   # Number of samples the model should see before saving a checkpoint during phase2.
   # Disabled when set to 0.


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

All the defaults are coming from the Field(default), thus using the
@model_validator to populate default values is not needed anymore.

Also, the @model_validator is typically used for custom logic, like if
you have more complex logic for setting defaults, such as computing them
based on other fields or some external data, the model_validator could
be necessary. However, in this case, the logic is simply setting the
default values, which Pydantic can already do through Field().

A few options with default_factory were incorrect too, we don't need a
lambda here. The default_factory should directly reference the callable
that returns an instance of the class.

Co-Authored-By: Ihar Hrachyshka <ihrachys@redhat.com>
Signed-off-by: Sébastien Han <seb@redhat.com>

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
