### PR TITLE
taxonomy diff/data generate: support taxonomy-base=empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.18.1
+
+### Features
+
+* `ilab data generate` and `ilab taxonomy diff` now support `--taxonomy-base=empty` to allow
+  specifying that all taxonomy files in the supplied repo should be included.
+
 ## v0.18
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -504,6 +504,12 @@ Before following these instructions, ensure the existing model you are adding sk
    ilab data generate --endpoint-url http://localhost:8000/v1
    ```
 
+Note that it is also possible to generate a synthetic dataset based on the entire contents of the taxonomy repo using the `--taxonomy-base=empty` option:
+
+   ```shell
+   ilab data generate --taxonomy-base=`empty`
+   ```
+
 ### 👩‍🏫 Training the model
 
 There are many options for training the model with your synthetic data-enhanced dataset.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ httpx>=0.25.0
 instructlab-eval>=0.1.1
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.3.1
-instructlab-sdg>=0.2.4
+instructlab-sdg>=0.2.6
 instructlab-training>=0.4.1
 jsonschema>=4.21.1
 llama_cpp_python[server]==0.2.79

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -65,7 +65,7 @@ logger = logging.getLogger(__name__)
     "--taxonomy-base",
     default=DEFAULTS.TAXONOMY_BASE,
     show_default=True,
-    help="Base git-ref to use when generating new taxonomy.",
+    help="Base git-ref to use for taxonomy, use 'empty' for the entire repo contents.",
 )
 @click.option(
     "--output-dir",

--- a/src/instructlab/taxonomy/diff.py
+++ b/src/instructlab/taxonomy/diff.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--taxonomy-base",
-    help="Base git-ref to use for taxonomy.",
+    help="Base git-ref to use for taxonomy, use 'empty' for the entire repo contents.",
 )
 @click.option(
     "--yaml-rules",
@@ -48,7 +48,12 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
     """
     # pylint: disable=import-outside-toplevel
     # Local
-    from ..utils import TaxonomyReadingException, get_taxonomy_diff, validate_taxonomy
+    from ..utils import (
+        TaxonomyReadingException,
+        get_taxonomy,
+        get_taxonomy_diff,
+        validate_taxonomy,
+    )
 
     # load defaults from config ctx obj if not specified via CLI arg
     if not taxonomy_base:
@@ -62,15 +67,20 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
         if is_file:  # taxonomy_path is file
             click.echo(taxonomy_path)
         else:  # taxonomy_path is dir
-            try:
-                updated_taxonomy_files = get_taxonomy_diff(taxonomy_path, taxonomy_base)
-            except (TaxonomyReadingException, GitError) as exc:
-                click.secho(
-                    f"Reading taxonomy failed with the following error: {exc}",
-                    fg="red",
-                )
-                raise SystemExit(1) from exc
-            for f in updated_taxonomy_files:
+            if taxonomy_base == "empty":
+                # Gather all the yamls - equivalent to a diff against "the null tree"
+                taxonomy_files = get_taxonomy(taxonomy_path)
+            else:
+                try:
+                    # Gather the new or changed YAMLs using git diff, including untracked files
+                    taxonomy_files = get_taxonomy_diff(taxonomy_path, taxonomy_base)
+                except (TaxonomyReadingException, GitError) as exc:
+                    click.secho(
+                        f"Reading taxonomy failed with the following error: {exc}",
+                        fg="red",
+                    )
+                    raise SystemExit(1) from exc
+            for f in taxonomy_files:
                 click.echo(f)
 
     # validate new or changed taxonomy files

--- a/tests/test_lab_diff.py
+++ b/tests/test_lab_diff.py
@@ -49,6 +49,28 @@ class TestLabDiff:
         assert tracked_file not in result.output
         assert result.exit_code == 0
 
+    def test_diff_empty_base(self, cli_runner: CliRunner):
+        taxonomy_base = "empty"
+        untracked_file = "compositional_skills/new/qna.yaml"
+        tracked_file = "compositional_skills/tracked/qna.yaml"
+        self.taxonomy.create_untracked(untracked_file)
+        self.taxonomy.add_tracked(tracked_file)
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "taxonomy",
+                "diff",
+                "--taxonomy-base",
+                taxonomy_base,
+                "--taxonomy-path",
+                self.taxonomy.root,
+            ],
+        )
+        assert untracked_file in result.output
+        assert tracked_file in result.output
+        assert result.exit_code == 0
+
     def test_diff_rm_tracked(self, cli_runner: CliRunner):
         tracked_file = "compositional_skills/tracked/qna.yaml"
         self.taxonomy.add_tracked(tracked_file)


### PR DESCRIPTION
This allows users to specify that they want all taxonomy files in their repo to be included, where 'null' symbolically represents the empty tree before this repo was created.

See also instructlab/sdg#242

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
