### PR TITLE
Add process group kill for vllm process

### DIFF
--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -200,16 +200,22 @@ def run_vllm(
     vllm_env.pop("VLLM_CONFIGURE_LOGGING", None)
 
     try:
+        # Note: start_new_session=True is needed to create a process group which will later be used on shutdown
         if background:
             vllm_process = subprocess.Popen(
                 args=vllm_cmd,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 env=vllm_env,
+                start_new_session=True,
             )
         else:
             # pylint: disable=consider-using-with
-            vllm_process = subprocess.Popen(args=vllm_cmd, env=vllm_env)
+            vllm_process = subprocess.Popen(
+                args=vllm_cmd,
+                env=vllm_env,
+                start_new_session=True,
+            )
 
         api_base = get_api_base(f"{host}:{port}")
         logger.info("vLLM starting up on pid %s at %s", vllm_process.pid, api_base)


### PR DESCRIPTION
In some cases, vllm may not be able to shutdown properly.  To handle that scenario, this logic adds one additional process group kill to make sure the child processes are cleaned up.  Nothing will happen if the vllm process is already shut down cleanly.

Example of it working:
```
DEBUG 2024-08-18 03:43:40,350 instructlab.eval.mt_bench_answers:29: {'answer_file': '/home/ec2-user/.local/share/instructlab/internal/eval_data/mt_bench/model_answer/test_model.jsonl'}
DEBUG 2024-08-18 03:43:40,351 instructlab.model.backends.backends:317: Sending SIGINT to vLLM server PID 1558425
DEBUG 2024-08-18 03:43:40,351 instructlab.model.backends.backends:321: Waiting for vLLM server to shut down gracefully
INFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [1558425]
INFO 08-18 03:43:40 async_llm_engine.py:51] Engine is gracefully shutting down.
ERROR 08-18 03:43:42 multiproc_worker_utils.py:120] Worker VllmWorkerProcess pid 1558516 died, exit code: -15
INFO 08-18 03:43:42 multiproc_worker_utils.py:123] Killing local vLLM worker processes
[rank0]:[W CudaIPCTypes.cpp:16] Producer process has been terminated before all shared CUDA tensors released. See Note [Sharing CUDA tensors]
/usr/lib64/python3.11/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 1 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
DEBUG 2024-08-18 03:43:50,432 instructlab.model.backends.backends:332: Sent SIGKILL to vLLM process group
INFO 2024-08-18 03:43:50,432 instructlab.model.backends.backends:349: Waiting for GPU VRAM reclamation...
DEBUG 2024-08-18 03:43:53,304 instructlab.model.backends.backends:400: GPU free vram stable (stable count 1, free 674996682752, last free 674996682752)
DEBUG 2024-08-18 03:43:54,305 instructlab.model.backends.backends:400: GPU free vram stable (stable count 2, free 674996682752, last free 674996682752)
DEBUG 2024-08-18 03:43:55,306 instructlab.model.backends.backends:400: GPU free vram stable (stable count 3, free 674996682752, last free 674996682752)
DEBUG 2024-08-18 03:43:56,307 instructlab.model.backends.backends:400: GPU free vram stable (stable count 4, free 674996682752, last free 674996682752)
DEBUG 2024-08-18 03:43:57,308 instructlab.model.backends.backends:400: GPU free vram stable (stable count 5, free 674996682752, last free 674996682752)
DEBUG 2024-08-18 03:43:58,309 instructlab.model.backends.backends:400: GPU free vram stable (stable count 6, free 674996682752, last free 674996682752)
DEBUG 2024-08-18 03:43:58,309 instructlab.model.backends.backends:407: Successful sample recorded, (stable count 6, free 674996682752, last free 674996682752)
Evaluating answers...
```


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
