### PR TITLE
enable nvidia-toolkit-setup.service

### DIFF
--- a/scripts/infra/nvidia-setup.sh
+++ b/scripts/infra/nvidia-setup.sh
@@ -168,4 +168,4 @@ fi \
     && ln -f -s /usr/lib/systemd/system/nvidia-toolkit-setup.service /usr/lib/systemd/system/basic.target.wants/nvidia-toolkit-setup.service \
     && ln -f -s /usr/lib/systemd/system/nvidia-persistenced.service /etc/systemd/system/multi-user.target.wants/nvidia-persistenced.service
     systemctl daemon-reload
-    systemctl restart nvidia-toolkit-setup.service
+    systemctl enable --now nvidia-toolkit-setup.service


### PR DESCRIPTION
I noticed after rebooting my instance after running `nvidia-setup.sh`, the nvidia-toolkit-setup.service was not running, which made the command
`python -m vllm.entrypoints.openai.api_server --model instructlab/granite-7b-lab --tensor-parallel-size 1` fail. 
Any reason not to enable the service? 
