### PR TITLE
Add better tuning for max_workers based on perf tests

### DIFF
--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -143,9 +143,36 @@ def format_template(model_family: str, model_path: pathlib.Path) -> str:
     return prefix + template
 
 
-def contains_argument(prefix: str, arg: typing.Iterable[str]) -> bool:
+def contains_argument(prefix: str, args: typing.Iterable[str]) -> bool:
     # Either --foo value or --foo=value
-    return any(s == prefix or s.startswith(prefix + "=") for s in arg)
+    return any(s == prefix or s.startswith(prefix + "=") for s in args)
+
+
+def get_argument(prefix: str, args: typing.List[str]):
+    # Return last value in args for either --foo value or --foo=value
+    # Returns True if flag --foo is provided with no value
+
+    args_len = len(args)
+    # Traverse the args in reverse (args_len-1 to 0)
+    for i in range(args_len - 1, -1, -1):
+        s = args[i]
+        if s == prefix:
+            # Case: --foo value or --foo (with no value)
+            if i == args_len - 1:
+                # --foo is the last entry, must be a flag
+                return True
+            next_arg = args[i + 1]
+            if next_arg.startswith("-"):
+                # No value provided, must be a flag
+                return True
+            # The entry after is the value
+            return next_arg
+        v = prefix + "="
+        if s.startswith(v):
+            # Case: --foo=value
+            # Return everything after prefix=
+            return s[len(v) :]
+    return None
 
 
 def create_tmpfile(data: str):


### PR DESCRIPTION
The result of those tests showed ideal values for max_workers needs to take gpu and cpu counts into account.  The new recommendation does have a magic number but hopefully the suggestion range is large enough to account for the magic number potentially not being perfect.  Removing the magic number would require understanding the relative compute power of the gpus.

Also switching from multiprocessing.cpu_count() to len(os.sched_getaffinity(0)) to avoid cases where the instance has cpus that aren't available to the current process. (Thanks @jaideepr97 )

Resolves #2050 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
