### PR TITLE
Ensure vllm logging is enabled

### DIFF
--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -195,14 +195,21 @@ def run_vllm(
 
     logger.debug(f"vLLM serving command is: {vllm_cmd}")
 
+    vllm_env = os.environ.copy()
+    # Reset vllm logging to the default (enabled)
+    vllm_env.pop("VLLM_CONFIGURE_LOGGING", None)
+
     try:
         if background:
             vllm_process = subprocess.Popen(
-                args=vllm_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                args=vllm_cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                env=vllm_env,
             )
         else:
             # pylint: disable=consider-using-with
-            vllm_process = subprocess.Popen(args=vllm_cmd)
+            vllm_process = subprocess.Popen(args=vllm_cmd, env=vllm_env)
 
         api_base = get_api_base(f"{host}:{port}")
         logger.info("vLLM starting up on pid %s at %s", vllm_process.pid, api_base)


### PR DESCRIPTION
vllm logging causes issues with instructlab libraries, but we want to ensure it's enabled when launching vllm itself.

Without this change, we aren't seeing most/all of the logging from vllm which makes debugging more difficult

Example of issue vllm logging causes when enabled globally: https://github.com/instructlab/eval/issues/65

Example of logging output we were missing:
```
INFO 08-18 13:42:36 distributed_gpu_executor.py:56] # GPU blocks: 199861, # CPU blocks: 16384
(VllmWorkerProcess pid=2533528) INFO 08-18 13:42:39 model_runner.py:1007] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
(VllmWorkerProcess pid=2533528) INFO 08-18 13:42:39 model_runner.py:1011] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
```


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
