### PR TITLE
Fix test case broken by conflicting changes

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -52,7 +52,10 @@ def vllm_setup_test(runner, args, mock_popen, *_mock_args):
     if result.exit_code != 0:
         print(result.output)
 
-    assert len(mock_popen.call_args_list) == 1
+    assert len(mock_popen.call_args_list) == 1 or (
+        "Retrying (1/1)" in result.output and len(mock_popen.call_args_list) == 2
+    )
+
     return mock_popen.call_args_list[0][1]["args"]
 
 


### PR DESCRIPTION
The combination of https://github.com/instructlab/instructlab/pull/2092 and https://github.com/instructlab/instructlab/pull/2046 broke the test cases.  This fix allows both scenarios to exist at the same time by allowing the vllm startup retry scenario within the common test case function.

Alternate fix for: https://github.com/instructlab/instructlab/pull/2115

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
