### PR TITLE
Retry vllm startup for long running processes

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -336,7 +336,7 @@ class _serve(BaseModel):
     # vllm configuration
     vllm: _serve_vllm = _serve_vllm(
         llm_family="",
-        max_startup_attempts=300,
+        max_startup_attempts=120,
     )
 
     # llama-cpp configuration
@@ -366,7 +366,7 @@ class _serve(BaseModel):
         defaults = {
             "model_path": DEFAULTS.DEFAULT_MODEL,
             "llama_cpp": {"gpu_layers": -1, "max_ctx_size": 4096, "llm_family": ""},
-            "vllm": {"llm_family": "", "vllm_args": [], "max_startup_attempts": 300},
+            "vllm": {"llm_family": "", "vllm_args": [], "max_startup_attempts": 120},
         }
         return finish_cfg_section(defaults, values)
 
@@ -666,7 +666,7 @@ def get_default_config() -> Config:
             ),
             vllm=_serve_vllm(
                 llm_family="",
-                max_startup_attempts=300,
+                max_startup_attempts=120,
             ),
         ),
         train=_train(

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -279,6 +279,7 @@ def generate(
                 ),
                 background=not enable_serving_output,
                 foreground_allowed=True,
+                max_startup_retries=1,
             )
         except Exception as exc:
             click.secho(f"Failed to start server: {exc}", fg="red")

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -451,8 +451,8 @@ def ensure_server(
         logger.info("Starting a temporary vLLM server at %s", temp_api_base)
         count = 0
         # Each call to check_api_base takes >2s + 2s sleep
-        # Default to 300 if not specified (~20 mins of wait time)
-        vllm_startup_max_attempts = max_startup_attempts or 300
+        # Default to 120 if not specified (~8 mins of wait time)
+        vllm_startup_max_attempts = max_startup_attempts or 120
         start_time_secs = time()
         while count < vllm_startup_max_attempts:
             count += 1

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -99,6 +99,7 @@ class BackendServer(abc.ABC):
         http_client: httpx.Client | None = None,
         background: bool = True,
         foreground_allowed: bool = False,
+        max_startup_retries: int = 0,
     ) -> str:
         """Run serving backend in background ('ilab model chat' when server is not running)"""
 

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -99,6 +99,7 @@ class Server(BackendServer):
         http_client: httpx.Client | None = None,
         background: bool = True,
         foreground_allowed: bool = False,
+        max_startup_retries: int = 0,
     ) -> str:
         logger.info(f"Trying to connect to model server at {self.api_base}")
         if check_api_base(self.api_base, http_client):

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -345,6 +345,7 @@ def launch_server(
             ),
             background=not enable_serving_output,
             foreground_allowed=True,
+            max_startup_retries=1,
         )
     except Exception as exc:
         click.secho(f"Failed to start server: {exc}", fg="red")

--- a/tests/test_lab_model_test.py
+++ b/tests/test_lab_model_test.py
@@ -30,6 +30,7 @@ class TestLabModelTest:
             http_client: httpx.Client | None = None,
             background: bool = True,
             foreground_allowed: bool = False,
+            max_startup_retries: int = 0,
         ) -> str:
             return "api_base_mock"
 

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -50,7 +50,7 @@ generate:
     vllm:
       gpus: null
       llm_family: ''
-      max_startup_attempts: 300
+      max_startup_attempts: 120
       vllm_args: []
 serve:
   backend: null
@@ -64,7 +64,7 @@ serve:
   vllm:
     gpus: null
     llm_family: ''
-    max_startup_attempts: 300
+    max_startup_attempts: 120
     vllm_args: []
 train:
   additional_args: {}


### PR DESCRIPTION
The reason for adding retries is instructlab has to start and stop vllm a lot of times to work through its workflow end to end.  Whenever a component is susceptible to intermitent failures (which vllm seems to be with some hardware configurations) it risks the long running process failing as a whole.  Or to the last savepoint as much as they exist.  The goal of this logic is to retry vllm startups for all the startups that exist in long running processes.  For now the logic is set to retry once for generate, phased training, and evaluate.

Once we have some level of confidence this approach is reasonable and we do want a value in config, there is some concern that config already has a variable named max_startup_attempts which should really be something like max_startup_connect_attempts or max_avail_checks since it is checking whether vllm is running.  This new variable might be called max_startup_retries.  And until we went through the process to change the current config var, we would just have to know what the two variables map to.

