### PR TITLE
Add auto max_workers capability

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -22,6 +22,7 @@ Config
 Containerfile
 coreutils
 cpp
+CPUs
 CRB
 cuBLAS
 cuda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## v0.19
 
-### Features
-
-* Add `log_format` to the `config.yaml` file to allow for customizing the log format.
-
 ### Breaking Changes
 
 * InstructLab now uses XDG-based directories on macOS, similar to Linux.
@@ -24,6 +20,10 @@
 ### Features
 
 * `ilab config init` now auto detects your hardware when running on Nvidia enabled systems and chooses the best train profile. It does this by checking first if your system directly matches one of our supported train profiles and then attempts to match the vRAM for each profile to the total vRAM on your system.
+* Add `log_format` to the `config.yaml` file to allow for customizing the log format.
+* `ilab model evaluate --max-workers=auto` is now supported and is the default option. When
+  auto is specified, the optimal value is determined based on your GPUs, CPUs, and
+  configuration.
 
 ## v0.18.1
 

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -307,9 +307,9 @@ class _mtbench(BaseModel):
         default_factory=lambda: DEFAULTS.EVAL_DATA_DIR,
         description="Directory where evaluation results are stored.",
     )
-    max_workers: int = Field(
-        default=16,
-        description="Number of workers to use for evaluation.",
+    max_workers: str | int = Field(
+        default="auto",
+        description="Number of workers to use for evaluation with mt_bench or mt_bench_branch. Must be a positive integer or 'auto'.",
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -292,7 +292,7 @@ evaluate:
   mt_bench:
     judge_model: prometheus
     output_dir: /dir/to/output
-    max_workers: 5
+    max_workers: auto
   mt_bench_branch:
     taxonomy_path: taxonomy
 general:

--- a/tests/test_lab_evaluate.py
+++ b/tests/test_lab_evaluate.py
@@ -204,7 +204,7 @@ def run_mt_bench_branch(cli_runner, error_rate):
 @patch("instructlab.model.evaluate.validate_model")
 @patch(
     "instructlab.model.evaluate.launch_server",
-    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1"),
+    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1", 1),
 )
 @patch("instructlab.eval.mt_bench.MTBenchEvaluator.gen_answers")
 @patch(
@@ -236,7 +236,7 @@ def test_evaluate_mt_bench(
 @patch("instructlab.model.evaluate.validate_model")
 @patch(
     "instructlab.model.evaluate.launch_server",
-    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1"),
+    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1", 1),
 )
 @patch("instructlab.eval.mt_bench.MTBenchBranchEvaluator.gen_answers")
 @patch(
@@ -270,7 +270,7 @@ def test_evaluate_mt_bench_branch(
 @patch("instructlab.model.evaluate.validate_model")
 @patch(
     "instructlab.model.evaluate.launch_server",
-    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1"),
+    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1", 1),
 )
 @patch(
     "instructlab.eval.mmlu.MMLUEvaluator.run",
@@ -316,7 +316,7 @@ def test_evaluate_mmlu(
 @patch("instructlab.model.evaluate.validate_model")
 @patch(
     "instructlab.model.evaluate.launch_server",
-    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1"),
+    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1", 1),
 )
 @patch(
     "instructlab.eval.mmlu.MMLUBranchEvaluator.run",
@@ -427,6 +427,30 @@ def test_invalid_model_mt_bench(cli_runner: CliRunner):
     assert result.exit_code != 0
 
 
+@patch("instructlab.model.evaluate.validate_model")
+def test_invalid_max_workers(_, cli_runner: CliRunner):
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "evaluate",
+            "--benchmark",
+            "mt_bench",
+            "--model",
+            "instructlab/granite-7b-lab",
+            "--judge-model",
+            "instructlab/merlinite-7b-lab",
+            "--max-workers",
+            "invalid",
+        ],
+    )
+    assert (
+        "max-workers must be specified as a positive integer or 'auto'" in result.output
+    )
+    assert result.exit_code != 0
+
+
 def test_invalid_model_mmlu(cli_runner: CliRunner):
     result = cli_runner.invoke(
         lab.ilab,
@@ -470,7 +494,7 @@ def test_int_batchsize_mmlu(mmlu_mock, _, cli_runner: CliRunner):
 @patch("instructlab.model.evaluate.validate_model")
 @patch(
     "instructlab.model.evaluate.launch_server",
-    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1"),
+    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1", 1),
 )
 def test_invalid_taxonomy_mt_bench_branch(launch_server_mock, _, cli_runner: CliRunner):
     result = cli_runner.invoke(
@@ -503,7 +527,7 @@ def test_invalid_taxonomy_mt_bench_branch(launch_server_mock, _, cli_runner: Cli
 @patch("instructlab.model.evaluate.validate_model")
 @patch(
     "instructlab.model.evaluate.launch_server",
-    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1"),
+    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1", 1),
 )
 def test_invalid_branch_mt_bench_branch(launch_server_mock, _, cli_runner: CliRunner):
     setup_taxonomy("taxonomy")
@@ -537,7 +561,7 @@ def test_invalid_branch_mt_bench_branch(launch_server_mock, _, cli_runner: CliRu
 @patch("instructlab.model.evaluate.validate_model")
 @patch(
     "instructlab.model.evaluate.launch_server",
-    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1"),
+    return_value=(mock.MagicMock(), "http://127.0.0.1:8000/v1", 1),
 )
 def test_invalid_tasks_dir(_, __, cli_runner: CliRunner):
     result = cli_runner.invoke(

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -66,9 +66,10 @@ evaluate:
     # Judge model for mt_bench and mt_bench_branch.
     # Default: prometheus-eval/prometheus-8x7b-v2.0
     judge_model: prometheus-eval/prometheus-8x7b-v2.0
-    # Number of workers to use for evaluation.
-    # Default: 16
-    max_workers: 16
+    # Number of workers to use for evaluation with mt_bench or mt_bench_branch. Must
+    # be a positive integer or 'auto'.
+    # Default: auto
+    max_workers: auto
     # Directory where evaluation results are stored.
     # Default: /data/instructlab/internal/eval_data
     output_dir: /data/instructlab/internal/eval_data


### PR DESCRIPTION
This capability takes advantage of the feature from the eval library which tunes max_workers according to the hardware configuration.  In order to accomplish this, effective gpus and max_workers="auto" needs to be passed to eval.  To accomplish this, gpus and effective gpus needed to be calculate earlier in the process.

This change also updates training to use get_gpus and max_workers=auto.  This means training now uses the gpu settings of evaluate when calling evaluate before defaulting to all gpus if not specified.

Resolves: https://github.com/instructlab/instructlab/issues/2079


https://github.com/instructlab/eval/pull/107 is now released enabling this change.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
