### PR TITLE
cloud-instance: Print help when only cloud type is passed

### DIFF
--- a/scripts/infra/cloud-instance.sh
+++ b/scripts/infra/cloud-instance.sh
@@ -14,7 +14,12 @@ else
 fi
 
 ec2() {
-    local cmdname=$1; shift
+    local cmdname=$1
+    if [ -z "$cmdname" ]; then
+        show_usage
+        exit 1
+    fi
+    shift
     if [ "$(type -t "ec2__$cmdname")" = "function" ] >/dev/null 2>&1; then
         INSTANCE_NAME="$EC2_INSTANCE_NAME"
         "ec2__$cmdname" "$@"
@@ -177,7 +182,12 @@ ec2_calculate_instance_public_dns() {
 }
 
 ibm() {
-    local cmdname=$1; shift
+    local cmdname=$1
+    if [ -z "$cmdname" ]; then
+        show_usage
+        exit 1
+    fi
+    shift
     if [ "$(type -t "ibm__$cmdname")" = "function" ] >/dev/null 2>&1; then
         INSTANCE_NAME="$IBM_INSTANCE_NAME"
         "ibm__$cmdname" "$@"

--- a/scripts/infra/local-setup.sh
+++ b/scripts/infra/local-setup.sh
@@ -39,7 +39,12 @@ rh__ensure-aws-system-pkgs() {
 }
 
 rh() {
-    local cmdname=$1; shift
+    local cmdname=$1
+    if [ -z "$cmdname" ]; then
+        show_usage
+        exit 1
+    fi
+    shift
     if [ "$(type -t "rh__$cmdname")" = "function" ] >/dev/null 2>&1; then
         "rh__$cmdname" "$@"
     elif [ "$(type -t "${cmdname//-/_}")" = "function" ] >/dev/null 2>&1; then
@@ -52,7 +57,12 @@ rh() {
 }
 
 ibm() {
-    local cmdname=$1; shift
+    local cmdname=$1
+    if [ -z "$cmdname" ]; then
+        show_usage
+        exit 1
+    fi
+    shift
     if [ "$(type -t "ibm__$cmdname")" = "function" ] >/dev/null 2>&1; then
         "ibm__$cmdname" "$@"
     elif [ "$(type -t "${cmdname//-/_}")" = "function" ] >/dev/null 2>&1; then


### PR DESCRIPTION
When running the following command,

    cloud-instance.sh ec2

the output would be empty as the script would silently exit on the
`shift`. It is desirable to output the usage help text in this case.
Adjust the `ec2` and `ibm` handlers to handle this case and print the
usage text when no command is provided.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
