### PR TITLE
refactor: move ensure_server() to vllm.py

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -32,7 +32,7 @@ def setup_gpus_config(section_path="serve", gpus=None, tps=None, vllm_args=lambd
     return _CFG_FILE_NAME
 
 
-@mock.patch("instructlab.model.backends.backends.check_api_base", return_value=False)
+@mock.patch("instructlab.model.backends.vllm.check_api_base", return_value=False)
 # ^ mimic server *not* running already
 @mock.patch(
     "instructlab.model.backends.backends.determine_backend",


### PR DESCRIPTION
ensure_server is used only by vllm.

Move it to reduce circular dependency between backends.py and vllm.py.
Slightly adopt the function on the new place.

References:
- https://en.wikipedia.org/wiki/Circular_dependency
- https://en.wikipedia.org/wiki/Acyclic_dependencies_principle

