### PR TITLE
feat: reduce mmlu eval in phased training via env var.

### DIFF
--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -806,8 +806,12 @@ def _mmlu(model: pathlib.Path) -> float:
     from instructlab.eval.mmlu import MMLU_TASKS, MMLUEvaluator
     import torch
 
-    # TODO: few_shots is enforced to be 5 here. Should be grabbed from config.
-    evaluator = MMLUEvaluator(model, tasks=MMLU_TASKS, few_shots=5)
+    min_tasks = os.environ.get("INSTRUCTLAB_EVAL_MMLU_MIN_TASKS")
+    if min_tasks is not None:
+        tasks = ["mmlu_abstract_algebra", "mmlu_anatomy", "mmlu_astronomy"]
+        evaluator = MMLUEvaluator(model, tasks=tasks)
+    else:
+        evaluator = MMLUEvaluator(model, tasks=MMLU_TASKS)
 
     # type the variable because MyPy doesn't seem to honor the types of the spread tuple
     ckpt_score: float


### PR DESCRIPTION
Allow a user to set env var `INSTRUCTLAB_EVAL_MMLU_MIN_TASKS=True` to reduce phased training times for development and experimentation.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
