### PR TITLE
fix: enable server log to file

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -38,7 +38,13 @@ import click
 
 # Local
 from . import log
-from .defaults import CONFIG_VERSION, DEFAULTS, MODEL_FAMILIES, MODEL_FAMILY_MAPPINGS
+from .defaults import (
+    CONFIG_VERSION,
+    DEFAULTS,
+    LOG_FORMAT,
+    MODEL_FAMILIES,
+    MODEL_FAMILY_MAPPINGS,
+)
 
 # Initialize ruamel.yaml
 yaml = YAML()
@@ -59,7 +65,7 @@ class _general(BaseModel):
     log_level: StrictStr = Field(default="INFO", description="Log level for logging.")
     debug_level: int = Field(default=0, description="Debug level for logging.")
     log_format: StrictStr = Field(
-        default="%(levelname)s %(asctime)s %(name)s:%(lineno)d: %(message)s",
+        default=LOG_FORMAT,
         description="Log format. https://docs.python.org/3/library/logging.html#logrecord-attributes",
         validate_default=True,
     )

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -18,6 +18,9 @@ MODEL_FAMILY_MAPPINGS = {
     "granite": "merlinite",
 }
 
+# Default log format
+LOG_FORMAT = "%(levelname)s %(asctime)s %(name)s:%(lineno)d: %(message)s"
+
 
 class STORAGE_DIR_NAMES:
     ILAB = "instructlab"

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -220,10 +220,13 @@ def select_backend(
     cfg: serve_config,
     backend: Optional[str] = None,
     model_path: pathlib.Path | None = None,
+    log_file: pathlib.Path | None = None,
 ) -> BackendServer:
     # Local
     from .llama_cpp import Server as llama_cpp_server
     from .vllm import Server as vllm_server
+
+    logger.debug("Selecting backend for model %s", model_path)
 
     model_path = pathlib.Path(model_path or cfg.model_path)
     backend_name = backend if backend is not None else cfg.backend
@@ -250,6 +253,7 @@ def select_backend(
             model_family=cfg.llama_cpp.llm_family,
             host=host,
             port=port,
+            log_file=log_file,
         )
     if backend == VLLM:
         # Instantiate the vllm server
@@ -262,6 +266,7 @@ def select_backend(
             host=host,
             port=port,
             max_startup_attempts=cfg.vllm.max_startup_attempts,
+            log_file=log_file,
         )
     click.secho(f"Unknown backend: {backend}", fg="red")
     raise click.exceptions.Exit(1)

--- a/src/instructlab/model/backends/server.py
+++ b/src/instructlab/model/backends/server.py
@@ -1,4 +1,5 @@
 # Standard
+from dataclasses import dataclass
 import abc
 import logging
 import pathlib
@@ -8,9 +9,16 @@ import typing
 import httpx
 
 # Local
+from ...log import add_file_handler_to_logger
 from .common import CHAT_TEMPLATE_AUTO, Closeable, safe_close_all
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ServerConfig:
+    api_base: str
+    log_file: typing.Optional[pathlib.Path] = None
 
 
 class BackendServer(abc.ABC):
@@ -21,17 +29,25 @@ class BackendServer(abc.ABC):
         model_family: str,
         model_path: pathlib.Path,
         chat_template: str,
-        api_base: str,
         host: str,
         port: int,
+        config: ServerConfig,
     ) -> None:
         self.model_family = model_family
         self.model_path = model_path
         self.chat_template = chat_template if chat_template else CHAT_TEMPLATE_AUTO
-        self.api_base = api_base
         self.host = host
         self.port = port
+        self.config = config
         self.resources: list[Closeable] = []
