### PR TITLE
Bump min version of sdg lib to 0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ httpx>=0.25.0
 instructlab-eval>=0.1.1
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.4.0
-instructlab-sdg>=0.2.6
+instructlab-sdg>=0.3.0
 instructlab-training>=0.4.1
 llama_cpp_python[server]==0.2.79
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'


### PR DESCRIPTION
Bumping the minimum version of sdg library because of:

- Removal of parameters in the `generate()` API to force Open AI client to be passed (no longer initialized in the API)
- Schema parsing and validation now being called from the schema library instead

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
