### PR TITLE
cloud-instance: Add `ec2 details` command

### DIFF
--- a/scripts/infra/cloud-instance.sh
+++ b/scripts/infra/cloud-instance.sh
@@ -100,6 +100,14 @@ ec2__launch() {
 
 }
 
+ec2__details() {
+    handle_help_and_instance_name_opts "$@"
+    ec2_calculate_instance_id
+    aws ec2 describe-instances \
+        --instance-ids "$INSTANCE_ID" \
+        --region "$EC2_REGION"
+}
+
 ec2__stop() {
     handle_help_and_instance_name_opts "$@"
     ec2_calculate_instance_id
@@ -431,7 +439,11 @@ Commands
             Name of the instance to launch (default provided in config)
         -t
             Instance type (default provided in config)
-    
+
+    details - Get details of the instance
+        -n
+            Name of the instance to get details of (default provided in config)
+
     stop - Stop the instance
         -n
             Name of the instance to stop (default provided in config)


### PR DESCRIPTION
Add a new command to get details about the EC2 instance launched by
this script. In my case I wanted to get the public IP address, but
there's a lot of info in the output that might be useful.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