We could have an env var to set max_startup_retries, but then technically we would need one for generate and one for evaluate.  Or one value would apply globally to all vllm starts.  Or one value would apply globally but only to evaluate, phased training, and generate.

Point being it's a bit messy and the provided impl of defaulting to 1 retry for generate and evaluate seems reasonable for all.

Example of it working.  See: Retrying (1/1):
```
INFO 2024-08-17 23:28:37,674 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:54281/v1, this might take a moment... Attempt: 99/100
INFO 2024-08-17 23:28:42,343 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:54281/v1, this might take a moment... Attempt: 100/100
INFO 2024-08-17 23:28:44,643 instructlab.model.backends.backends:476: Gave up waiting for vLLM server to start at http://127.0.0.1:54281/v1 after 100 attempts
DEBUG 2024-08-17 23:28:44,643 instructlab.model.backends.backends:315: Sending SIGINT to vLLM server PID 1221456
DEBUG 2024-08-17 23:28:44,643 instructlab.model.backends.backends:318: Waiting for vLLM server to shut down gracefully
[rank0]: Traceback (most recent call last):
[rank0]:   File "<frozen runpy>", line 198, in _run_module_as_main
[rank0]:   File "<frozen runpy>", line 88, in _run_code
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 282, in <module>
[rank0]:     run_server(args)
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 224, in run_server
[rank0]:     if llm_engine is not None else AsyncLLMEngine.from_engine_args(
[rank0]:                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/engine/async_llm_engine.py", line 444, in from_engine_args
[rank0]:     engine = cls(
[rank0]:              ^^^^
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/engine/async_llm_engine.py", line 373, in __init__
[rank0]:     self.engine = self._init_engine(*args, **kwargs)
[rank0]:                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/engine/async_llm_engine.py", line 525, in _init_engine
[rank0]:     return engine_class(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/engine/llm_engine.py", line 249, in __init__
[rank0]:     self.model_executor = executor_class(
[rank0]:                           ^^^^^^^^^^^^^^^
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/executor/multiproc_gpu_executor.py", line 158, in __init__
[rank0]:     super().__init__(*args, **kwargs)
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/executor/distributed_gpu_executor.py", line 25, in __init__
[rank0]:     super().__init__(*args, **kwargs)
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/executor/executor_base.py", line 150, in __init__
[rank0]:     super().__init__(model_config, cache_config, parallel_config,
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/executor/executor_base.py", line 46, in __init__
[rank0]:     self._init_executor()
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/executor/multiproc_gpu_executor.py", line 83, in _init_executor
[rank0]:     self._run_workers("init_device")
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/executor/multiproc_gpu_executor.py", line 139, in _run_workers
[rank0]:     ] + [output.get() for output in worker_outputs]
[rank0]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/executor/multiproc_gpu_executor.py", line 139, in <listcomp>
[rank0]:     ] + [output.get() for output in worker_outputs]
[rank0]:          ^^^^^^^^^^^^
[rank0]:   File "/home/ec2-user/danmcp/instructlab/venv/lib64/python3.11/site-packages/vllm/executor/multiproc_worker_utils.py", line 55, in get
[rank0]:     self.wait()
[rank0]:   File "/usr/lib64/python3.11/threading.py", line 629, in wait
[rank0]:     signaled = self._cond.wait(timeout)
[rank0]:                ^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/lib64/python3.11/threading.py", line 327, in wait
[rank0]:     waiter.acquire()
[rank0]: KeyboardInterrupt
ERROR 08-17 23:28:45 multiproc_worker_utils.py:120] Worker VllmWorkerProcess pid 1221546 died, exit code: -15
INFO 08-17 23:28:45 multiproc_worker_utils.py:123] Killing local vLLM worker processes
/usr/lib64/python3.11/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 1 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
INFO 2024-08-17 23:28:47,664 instructlab.model.backends.backends:337: Waiting for GPU VRAM reclamation...
DEBUG 2024-08-17 23:28:50,536 instructlab.model.backends.backends:388: GPU free vram stable (stable count 1, free 674996682752, last free 674996682752)
DEBUG 2024-08-17 23:28:51,537 instructlab.model.backends.backends:388: GPU free vram stable (stable count 2, free 674996682752, last free 674996682752)
DEBUG 2024-08-17 23:28:52,538 instructlab.model.backends.backends:388: GPU free vram stable (stable count 3, free 674996682752, last free 674996682752)
DEBUG 2024-08-17 23:28:53,539 instructlab.model.backends.backends:388: GPU free vram stable (stable count 4, free 674996682752, last free 674996682752)
DEBUG 2024-08-17 23:28:54,540 instructlab.model.backends.backends:388: GPU free vram stable (stable count 5, free 674996682752, last free 674996682752)
DEBUG 2024-08-17 23:28:55,540 instructlab.model.backends.backends:388: GPU free vram stable (stable count 6, free 674996682752, last free 674996682752)
DEBUG 2024-08-17 23:28:55,541 instructlab.model.backends.backends:395: Successful sample recorded, (stable count 6, free 674996682752, last free 674996682752)
INFO 2024-08-17 23:28:55,541 instructlab.model.backends.vllm:120: vLLM startup failed.  Retrying (1/1)
ERROR 2024-08-17 23:28:55,541 instructlab.model.backends.vllm:125: vLLM failed to start up in 463.7 seconds
INFO 2024-08-17 23:28:55,541 instructlab.model.backends.backends:438: Trying to connect to model server at http://127.0.0.1:8000/v1
DEBUG 2024-08-17 23:28:58,210 instructlab.model.backends.backends:442: Using available port 43911 for temporary model serving.
DEBUG 2024-08-17 23:28:58,210 instructlab.model.backends.backends:514: Searching hard coded model templates for model family merlinite's template
DEBUG 2024-08-17 23:28:58,211 instructlab.model.backends.vllm:205: vLLM serving command is: ['/home/ec2-user/danmcp/instructlab/venv/bin/python3.11', '-m', 'vllm.entrypoints.openai.api_server', '--host', '127.0.0.1', '--port', '43911', '--model', '/home/ec2-user/.cache/instructlab/models/instructlab/granite-7b-lab', '--chat-template', '/tmp/tmpj05r81pj', '--distributed-executor-backend', 'mp', '--served-model-name', 'test_model', '--tensor-parallel-size', '8']
INFO 2024-08-17 23:28:58,212 instructlab.model.backends.vllm:222: vLLM starting up on pid 1222429 at http://127.0.0.1:43911/v1
INFO 2024-08-17 23:28:58,212 instructlab.model.backends.backends:451: Starting a temporary vLLM server at http://127.0.0.1:43911/v1
INFO 2024-08-17 23:28:58,212 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:43911/v1, this might take a moment... Attempt: 1/100
INFO 08-17 23:29:01 api_server.py:212] vLLM API server version 0.5.2.3
INFO 08-17 23:29:01 api_server.py:213] args: Namespace(host='127.0.0.1', port=43911, uvicorn_log_level='info', allow_credentials=False, allowed_origins=['*'], allowed_methods=['*'], allowed_headers=['*'], api_key=None, lora_modules=None, prompt_adapters=None, chat_template='/tmp/tmpj05r81pj', response_role='assistant', ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_cert_reqs=0, root_path=None, middleware=[], model='/home/ec2-user/.cache/instructlab/models/instructlab/granite-7b-lab', tokenizer=None, skip_tokenizer_init=False, revision=None, code_revision=None, tokenizer_revision=None, tokenizer_mode='auto', trust_remote_code=False, download_dir=None, load_format='auto', dtype='auto', kv_cache_dtype='auto', quantization_param_path=None, max_model_len=None, guided_decoding_backend='outlines', distributed_executor_backend='mp', worker_use_ray=False, pipeline_parallel_size=1, tensor_parallel_size=8, max_parallel_loading_workers=None, ray_workers_use_nsight=False, block_size=16, enable_prefix_caching=False, disable_sliding_window=False, use_v2_block_manager=False, num_lookahead_slots=0, seed=0, swap_space=4, gpu_memory_utilization=0.9, num_gpu_blocks_override=None, max_num_batched_tokens=None, max_num_seqs=256, max_logprobs=20, disable_log_stats=False, quantization=None, rope_scaling=None, rope_theta=None, enforce_eager=False, max_context_len_to_capture=None, max_seq_len_to_capture=8192, disable_custom_all_reduce=False, tokenizer_pool_size=0, tokenizer_pool_type='ray', tokenizer_pool_extra_config=None, enable_lora=False, max_loras=1, max_lora_rank=16, lora_extra_vocab_size=256, lora_dtype='auto', long_lora_scaling_factors=None, max_cpu_loras=None, fully_sharded_loras=False, enable_prompt_adapter=False, max_prompt_adapters=1, max_prompt_adapter_token=0, device='auto', scheduler_delay_factor=0.0, enable_chunked_prefill=False, speculative_model=None, num_speculative_tokens=None, speculative_draft_tensor_parallel_size=None, speculative_max_model_len=None, speculative_disable_by_batch_size=None, ngram_prompt_lookup_max=None, ngram_prompt_lookup_min=None, spec_decoding_acceptance_method='rejection_sampler', typical_acceptance_sampler_posterior_threshold=None, typical_acceptance_sampler_posterior_alpha=None, model_loader_extra_config=None, preemption_mode=None, served_model_name=['test_model'], qlora_adapter_name_or_path=None, otlp_traces_endpoint=None, engine_use_ray=False, disable_log_requests=False, max_log_len=None)
INFO 08-17 23:29:01 config.py:1375] Downcasting torch.float32 to torch.float16.
INFO 08-17 23:29:01 llm_engine.py:174] Initializing an LLM engine (v0.5.2.3) with config: model='/home/ec2-user/.cache/instructlab/models/instructlab/granite-7b-lab', speculative_config=None, tokenizer='/home/ec2-user/.cache/instructlab/models/instructlab/granite-7b-lab', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=8, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None), seed=0, served_model_name=test_model, use_v2_block_manager=False, enable_prefix_caching=False)
You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.
INFO 08-17 23:29:01 custom_cache_manager.py:17] Setting Triton cache manager to: vllm.triton_utils.custom_cache_manager:CustomCacheManager
INFO 2024-08-17 23:29:02,743 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:43911/v1, this might take a moment... Attempt: 2/100
(VllmWorkerProcess pid=1222518) INFO 08-17 23:29:03 multiproc_worker_utils.py:215] Worker ready; awaiting tasks
(VllmWorkerProcess pid=1222517) INFO 08-17 23:29:03 multiproc_worker_utils.py:215] Worker ready; awaiting tasks
(VllmWorkerProcess pid=1222519) INFO 08-17 23:29:04 multiproc_worker_utils.py:215] Worker ready; awaiting tasks
(VllmWorkerProcess pid=1222521) INFO 08-17 23:29:04 multiproc_worker_utils.py:215] Worker ready; awaiting tasks
(VllmWorkerProcess pid=1222523) INFO 08-17 23:29:04 multiproc_worker_utils.py:215] Worker ready; awaiting tasks
(VllmWorkerProcess pid=1222522) INFO 08-17 23:29:04 multiproc_worker_utils.py:215] Worker ready; awaiting tasks
(VllmWorkerProcess pid=1222520) INFO 08-17 23:29:04 multiproc_worker_utils.py:215] Worker ready; awaiting tasks
INFO 08-17 23:29:05 utils.py:737] Found nccl from library libnccl.so.2
(VllmWorkerProcess pid=1222519) INFO 08-17 23:29:05 utils.py:737] Found nccl from library libnccl.so.2
(VllmWorkerProcess pid=1222518) INFO 08-17 23:29:05 utils.py:737] Found nccl from library libnccl.so.2
(VllmWorkerProcess pid=1222519) INFO 08-17 23:29:05 pynccl.py:63] vLLM is using nccl==2.20.5
INFO 08-17 23:29:05 pynccl.py:63] vLLM is using nccl==2.20.5
(VllmWorkerProcess pid=1222518) INFO 08-17 23:29:05 pynccl.py:63] vLLM is using nccl==2.20.5
(VllmWorkerProcess pid=1222523) INFO 08-17 23:29:05 utils.py:737] Found nccl from library libnccl.so.2
(VllmWorkerProcess pid=1222521) INFO 08-17 23:29:05 utils.py:737] Found nccl from library libnccl.so.2
(VllmWorkerProcess pid=1222522) INFO 08-17 23:29:05 utils.py:737] Found nccl from library libnccl.so.2
(VllmWorkerProcess pid=1222523) INFO 08-17 23:29:05 pynccl.py:63] vLLM is using nccl==2.20.5
(VllmWorkerProcess pid=1222521) INFO 08-17 23:29:05 pynccl.py:63] vLLM is using nccl==2.20.5
(VllmWorkerProcess pid=1222522) INFO 08-17 23:29:05 pynccl.py:63] vLLM is using nccl==2.20.5
(VllmWorkerProcess pid=1222517) INFO 08-17 23:29:05 utils.py:737] Found nccl from library libnccl.so.2
(VllmWorkerProcess pid=1222520) INFO 08-17 23:29:05 utils.py:737] Found nccl from library libnccl.so.2
(VllmWorkerProcess pid=1222520) INFO 08-17 23:29:05 pynccl.py:63] vLLM is using nccl==2.20.5
(VllmWorkerProcess pid=1222517) INFO 08-17 23:29:05 pynccl.py:63] vLLM is using nccl==2.20.5
INFO 2024-08-17 23:29:07,405 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:43911/v1, this might take a moment... Attempt: 3/100
INFO 2024-08-17 23:29:11,984 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:43911/v1, this might take a moment... Attempt: 4/100
(VllmWorkerProcess pid=1222519) INFO 08-17 23:29:12 custom_all_reduce_utils.py:232] reading GPU P2P access cache from /home/ec2-user/.config/vllm/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
(VllmWorkerProcess pid=1222520) INFO 08-17 23:29:12 custom_all_reduce_utils.py:232] reading GPU P2P access cache from /home/ec2-user/.config/vllm/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
(VllmWorkerProcess pid=1222523) INFO 08-17 23:29:12 custom_all_reduce_utils.py:232] reading GPU P2P access cache from /home/ec2-user/.config/vllm/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
(VllmWorkerProcess pid=1222521) INFO 08-17 23:29:12 custom_all_reduce_utils.py:232] reading GPU P2P access cache from /home/ec2-user/.config/vllm/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
(VllmWorkerProcess pid=1222522) INFO 08-17 23:29:12 custom_all_reduce_utils.py:232] reading GPU P2P access cache from /home/ec2-user/.config/vllm/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
INFO 08-17 23:29:12 custom_all_reduce_utils.py:232] reading GPU P2P access cache from /home/ec2-user/.config/vllm/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
(VllmWorkerProcess pid=1222517) INFO 08-17 23:29:12 custom_all_reduce_utils.py:232] reading GPU P2P access cache from /home/ec2-user/.config/vllm/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
(VllmWorkerProcess pid=1222518) INFO 08-17 23:29:12 custom_all_reduce_utils.py:232] reading GPU P2P access cache from /home/ec2-user/.config/vllm/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
INFO 2024-08-17 23:29:16,686 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:43911/v1, this might take a moment... Attempt: 5/100
INFO 2024-08-17 23:29:21,160 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:43911/v1, this might take a moment... Attempt: 6/100
(VllmWorkerProcess pid=1222519) INFO 08-17 23:29:21 model_runner.py:266] Loading model weights took 1.5874 GB
(VllmWorkerProcess pid=1222523) INFO 08-17 23:29:22 model_runner.py:266] Loading model weights took 1.5874 GB
(VllmWorkerProcess pid=1222521) INFO 08-17 23:29:22 model_runner.py:266] Loading model weights took 1.5874 GB
(VllmWorkerProcess pid=1222522) INFO 08-17 23:29:22 model_runner.py:266] Loading model weights took 1.5874 GB
(VllmWorkerProcess pid=1222518) INFO 08-17 23:29:22 model_runner.py:266] Loading model weights took 1.5874 GB
(VllmWorkerProcess pid=1222520) INFO 08-17 23:29:22 model_runner.py:266] Loading model weights took 1.5874 GB
INFO 08-17 23:29:22 model_runner.py:266] Loading model weights took 1.5874 GB
(VllmWorkerProcess pid=1222517) INFO 08-17 23:29:22 model_runner.py:266] Loading model weights took 1.5874 GB
INFO 2024-08-17 23:29:25,559 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:43911/v1, this might take a moment... Attempt: 7/100
INFO 08-17 23:29:27 distributed_gpu_executor.py:56] # GPU blocks: 61419, # CPU blocks: 4096
INFO 2024-08-17 23:29:30,075 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:43911/v1, this might take a moment... Attempt: 8/100
(VllmWorkerProcess pid=1222520) INFO 08-17 23:29:30 model_runner.py:1007] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
(VllmWorkerProcess pid=1222520) INFO 08-17 23:29:30 model_runner.py:1011] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
INFO 08-17 23:29:30 model_runner.py:1007] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
INFO 08-17 23:29:30 model_runner.py:1011] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
(VllmWorkerProcess pid=1222517) INFO 08-17 23:29:30 model_runner.py:1007] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
(VllmWorkerProcess pid=1222517) INFO 08-17 23:29:30 model_runner.py:1011] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
(VllmWorkerProcess pid=1222522) INFO 08-17 23:29:30 model_runner.py:1007] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
(VllmWorkerProcess pid=1222522) INFO 08-17 23:29:30 model_runner.py:1011] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
(VllmWorkerProcess pid=1222521) INFO 08-17 23:29:30 model_runner.py:1007] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
(VllmWorkerProcess pid=1222521) INFO 08-17 23:29:30 model_runner.py:1011] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
(VllmWorkerProcess pid=1222519) INFO 08-17 23:29:30 model_runner.py:1007] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
(VllmWorkerProcess pid=1222523) INFO 08-17 23:29:30 model_runner.py:1007] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
(VllmWorkerProcess pid=1222519) INFO 08-17 23:29:30 model_runner.py:1011] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
(VllmWorkerProcess pid=1222523) INFO 08-17 23:29:30 model_runner.py:1011] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
(VllmWorkerProcess pid=1222518) INFO 08-17 23:29:30 model_runner.py:1007] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
(VllmWorkerProcess pid=1222518) INFO 08-17 23:29:30 model_runner.py:1011] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode. You can also reduce the `max_num_seqs` as needed to decrease memory usage.
INFO 2024-08-17 23:29:34,833 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:43911/v1, this might take a moment... Attempt: 9/100
INFO 2024-08-17 23:29:39,561 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:43911/v1, this might take a moment... Attempt: 10/100
INFO 2024-08-17 23:29:44,206 instructlab.model.backends.backends:466: Waiting for the vLLM server to start at http://127.0.0.1:43911/v1, this might take a moment... Attempt: 11/100
(VllmWorkerProcess pid=1222523) INFO 08-17 23:29:44 custom_all_reduce.py:219] Registering 2275 cuda graph addresses
INFO 08-17 23:29:44 custom_all_reduce.py:219] Registering 2275 cuda graph addresses
(VllmWorkerProcess pid=1222517) INFO 08-17 23:29:44 custom_all_reduce.py:219] Registering 2275 cuda graph addresses
(VllmWorkerProcess pid=1222519) INFO 08-17 23:29:44 custom_all_reduce.py:219] Registering 2275 cuda graph addresses
(VllmWorkerProcess pid=1222520) INFO 08-17 23:29:44 custom_all_reduce.py:219] Registering 2275 cuda graph addresses
(VllmWorkerProcess pid=1222521) INFO 08-17 23:29:44 custom_all_reduce.py:219] Registering 2275 cuda graph addresses
(VllmWorkerProcess pid=1222518) INFO 08-17 23:29:44 custom_all_reduce.py:219] Registering 2275 cuda graph addresses
(VllmWorkerProcess pid=1222522) INFO 08-17 23:29:44 custom_all_reduce.py:219] Registering 2275 cuda graph addresses
INFO 08-17 23:29:44 model_runner.py:1208] Graph capturing finished in 14 secs.
(VllmWorkerProcess pid=1222523) INFO 08-17 23:29:44 model_runner.py:1208] Graph capturing finished in 14 secs.
(VllmWorkerProcess pid=1222520) INFO 08-17 23:29:44 model_runner.py:1208] Graph capturing finished in 14 secs.
(VllmWorkerProcess pid=1222517) INFO 08-17 23:29:44 model_runner.py:1208] Graph capturing finished in 14 secs.
(VllmWorkerProcess pid=1222521) INFO 08-17 23:29:44 model_runner.py:1208] Graph capturing finished in 14 secs.
(VllmWorkerProcess pid=1222519) INFO 08-17 23:29:44 model_runner.py:1208] Graph capturing finished in 14 secs.
(VllmWorkerProcess pid=1222522) INFO 08-17 23:29:44 model_runner.py:1208] Graph capturing finished in 14 secs.
(VllmWorkerProcess pid=1222518) INFO 08-17 23:29:44 model_runner.py:1208] Graph capturing finished in 14 secs.
INFO 08-17 23:29:44 serving_chat.py:94] Using supplied chat template:
INFO 08-17 23:29:44 serving_chat.py:94] {% set eos_token = "<|endoftext|>" %}
INFO 08-17 23:29:44 serving_chat.py:94] {% for message in messages %}
INFO 08-17 23:29:44 serving_chat.py:94] {% if message['role'] == 'user' %}
INFO 08-17 23:29:44 serving_chat.py:94] {{ '<|user|>
INFO 08-17 23:29:44 serving_chat.py:94] ' + message['content'] }}
INFO 08-17 23:29:44 serving_chat.py:94] {% elif message['role'] == 'system' %}
INFO 08-17 23:29:44 serving_chat.py:94] {{ '<|system|>
INFO 08-17 23:29:44 serving_chat.py:94] ' + message['content'] }}
INFO 08-17 23:29:44 serving_chat.py:94] {% elif message['role'] == 'assistant' %}
INFO 08-17 23:29:44 serving_chat.py:94] {{ '<|assistant|>
INFO 08-17 23:29:44 serving_chat.py:94] ' + message['content'] + eos_token }}
INFO 08-17 23:29:44 serving_chat.py:94] {% endif %}
INFO 08-17 23:29:44 serving_chat.py:94] {% if loop.last and add_generation_prompt %}
INFO 08-17 23:29:44 serving_chat.py:94] {{ '<|assistant|>' }}
INFO 08-17 23:29:44 serving_chat.py:94] {% endif %}
INFO 08-17 23:29:44 serving_chat.py:94] {% endfor %}
WARNING 08-17 23:29:44 serving_embedding.py:138] embedding_mode is False. Embedding API will not work.
INFO 08-17 23:29:44 api_server.py:257] Available routes are:
INFO 08-17 23:29:44 api_server.py:262] Route: /openapi.json, Methods: GET, HEAD
INFO 08-17 23:29:44 api_server.py:262] Route: /docs, Methods: GET, HEAD
INFO 08-17 23:29:44 api_server.py:262] Route: /docs/oauth2-redirect, Methods: GET, HEAD
INFO 08-17 23:29:44 api_server.py:262] Route: /redoc, Methods: GET, HEAD
INFO 08-17 23:29:44 api_server.py:262] Route: /health, Methods: GET
INFO 08-17 23:29:44 api_server.py:262] Route: /tokenize, Methods: POST
INFO 08-17 23:29:44 api_server.py:262] Route: /detokenize, Methods: POST
INFO 08-17 23:29:44 api_server.py:262] Route: /v1/models, Methods: GET
INFO 08-17 23:29:44 api_server.py:262] Route: /version, Methods: GET
INFO 08-17 23:29:44 api_server.py:262] Route: /v1/chat/completions, Methods: POST
INFO 08-17 23:29:44 api_server.py:262] Route: /v1/completions, Methods: POST
INFO 08-17 23:29:44 api_server.py:262] Route: /v1/embeddings, Methods: POST
INFO:     Started server process [1222429]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:43911 (Press CTRL+C to quit)
INFO:     127.0.0.1:40072 - "GET /v1/models HTTP/1.1" 200 OK
INFO 2024-08-17 23:29:45,121 instructlab.model.backends.backends:473: vLLM engine successfully started at http://127.0.0.1:43911/v1
DEBUG 2024-08-17 23:29:45,121 instructlab.eval.mt_bench:58: {'self': <instructlab.eval.mt_bench.MTBenchEvaluator object at 0x7fc1e1e60dd0>, 'server_url': 'http://127.0.0.1:43911/v1'}
DEBUG 2024-08-17 23:29:45,121 instructlab.eval.mt_bench_answers:113: {'model_name': 'test_model', 'model_api_base': 'http://127.0.0.1:43911/v1', 'branch': None, 'output_dir': '/home/ec2-user/.local/share/instructlab/internal/eval_data', 'data_dir': None, 'question_begin': None, 'question_end': None, 'force_temperature': None, 'num_choices': 1, 'max_tokens': 1024, 'max_workers': 16, 'bench_name': 'mt_bench'}
```

This PR also changes the default max attempts to connect to 120.
Since there is now logic to restart, the risk of serving not starting is not nearly as high.  The longest 'normal' case restarts with larger models tend to finish within 60-80 attempts on the first start and ~10 on each subsequent start.  120 is still a sufficient buffer.


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