+
+        # Write logs to a file if log_file is provided
+        if self.config.log_file:
+            self.setup_logs_to_file(logger)
+
+    def setup_logs_to_file(self, a_logger: logging.Logger) -> None:
+        """Write logs to a file if log_file is provided"""
+        add_file_handler_to_logger(a_logger, self.config.log_file)
 
     @abc.abstractmethod
     def run(self):

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -114,6 +114,11 @@ def serve(
     vLLm parameters are documented at
     https://docs.vllm.ai/en/stable/serving/openai_compatible_server.html
     """
+    # If a log file is specified, write logs to the file
+    root_logger = logging.getLogger()
+    if log_file:
+        log.add_file_handler_to_logger(root_logger, log_file)
+
     # First Party
     from instructlab.model.backends import llama_cpp, vllm
 
@@ -124,11 +129,6 @@ def serve(
     except (ValueError, AttributeError) as e:
         click.secho(f"Failed to determine backend: {e}", fg="red")
         raise click.exceptions.Exit(1)
-
-    # Redirect server stdout and stderr to the logger
-    log.stdout_stderr_to_logger(
-        logger=logger, log_file=log_file, fmt=ctx.obj.config.general.log_format
-    )
 
     if chat_template is None:
         chat_template = ctx.obj.config.serve.chat_template
@@ -153,6 +153,7 @@ def serve(
             gpu_layers=gpu_layers,
             max_ctx_size=max_ctx_size,
             num_threads=num_threads,
+            log_file=log_file,
         )
     elif backend == backends.VLLM:
         # First Party
@@ -196,6 +197,7 @@ def serve(
             vllm_args=vllm_args,
             host=host,
             port=port,
+            log_file=log_file,
         )
     else:
         click.secho(f"Unknown backend: {backend}", fg="red")

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -195,13 +195,25 @@ def test_ilab_vllm_args(
         vllm_args=["--enable_lora"],
         host="127.0.0.1",
         port=8000,
+        log_file=None,
     )
 
 
+@pytest.mark.parametrize(
+    "log_file_flag, expected_log_file",
+    [
+        (None, None),
+        ("--log-file", pathlib.Path("test.log")),
+    ],
+)
 @mock.patch("instructlab.model.backends.llama_cpp.Server")
 @mock.patch("instructlab.model.backends.backends.get", return_value=backends.LLAMA_CPP)
 def test_ilab_llama_cpp_args(
-    m_backends_get: mock.Mock, m_server: mock.Mock, cli_runner: CliRunner
+    m_backends_get: mock.Mock,
+    m_server: mock.Mock,
+    cli_runner: CliRunner,
+    log_file_flag,
+    expected_log_file,
 ):
     gguf = pathlib.Path("test.gguf")
     cmd = [
@@ -214,6 +226,9 @@ def test_ilab_llama_cpp_args(
         "--backend",
         backends.LLAMA_CPP,
     ]
+    if log_file_flag:
+        cmd.extend([log_file_flag, str(expected_log_file)])
+
     result = cli_runner.invoke(lab.ilab, cmd)
     assert result.exit_code == 0, result.stdout
     m_backends_get.assert_called_once_with(gguf, backends.LLAMA_CPP)
@@ -227,6 +242,7 @@ def test_ilab_llama_cpp_args(
         max_ctx_size=4096,
         num_threads=None,
         chat_template=None,
+        log_file=expected_log_file,
     )
 
 

--- a/tests/test_lab_model_test.py
+++ b/tests/test_lab_model_test.py
@@ -13,7 +13,7 @@ import pytest
 
 # First Party
 from instructlab import lab
-from instructlab.model.backends.server import BackendServer
+from instructlab.model.backends.server import BackendServer, ServerConfig
 
 
 @pytest.mark.usefixtures("mock_mlx_package")
@@ -23,7 +23,15 @@ class TestLabModelTest:
     class ServerMock(BackendServer):
         # py lint: disable=W0613
         def __init__(self):
-            super().__init__("", "", "", "", "", 0)
+            sc = ServerConfig("", None)
+            super().__init__(
+                model_family="",
+                model_path="",
+                chat_template="",
+                host="",
+                port=0,
+                config=sc,
+            )
 
         def run_detached(
             self,


### PR DESCRIPTION
Since we no longer pass loggers between modules, we've lost the ability to easily redirect stdout/stderr to a logger. Now, any encountered loggers will be redirected to the `log_file` if specified.

We had to introduce a new ServerConfig class to reduce the number of
attributes to BackendServer. However, only a few options were added to
avoid pylint failing. Later on, we will continue to move other
attributes into ServerConfig. But for now, let's keep the change
minimal.

Fixes: https://github.com/instructlab/instructlab/issues/1738, https://github.com/instructlab/instructlab/issues/2080
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
