### PR TITLE
fix alias help text

### DIFF
--- a/src/instructlab/clickext.py
+++ b/src/instructlab/clickext.py
@@ -66,7 +66,7 @@ class ExpandAliasesGroup(LazyEntryPointGroup):
     def get_alias_info(self, cmd_name: str) -> tuple[str, str]:
         ep: metadata.EntryPoint = self.alias_eps[cmd_name]
         # assume that the second item of the module name is the group
-        return ep.module.split(".", 3)[1], ep.attr
+        return ep.module.split(".", 3)[1], ep.module.split(".", 3)[2]
 
     def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
         if cmd_name in self.alias_eps.names:


### PR DESCRIPTION
commands with names like `model_list` rather than `list` represent themselves with the function name not the command name. return the name when parsing aliases, not the attr so `model list` is printed rather than `model model_list`

before:

```
Aliases:
  chat      model chat
  convert   model convert
  diff      taxonomy diff
  download  model download
  evaluate  model evaluate
  generate  data generate
  init      config init
  list      model model_list
  serve     model serve
  sysinfo   system info
  test      model test
  train     model train
```

after:

```
Aliases:
  chat      model chat
  convert   model convert
  diff      taxonomy diff
  download  model download
  evaluate  model evaluate
  generate  data generate
  init      config init
  list      model list
  serve     model serve
  sysinfo   system info
  test      model test
  train     model train
```
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
