### PR TITLE
taxonomy base fix

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -154,9 +154,9 @@ def init(
         cfg.generate.model = model_path
         cfg.serve.model_path = model_path
         cfg.evaluate.model = model_path
-    cfg.generate.taxonomy_path = taxonomy_path
-    cfg.generate.taxonomy_base = taxonomy_base
-    cfg.evaluate.mt_bench_branch.taxonomy_path = taxonomy_path
+        cfg.generate.taxonomy_base = taxonomy_base
+        cfg.generate.taxonomy_path = taxonomy_path
+        cfg.evaluate.mt_bench_branch.taxonomy_path = taxonomy_path
     write_config(cfg)
 
     click.secho(


### PR DESCRIPTION
when using taxonomy base from ENV, do not override with the default value from `get_params`

also place taxonomy path inside of this ENV check. If a user provides a global cfg with ANY of these paths, models, etc we should not override w/ the defaults

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
