### PR TITLE
Add back a pip -e . for instructlab in cloud-instance

### DIFF
--- a/scripts/infra/cloud-instance.sh
+++ b/scripts/infra/cloud-instance.sh
@@ -351,6 +351,7 @@ pip_install_with_nvidia() {
             llama_cpp_python -c constraints.txt llama_cpp_python \
          && pip install wheel packaging torch -c constraints.txt \
          && pip install .[cuda] -r requirements-vllm-cuda.txt \
+         && pip install -e . --no-deps \
          && ilab"
 }
 


### PR DESCRIPTION
The logic was adjusted to pull in all the appropriate dependencies and lost the -e along the way.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
