### PR TITLE
Update testdata yaml files to account for updated schema in instructlab-schema v0.4.1

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -330,7 +330,7 @@ test_loading_session_history(){
 
 test_generate(){
     mkdir -p test_taxonomy/compositional_skills
-    cat - <<EOF >  test_taxonomy/compositional_skills/simple_math.yaml
+    cat - <<EOF >  test_taxonomy/compositional_skills/qna.yaml
 created_by: ci
 version: 2
 seed_examples:
@@ -350,7 +350,7 @@ EOF
     sed -i.bak -e 's/sdg_scale_factor.*/sdg_scale_factor: 1/g' "${ILAB_CONFIG_FILE}"
 
     # This should be finished in a minute or so but time it out incase it goes wrong
-    if ! timeout 20m ilab data generate --taxonomy-path test_taxonomy/compositional_skills/simple_math.yaml; then
+    if ! timeout 20m ilab data generate --taxonomy-path test_taxonomy/compositional_skills/qna.yaml; then
         echo "Error: ilab data generate command took more than 20 minutes and was cancelled"
         exit 1
     fi

--- a/tests/test_lab_diff.py
+++ b/tests/test_lab_diff.py
@@ -14,7 +14,7 @@ from instructlab import lab
 
 TAXONOMY_BASE = "main"
 
-TEST_CUSTOM_YAML_RULES = b"""extends: relaxed
+TEST_CUSTOM_YAML_RULES = b"""empty-lines: relaxed
 
 rules:
   line-length:

--- a/tests/testdata/invalid_yaml.yaml
+++ b/tests/testdata/invalid_yaml.yaml
@@ -16,3 +16,4 @@ seed_examples:
 - answer: "answer5"
   question: "question5"
 task_description: For invalid yaml tests
+


### PR DESCRIPTION


<!-- Thank you for contributing to InstructLab! -->

`instructlab-schema v0.4.1` disabled the line-length check and enforced a requirement for leaf nodes to be called `qna.yaml`. This PR reflects these updates to the testdata yaml files used in the CLI as part of the unit and functional tests

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
