### PR TITLE
feat: implement `ilab profile set`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ issues = "https://github.com/instructlab/instructlab/issues"
 "model" = "instructlab.model.model:model"
 "system" = "instructlab.system.system:system"
 "taxonomy" = "instructlab.taxonomy.taxonomy:taxonomy"
+"profile" = "instructlab.profile.profile:profile"
 
 [project.entry-points."instructlab.command.config"]
 "edit" = "instructlab.config.edit:edit"
@@ -67,6 +68,9 @@ issues = "https://github.com/instructlab/instructlab/issues"
 
 [project.entry-points."instructlab.command.taxonomy"]
 "diff" = "instructlab.taxonomy.diff:diff"
+
+[project.entry-points."instructlab.command.profile"]
+"set" = "instructlab.profile.set:set"
 
 [project.entry-points."instructlab.command.alias"]
 "chat" = "instructlab.model.chat:chat"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 # Habana installer has NumPy 1.23.5
 numpy>=1.23.5,<2.0.0 ; python_version == '3.10'
 numpy>=1.26.4,<2.0.0 ; python_version >= '3.11'
+nvidia-ml-py3
+nvidia_smi
 openai>=1.13.3
 peft>=0.9.0
 platformdirs>=4.2

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1527,7 +1527,7 @@ class Lab:
 
 
 
-def render_configs_and_profiles(gpus: int) ->  list[tuple[int, Config, list[dict[str, _train]]]]:
+def render_configs_and_profiles(gpus: int) ->  list[tuple[int, Config, list[dict[str, tuple[int, _train]]]]]:
     single_gpu_confg = Config(
         generate=_generate(
             sdg_scale_factor=10,
@@ -1609,10 +1609,10 @@ def render_configs_and_profiles(gpus: int) ->  list[tuple[int, Config, list[dict
 
 
     return [
-        (16, single_gpu_confg, [{"NVIDIA RTX 3070/3080/4070/4080": SINGLE_CONSUMER_GPU_TRAIN}]),
-        (24, single_server_gpu_config, [{"NVIDIA A100/H100/L40/L4": SINGLE_SERVER_GPU_TRAIN}]),
-        (48, multi_gpu_config, [{"NVIDIA RTX 3070/3080/4070/4080": MULTI_CONSUMER_GPU_TRAIN}]),
-        (196, multi_server_gpu_config, [{"NVIDIA 2x A100/H100": (160, TWO_GPU_TRAIN_AH)}, {"NVIDIA 4x A100/H100": (320, FOUR_GPU_TRAIN_AH)}, {"NVIDIA 8x A100 or H100": (640, EIGHT_GPU_TRAIN_AH)}, {"NVIDIA 4x L40": (192, FOUR_L_FORTY_GPU)}, {"NVIDIA 8x L40": (384, EIGHT_L_FORTY_GPU)}, {"NVIDIA 8x L4": (192, EIGHT_L_FOUR_GPU)}]),
+        (16, single_gpu_confg, [{"NVIDIA RTX 3070/3080/4070/4080": (16, SINGLE_CONSUMER_GPU_TRAIN)}]),
+        (24, single_server_gpu_config, [{"NVIDIA A100/H100/L40/L4": (24, SINGLE_SERVER_GPU_TRAIN)}]),
+        (48, multi_gpu_config, [{"NVIDIA RTX 3070/3080/4070/4080": (48, MULTI_CONSUMER_GPU_TRAIN)}]),
+        (640, multi_server_gpu_config, [{"NVIDIA 2x A100/H100": (160, TWO_GPU_TRAIN_AH)}, {"NVIDIA 8x L4": (192, EIGHT_L_FOUR_GPU)}, {"NVIDIA 4x L40": (192, FOUR_L_FORTY_GPU)}, {"NVIDIA 4x A100/H100": (320, FOUR_GPU_TRAIN_AH)}, {"NVIDIA 8x L40": (384, EIGHT_L_FORTY_GPU)}, {"NVIDIA 8x A100 or H100": (640, EIGHT_GPU_TRAIN_AH)}, ]),
         (0, macos_config, [MACOS_TRAIN]),
     ]
 

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1527,7 +1527,7 @@ class Lab:
 
 
 
-def render_configs_and_profiles(gpus: int) ->  list[tuple[Config, list[dict[str, _train]]]]:
+def render_configs_and_profiles(gpus: int) ->  list[tuple[int, Config, list[dict[str, _train]]]]:
     single_gpu_confg = Config(
         generate=_generate(
             sdg_scale_factor=10,
@@ -1609,11 +1609,11 @@ def render_configs_and_profiles(gpus: int) ->  list[tuple[Config, list[dict[str,
 
 
     return [
-        (single_gpu_confg, [{"NVIDIA RTX 3070/3080/4070/4080": SINGLE_CONSUMER_GPU_TRAIN}]),
-        (multi_gpu_config, [{"NVIDIA RTX 3070/3080/4070/4080": MULTI_CONSUMER_GPU_TRAIN}]),
-        (single_server_gpu_config, [{"NVIDIA A100/H100/L40/L4": SINGLE_SERVER_GPU_TRAIN}]),
-        (multi_server_gpu_config, [{"NVIDIA 2x A100/H100": TWO_GPU_TRAIN_AH}, {"NVIDIA 4x A100/H100": FOUR_GPU_TRAIN_AH}, {"NVIDIA 8x A100 or H100": EIGHT_GPU_TRAIN_AH}, {"NVIDIA 4x L40": FOUR_L_FORTY_GPU}, {"NVIDIA 8x L40": EIGHT_L_FORTY_GPU}, {"NVIDIA 8x L4": EIGHT_L_FOUR_GPU}]),
-        (macos_config, [MACOS_TRAIN]),
+        (16, single_gpu_confg, [{"NVIDIA RTX 3070/3080/4070/4080": SINGLE_CONSUMER_GPU_TRAIN}]),
+        (24, single_server_gpu_config, [{"NVIDIA A100/H100/L40/L4": SINGLE_SERVER_GPU_TRAIN}]),
+        (48, multi_gpu_config, [{"NVIDIA RTX 3070/3080/4070/4080": MULTI_CONSUMER_GPU_TRAIN}]),
+        (196, multi_server_gpu_config, [{"NVIDIA 2x A100/H100": (160, TWO_GPU_TRAIN_AH)}, {"NVIDIA 4x A100/H100": (320, FOUR_GPU_TRAIN_AH)}, {"NVIDIA 8x A100 or H100": (640, EIGHT_GPU_TRAIN_AH)}, {"NVIDIA 4x L40": (192, FOUR_L_FORTY_GPU)}, {"NVIDIA 8x L40": (384, EIGHT_L_FORTY_GPU)}, {"NVIDIA 8x L4": (192, EIGHT_L_FOUR_GPU)}]),
+        (0, macos_config, [MACOS_TRAIN]),
     ]
 
 

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -245,6 +245,7 @@ MODEL_FAMILY_MAPPINGS = {
 }
 
 
+
 class ConfigException(Exception):
     """An exception that a configuration file has an error."""
 
@@ -907,6 +908,163 @@ def get_default_config() -> Config:
     )
 
 
+EIGHT_GPU_TRAIN_AH = _train(
+    additional_args={
+        "warmup_steps": 25,
+        "learning_rate": 2e-5,
+        "lora_dropout": 0.1,
+         "lora_alpha": 32,
+    },
+    ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
+    data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
+    data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
+    nproc_per_node=8,
+    effective_batch_size=128,
+    lora_quantize_dtype=None,
+    lora_rank=0,
+    max_batch_len=60000,
+    max_seq_len=4096,
+    save_samples=1000,
+    deepspeed_cpu_offload_optimizer=False,
+    is_padding_free=True,
+    num_epochs=8,
+    model_path=os.path.join(
+        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
+    ),
+)
+
+FOUR_GPU_TRAIN_AH = _train(
+    additional_args={
+        "warmup_steps": 25,
+        "learning_rate": 2e-5,
+        "lora_dropout": 0.1,
+        "lora_alpha": 32,
+    },
+    ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
+    data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
+    data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
+    nproc_per_node=4,
+    effective_batch_size=128,
+    lora_quantize_dtype=None,
+    lora_rank=0,
+    max_batch_len=54000,
+    max_seq_len=4096,
+    save_samples=1000,
+    deepspeed_cpu_offload_optimizer=False,
+    is_padding_free=True,
+    num_epochs=8,
+    model_path=os.path.join(
+        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
+    ),
+)
+
+TWO_GPU_TRAIN_AH = _train(
+    additional_args={
+        "warmup_steps": 25,
+        "learning_rate": 2e-5,
+        "lora_dropout": 0.1,
+        "lora_alpha": 32,
+        "deepspeed_cpu_offload_optimizer_ratio": 1,
+        "deepspeed_cpu_offload_optimizer_pin_memory": True,
+    },
+    ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
+    data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
+    data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
+    nproc_per_node=2,
+    effective_batch_size=128,
+    lora_quantize_dtype=None,
+    lora_rank=0,
+    max_batch_len=60000,
+    max_seq_len=4096,
+    save_samples=1000,
+    deepspeed_cpu_offload_optimizer=True,
+    is_padding_free=True,
+    num_epochs=8,
+    model_path=os.path.join(
+        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
+    ),
+)
+
+EIGHT_L_FORTY_GPU = _train(
+    additional_args={
+        "warmup_steps": 25,
+        "learning_rate": 2e-5,
+        "lora_dropout": 0.1,
+        "lora_alpha": 32,
+    },
+    ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
+    data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
+    data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
+    nproc_per_node=8,
+    effective_batch_size=128,
+    lora_quantize_dtype=None,
+    lora_rank=0,
+    max_batch_len=30000,
+    max_seq_len=4096,
+    save_samples=1000,
+    deepspeed_cpu_offload_optimizer=False,
+    is_padding_free=True,
+    num_epochs=8,
+    model_path=os.path.join(
+        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
+    ),
+)
+
+FOUR_L_FORTY_GPU = _train(
+    additional_args={
+        "warmup_steps": 25,
+        "learning_rate": 2e-5,
+        "lora_dropout": 0.1,
+        "lora_alpha": 32,
+        "deepspeed_cpu_offload_optimizer_ratio": 1,
+        "deepspeed_cpu_offload_optimizer_pin_memory": True,
+    },
+    ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
+    data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
+    data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
+    nproc_per_node=4,
+    effective_batch_size=128,
+    lora_quantize_dtype=None,
+    lora_rank=0,
+    max_batch_len=30000,
+    max_seq_len=4096,
+    save_samples=1000,
+    num_epochs=8,
+    deepspeed_cpu_offload_optimizer=True,
+    is_padding_free=True,
+    model_path=os.path.join(
+        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
+    ),
+)
+
+EIGHT_L_FOUR_GPU = _train(
+    additional_args={
+        "warmup_steps": 25,
+        "learning_rate": 2e-5,
+        "lora_dropout": 0.1,
+        "lora_alpha": 32,
+        "deepspeed_cpu_offload_optimizer_ratio": 1,
+        "deepspeed_cpu_offload_optimizer_pin_memory": True,
+    },
+    ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
+    data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
+    data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
+    nproc_per_node=8,
+    effective_batch_size=128,
+    lora_quantize_dtype=None,
+    lora_rank=0,
+    max_batch_len=30000,
+    max_seq_len=4096,
+    save_samples=1000,
+    num_epochs=8,
+    deepspeed_cpu_offload_optimizer=True,
+    is_padding_free=True,
+    model_path=os.path.join(
+        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
+    ),
+)
+
+
 def read_train_profile(train_file) -> _train:
     try:
         with open(train_file, "r", encoding="utf-8") as yamlfile:
@@ -1213,163 +1371,6 @@ def recreate_train_profiles(overwrite: bool = False) -> bool:
                     loaded = yaml.load(d)
                     yaml.dump(loaded, outfile)
     else:
-        # else render the defaults
-        EIGHT_GPU_TRAIN_AH = _train(
-            additional_args={
-                "warmup_steps": 25,
-                "learning_rate": 2e-5,
-                "lora_dropout": 0.1,
-                "lora_alpha": 32,
-            },
-            ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
-            data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
-            data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
-            nproc_per_node=8,
-            effective_batch_size=128,
-            lora_quantize_dtype=None,
-            lora_rank=0,
-            max_batch_len=60000,
-            max_seq_len=4096,
-            save_samples=1000,
-            deepspeed_cpu_offload_optimizer=False,
-            is_padding_free=True,
-            num_epochs=8,
-            model_path=os.path.join(
-                DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-            ),
-        )
-
-        FOUR_GPU_TRAIN_AH = _train(
-            additional_args={
-                "warmup_steps": 25,
-                "learning_rate": 2e-5,
-                "lora_dropout": 0.1,
-                "lora_alpha": 32,
-            },
-            ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
-            data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
-            data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
-            nproc_per_node=4,
-            effective_batch_size=128,
-            lora_quantize_dtype=None,
-            lora_rank=0,
-            max_batch_len=54000,
-            max_seq_len=4096,
-            save_samples=1000,
-            deepspeed_cpu_offload_optimizer=False,
-            is_padding_free=True,
-            num_epochs=8,
-            model_path=os.path.join(
-                DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-            ),
-        )
-
-        TWO_GPU_TRAIN_AH = _train(
-            additional_args={
-                "warmup_steps": 25,
-                "learning_rate": 2e-5,
-                "lora_dropout": 0.1,
-                "lora_alpha": 32,
-                "deepspeed_cpu_offload_optimizer_ratio": 1,
-                "deepspeed_cpu_offload_optimizer_pin_memory": True,
-            },
-            ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
-            data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
-            data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
-            nproc_per_node=2,
-            effective_batch_size=128,
-            lora_quantize_dtype=None,
-            lora_rank=0,
-            max_batch_len=60000,
-            max_seq_len=4096,
-            save_samples=1000,
-            deepspeed_cpu_offload_optimizer=True,
-            is_padding_free=True,
-            num_epochs=8,
-            model_path=os.path.join(
-                DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-            ),
-        )
-
-        EIGHT_L_FORTY_GPU = _train(
-            additional_args={
-                "warmup_steps": 25,
-                "learning_rate": 2e-5,
-                "lora_dropout": 0.1,
-                "lora_alpha": 32,
-            },
-            ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
-            data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
-            data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
-            nproc_per_node=8,
-            effective_batch_size=128,
-            lora_quantize_dtype=None,
-            lora_rank=0,
-            max_batch_len=30000,
-            max_seq_len=4096,
-            save_samples=1000,
-            deepspeed_cpu_offload_optimizer=False,
-            is_padding_free=True,
-            num_epochs=8,
-            model_path=os.path.join(
-                DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-            ),
-        )
-
-        FOUR_L_FORTY_GPU = _train(
-            additional_args={
-                "warmup_steps": 25,
-                "learning_rate": 2e-5,
-                "lora_dropout": 0.1,
-                "lora_alpha": 32,
-                "deepspeed_cpu_offload_optimizer_ratio": 1,
-                "deepspeed_cpu_offload_optimizer_pin_memory": True,
-            },
-            ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
-            data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
-            data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
-            nproc_per_node=4,
-            effective_batch_size=128,
-            lora_quantize_dtype=None,
-            lora_rank=0,
-            max_batch_len=30000,
-            max_seq_len=4096,
-            save_samples=1000,
-            num_epochs=8,
-            deepspeed_cpu_offload_optimizer=True,
-            is_padding_free=True,
-            model_path=os.path.join(
-                DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-            ),
-        )
-
-        EIGHT_L_FOUR_GPU = _train(
-            additional_args={
-                "warmup_steps": 25,
-                "learning_rate": 2e-5,
-                "lora_dropout": 0.1,
-                "lora_alpha": 32,
-                "deepspeed_cpu_offload_optimizer_ratio": 1,
-                "deepspeed_cpu_offload_optimizer_pin_memory": True,
-            },
-            ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
-            data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
-            data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
-            nproc_per_node=8,
-            effective_batch_size=128,
-            lora_quantize_dtype=None,
-            lora_rank=0,
-            max_batch_len=30000,
-            max_seq_len=4096,
-            save_samples=1000,
-            num_epochs=8,
-            deepspeed_cpu_offload_optimizer=True,
-            is_padding_free=True,
-            model_path=os.path.join(
-                DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-            ),
-        )
-
         to_write = {
             DEFAULTS.TRAIN_A100_H100_X4_PROFILE: FOUR_GPU_TRAIN_AH,
             DEFAULTS.TRAIN_A100_H100_X8_PROFILE: EIGHT_GPU_TRAIN_AH,
@@ -1414,6 +1415,93 @@ class Lab:
         """
         if self.error_msg is not None:
             ctx.fail(self.error_msg)
+
+
+
+
+
+
+
+
+def render_configs_and_profiles(gpus: int) ->  dict[str, dict[str, tuple[Config, list[str]]]]:
+    single_gpu_confg = Config(
+        generate=_generate(
+            teacher=_serve(
+                model_path="~/.cache/instructlab/models/mistralai/Mistral-7B-Instruct-v0.2",
+                vllm=_serve_vllm(
+                    gpus=1,
+                    llm_family='mixtral'       
+                )
+            )
+        )
+    )
+    multi_gpu_config = Config(
+        generate=_generate(
+            teacher=_serve(
+                model_path="~/.cache/instructlab/models/mistralai/Mistral-7B-Instruct-v0.2",
+                vllm=_serve_vllm(
+                    gpus=gpus,
+                    llm_family='mixtral'       
+                )
+            )
+        )
+    )
+    single_server_gpu_config = Config(
+            serve=_serve(
+                vllm=_serve_vllm(
+                    gpus=1,
+                ),
+                model_path="~/.cache/instructlab/models/instructlab/granite-7b-lab",
+            ),
+            generate=_generate(
+            teacher=_serve(
+                model_path="~/.cache/instructlab/models/mistralai/Mistral-7B-Instruct-v0.2",
+                vllm=_serve_vllm(
+                    gpus=2,
+                    llm_family='mixtral'       
+                )
+            )
+        )
+    )
+    multi_server_gpu_config = Config(
+        serve=_serve(
+            vllm=_serve_vllm(
+                gpus=gpus,
+            ),
+            model_path="~/.cache/instructlab/models/instructlab/granite-7b-lab",
+        ),
+        generate=_generate(
+            teacher=_serve(
+                model_path="~/.cache/instructlab/models/mistralai/Mixtral-8x7B-Instruct-v0.1",
+                vllm=_serve_vllm(
+                    gpus=2,
+                    llm_family='mixtral'       
+                )
+            )
+        )
+    )
+    macos_config = Config(
+        _serve_llama_cpp(
+           gpu_layers=15 
+        ),
+        serve=_serve(
+            model_path="~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf",
+        ),
+        generate=_generate(
+            teacher=_serve(
+                model_path="~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf",
+            )
+        )
+    )
+
+
+    return {
+    "single-gpu": {"Single Consumer GPU": (single_gpu_confg, ["profiles"])},
+    "multi-gpu": {"Multi Consumer GPU": (multi_gpu_config, ["profiles"])},
+    "single-server-gpu": {"Single Server GPU": (single_server_gpu_config, ["profiles"])},
+    "multi-server-gpu": {"Multi Server GPU": (multi_server_gpu_config, [TWO_GPU_TRAIN_AH, FOUR_GPU_TRAIN_AH, EIGHT_GPU_TRAIN_AH, FOUR_L_FORTY_GPU, EIGHT_L_FORTY_GPU, EIGHT_L_FOUR_GPU])},
+    "macos": {"MacOS": (macos_config, ["profiles"])},
+    }
 
 
 def init(

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1609,11 +1609,11 @@ def render_configs_and_profiles(gpus: int) ->  list[tuple[Config, list[dict[str,
 
 
     return [
-    (single_gpu_confg, [{"NVIDIA RTX 3070/3080/4070/4080": SINGLE_CONSUMER_GPU_TRAIN}]),
-    (multi_gpu_config, [{"NVIDIA RTX 3070/3080/4070/4080": MULTI_CONSUMER_GPU_TRAIN}]),
-    (single_server_gpu_config, [{"NVIDIA A100/H100/L40/L4": SINGLE_SERVER_GPU_TRAIN}]),
-    (multi_server_gpu_config, [{" NVIDIA 2xA100/H100": TWO_GPU_TRAIN_AH}, {"NVIDIA 4xA100/H100": FOUR_GPU_TRAIN_AH}, {"NVIDIA 8x A100 or H100": EIGHT_GPU_TRAIN_AH}, {"NVIDIA 4x L40": FOUR_L_FORTY_GPU}, {"NVIDIA 8x L40": EIGHT_L_FORTY_GPU}, {"NVIDIA 8x L4": EIGHT_L_FOUR_GPU}]),
-    (macos_config, [MACOS_TRAIN]),
+        (single_gpu_confg, [{"NVIDIA RTX 3070/3080/4070/4080": SINGLE_CONSUMER_GPU_TRAIN}]),
+        (multi_gpu_config, [{"NVIDIA RTX 3070/3080/4070/4080": MULTI_CONSUMER_GPU_TRAIN}]),
+        (single_server_gpu_config, [{"NVIDIA A100/H100/L40/L4": SINGLE_SERVER_GPU_TRAIN}]),
+        (multi_server_gpu_config, [{"NVIDIA 2x A100/H100": TWO_GPU_TRAIN_AH}, {"NVIDIA 4x A100/H100": FOUR_GPU_TRAIN_AH}, {"NVIDIA 8x A100 or H100": EIGHT_GPU_TRAIN_AH}, {"NVIDIA 4x L40": FOUR_L_FORTY_GPU}, {"NVIDIA 8x L40": EIGHT_L_FORTY_GPU}, {"NVIDIA 8x L4": EIGHT_L_FOUR_GPU}]),
+        (macos_config, [MACOS_TRAIN]),
     ]
 
 

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1527,11 +1527,7 @@ class Lab:
 
 
 
-
-
-
-
-def render_configs_and_profiles(gpus: int) ->  dict[str, dict[str, tuple[Config, list[str]]]]:
+def render_configs_and_profiles(gpus: int) ->  list[tuple[Config, list[dict[str, _train]]]]:
     single_gpu_confg = Config(
         generate=_generate(
             sdg_scale_factor=10,
@@ -1596,10 +1592,10 @@ def render_configs_and_profiles(gpus: int) ->  dict[str, dict[str, tuple[Config,
         )
     )
     macos_config = Config(
-        _serve_llama_cpp(
+        serve=_serve(
+            llama_cpp=_serve_llama_cpp(
            gpu_layers=15 
         ),
-        serve=_serve(
             model_path="~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf",
         ),
         generate=_generate(
@@ -1612,13 +1608,13 @@ def render_configs_and_profiles(gpus: int) ->  dict[str, dict[str, tuple[Config,
     )
 
 
-    return {
-    "single-gpu": {"Single Consumer GPU": (single_gpu_confg, [SINGLE_CONSUMER_GPU_TRAIN])},
-    "multi-gpu": {"Multi Consumer GPU": (multi_gpu_config, [MULTI_CONSUMER_GPU_TRAIN])},
-    "single-server-gpu": {"Single Server GPU": (single_server_gpu_config, [SINGLE_SERVER_GPU_TRAIN])},
-    "multi-server-gpu": {"Multi Server GPU": (multi_server_gpu_config, [TWO_GPU_TRAIN_AH, FOUR_GPU_TRAIN_AH, EIGHT_GPU_TRAIN_AH, FOUR_L_FORTY_GPU, EIGHT_L_FORTY_GPU, EIGHT_L_FOUR_GPU])},
-    "macos": {"MacOS": (macos_config, [MACOS_TRAIN])},
-    }
+    return [
+    (single_gpu_confg, [{"NVIDIA RTX 3070/3080/4070/4080": SINGLE_CONSUMER_GPU_TRAIN}]),
+    (multi_gpu_config, [{"NVIDIA RTX 3070/3080/4070/4080": MULTI_CONSUMER_GPU_TRAIN}]),
+    (single_server_gpu_config, [{"NVIDIA A100/H100/L40/L4": SINGLE_SERVER_GPU_TRAIN}]),
+    (multi_server_gpu_config, [{" NVIDIA 2xA100/H100": TWO_GPU_TRAIN_AH}, {"NVIDIA 4xA100/H100": FOUR_GPU_TRAIN_AH}, {"NVIDIA 8x A100 or H100": EIGHT_GPU_TRAIN_AH}, {"NVIDIA 4x L40": FOUR_L_FORTY_GPU}, {"NVIDIA 8x L40": EIGHT_L_FORTY_GPU}, {"NVIDIA 8x L4": EIGHT_L_FOUR_GPU}]),
+    (macos_config, [MACOS_TRAIN]),
+    ]
 
 
 def init(

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1064,6 +1064,114 @@ EIGHT_L_FOUR_GPU = _train(
     ),
 )
 
+SINGLE_SERVER_GPU_TRAIN = _train(
+    additional_args={
+        "warmup_steps": 25,
+        "learning_rate": 2e-5,
+        "lora_dropout": 0.1,
+        "lora_alpha": 32,
+        "deepspeed_cpu_offload_optimizer_ratio": 1,
+        "deepspeed_cpu_offload_optimizer_pin_memory": True,
+    },
+    ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
+    data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
+    data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
+    nproc_per_node=1,
+    effective_batch_size=96,
+    lora_quantize_dtype='nf4',
+    lora_rank=2,
+    max_batch_len=60000,
+    max_seq_len=4096,
+    save_samples=1000,
+    deepspeed_cpu_offload_optimizer=True,
+    is_padding_free=True,
+    num_epochs=8,
+    model_path=os.path.join(
+        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
+    ),
+)
+
+MACOS_TRAIN = _train(
+    additional_args={
+        "warmup_steps": 25,
+        "learning_rate": 2e-5,
+        "lora_dropout": 0.1,
+        "lora_alpha": 32,
+        "deepspeed_cpu_offload_optimizer_ratio": 1,
+        "deepspeed_cpu_offload_optimizer_pin_memory": True,
+    },
+    ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
+    data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
+    data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
+    nproc_per_node=1,
+    effective_batch_size=96,
+    lora_quantize_dtype='nf4',
+    lora_rank=2,
+    max_batch_len=60000,
+    max_seq_len=4096,
+    save_samples=1000,
+    deepspeed_cpu_offload_optimizer=True,
+    is_padding_free=True,
+    num_epochs=5,
+    model_path=os.path.join(
+        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
+    ),
+)
+
+SINGLE_CONSUMER_GPU_TRAIN = _train(
+    additional_args={
+        "warmup_steps": 25,
+        "learning_rate": 2e-5,
+        "lora_dropout": 0.1,
+        "lora_alpha": 32,
+        "deepspeed_cpu_offload_optimizer_ratio": 1,
+        "deepspeed_cpu_offload_optimizer_pin_memory": True,
+    },
+    ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
+    data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
+    data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
+    nproc_per_node=1,
+    effective_batch_size=96,
+    lora_quantize_dtype='nf4',
+    lora_rank=2,
+    max_batch_len=30000,
+    max_seq_len=4096,
+    save_samples=1000,
+    deepspeed_cpu_offload_optimizer=True,
+    is_padding_free=True,
+    num_epochs=5,
+    model_path=os.path.join(
+        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
+    ),
+)
+
+
+MULTI_CONSUMER_GPU_TRAIN = _train(
+    additional_args={
+        "warmup_steps": 25,
+        "learning_rate": 2e-5,
+        "lora_dropout": 0.1,
+        "lora_alpha": 32,
+        "deepspeed_cpu_offload_optimizer_ratio": 1,
+        "deepspeed_cpu_offload_optimizer_pin_memory": True,
+    },
+    ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
+    data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
+    data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
+    nproc_per_node=2,
+    effective_batch_size=96,
+    lora_quantize_dtype='nf4',
+    lora_rank=2,
+    max_batch_len=30000,
+    max_seq_len=4096,
+    save_samples=1000,
+    deepspeed_cpu_offload_optimizer=True,
+    is_padding_free=True,
+    num_epochs=5,
+    model_path=os.path.join(
+        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
+    ),
+)
 
 def read_train_profile(train_file) -> _train:
     try:
@@ -1426,6 +1534,8 @@ class Lab:
 def render_configs_and_profiles(gpus: int) ->  dict[str, dict[str, tuple[Config, list[str]]]]:
     single_gpu_confg = Config(
         generate=_generate(
+            sdg_scale_factor=10,
+            pipeline="full",
             teacher=_serve(
                 model_path="~/.cache/instructlab/models/mistralai/Mistral-7B-Instruct-v0.2",
                 vllm=_serve_vllm(
@@ -1437,6 +1547,8 @@ def render_configs_and_profiles(gpus: int) ->  dict[str, dict[str, tuple[Config,
     )
     multi_gpu_config = Config(
         generate=_generate(
+            sdg_scale_factor=10,
+            pipeline="full",
             teacher=_serve(
                 model_path="~/.cache/instructlab/models/mistralai/Mistral-7B-Instruct-v0.2",
                 vllm=_serve_vllm(
@@ -1454,6 +1566,8 @@ def render_configs_and_profiles(gpus: int) ->  dict[str, dict[str, tuple[Config,
                 model_path="~/.cache/instructlab/models/instructlab/granite-7b-lab",
             ),
             generate=_generate(
+            sdg_scale_factor=10,
+            pipeline="full",
             teacher=_serve(
                 model_path="~/.cache/instructlab/models/mistralai/Mistral-7B-Instruct-v0.2",
                 vllm=_serve_vllm(
@@ -1472,6 +1586,7 @@ def render_configs_and_profiles(gpus: int) ->  dict[str, dict[str, tuple[Config,
         ),
         generate=_generate(
             teacher=_serve(
+            pipeline="full",
                 model_path="~/.cache/instructlab/models/mistralai/Mixtral-8x7B-Instruct-v0.1",
                 vllm=_serve_vllm(
                     gpus=2,
@@ -1488,6 +1603,8 @@ def render_configs_and_profiles(gpus: int) ->  dict[str, dict[str, tuple[Config,
             model_path="~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf",
         ),
         generate=_generate(
+            sdg_scale_factor=10,
+            pipeline="full",
             teacher=_serve(
                 model_path="~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf",
             )
@@ -1496,11 +1613,11 @@ def render_configs_and_profiles(gpus: int) ->  dict[str, dict[str, tuple[Config,
 
 
     return {
-    "single-gpu": {"Single Consumer GPU": (single_gpu_confg, ["profiles"])},
-    "multi-gpu": {"Multi Consumer GPU": (multi_gpu_config, ["profiles"])},
-    "single-server-gpu": {"Single Server GPU": (single_server_gpu_config, ["profiles"])},
+    "single-gpu": {"Single Consumer GPU": (single_gpu_confg, [SINGLE_CONSUMER_GPU_TRAIN])},
+    "multi-gpu": {"Multi Consumer GPU": (multi_gpu_config, [MULTI_CONSUMER_GPU_TRAIN])},
+    "single-server-gpu": {"Single Server GPU": (single_server_gpu_config, [SINGLE_SERVER_GPU_TRAIN])},
     "multi-server-gpu": {"Multi Server GPU": (multi_server_gpu_config, [TWO_GPU_TRAIN_AH, FOUR_GPU_TRAIN_AH, EIGHT_GPU_TRAIN_AH, FOUR_L_FORTY_GPU, EIGHT_L_FORTY_GPU, EIGHT_L_FOUR_GPU])},
-    "macos": {"MacOS": (macos_config, ["profiles"])},
+    "macos": {"MacOS": (macos_config, [MACOS_TRAIN])},
     }
 
 

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -245,7 +245,6 @@ MODEL_FAMILY_MAPPINGS = {
 }
 
 
-
 class ConfigException(Exception):
     """An exception that a configuration file has an error."""
 
@@ -913,7 +912,7 @@ EIGHT_GPU_TRAIN_AH = _train(
         "warmup_steps": 25,
         "learning_rate": 2e-5,
         "lora_dropout": 0.1,
-         "lora_alpha": 32,
+        "lora_alpha": 32,
     },
     ckpt_output_dir=os.path.join(DEFAULTS._data_dir, "checkpoints"),
     data_output_dir=os.path.join(DEFAULTS._data_dir, "internal"),
@@ -928,9 +927,7 @@ EIGHT_GPU_TRAIN_AH = _train(
     deepspeed_cpu_offload_optimizer=False,
     is_padding_free=True,
     num_epochs=8,
-    model_path=os.path.join(
-        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-    ),
+    model_path=os.path.join(DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"),
 )
 
 FOUR_GPU_TRAIN_AH = _train(
@@ -953,9 +950,7 @@ FOUR_GPU_TRAIN_AH = _train(
     deepspeed_cpu_offload_optimizer=False,
     is_padding_free=True,
     num_epochs=8,
-    model_path=os.path.join(
-        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-    ),
+    model_path=os.path.join(DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"),
 )
 
 TWO_GPU_TRAIN_AH = _train(
@@ -980,9 +975,7 @@ TWO_GPU_TRAIN_AH = _train(
     deepspeed_cpu_offload_optimizer=True,
     is_padding_free=True,
     num_epochs=8,
-    model_path=os.path.join(
-        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-    ),
+    model_path=os.path.join(DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"),
 )
 
 EIGHT_L_FORTY_GPU = _train(
@@ -1005,9 +998,7 @@ EIGHT_L_FORTY_GPU = _train(
     deepspeed_cpu_offload_optimizer=False,
     is_padding_free=True,
     num_epochs=8,
-    model_path=os.path.join(
-        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-    ),
+    model_path=os.path.join(DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"),
 )
 
 FOUR_L_FORTY_GPU = _train(
@@ -1032,9 +1023,7 @@ FOUR_L_FORTY_GPU = _train(
     num_epochs=8,
     deepspeed_cpu_offload_optimizer=True,
     is_padding_free=True,
-    model_path=os.path.join(
-        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-    ),
+    model_path=os.path.join(DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"),
 )
 
 EIGHT_L_FOUR_GPU = _train(
@@ -1059,9 +1048,7 @@ EIGHT_L_FOUR_GPU = _train(
     num_epochs=8,
     deepspeed_cpu_offload_optimizer=True,
     is_padding_free=True,
-    model_path=os.path.join(
-        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-    ),
+    model_path=os.path.join(DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"),
 )
 
 SINGLE_SERVER_GPU_TRAIN = _train(
@@ -1078,7 +1065,7 @@ SINGLE_SERVER_GPU_TRAIN = _train(
     data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
     nproc_per_node=1,
     effective_batch_size=96,
-    lora_quantize_dtype='nf4',
+    lora_quantize_dtype="nf4",
     lora_rank=2,
     max_batch_len=60000,
     max_seq_len=4096,
@@ -1086,9 +1073,7 @@ SINGLE_SERVER_GPU_TRAIN = _train(
     deepspeed_cpu_offload_optimizer=True,
     is_padding_free=True,
     num_epochs=8,
-    model_path=os.path.join(
-        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-    ),
+    model_path=os.path.join(DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"),
 )
 
 MACOS_TRAIN = _train(
@@ -1105,7 +1090,7 @@ MACOS_TRAIN = _train(
     data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
     nproc_per_node=1,
     effective_batch_size=96,
-    lora_quantize_dtype='nf4',
+    lora_quantize_dtype="nf4",
     lora_rank=2,
     max_batch_len=60000,
     max_seq_len=4096,
@@ -1113,9 +1098,7 @@ MACOS_TRAIN = _train(
     deepspeed_cpu_offload_optimizer=True,
     is_padding_free=True,
     num_epochs=5,
-    model_path=os.path.join(
-        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-    ),
+    model_path=os.path.join(DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"),
 )
 
 SINGLE_CONSUMER_GPU_TRAIN = _train(
@@ -1132,7 +1115,7 @@ SINGLE_CONSUMER_GPU_TRAIN = _train(
     data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
     nproc_per_node=1,
     effective_batch_size=96,
-    lora_quantize_dtype='nf4',
+    lora_quantize_dtype="nf4",
     lora_rank=2,
     max_batch_len=30000,
     max_seq_len=4096,
@@ -1140,9 +1123,7 @@ SINGLE_CONSUMER_GPU_TRAIN = _train(
     deepspeed_cpu_offload_optimizer=True,
     is_padding_free=True,
     num_epochs=5,
-    model_path=os.path.join(
-        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-    ),
+    model_path=os.path.join(DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"),
 )
 
 
@@ -1160,7 +1141,7 @@ MULTI_CONSUMER_GPU_TRAIN = _train(
     data_path=os.path.join(DEFAULTS._data_dir, "datasets"),
     nproc_per_node=2,
     effective_batch_size=96,
-    lora_quantize_dtype='nf4',
+    lora_quantize_dtype="nf4",
     lora_rank=2,
     max_batch_len=30000,
     max_seq_len=4096,
@@ -1168,10 +1149,9 @@ MULTI_CONSUMER_GPU_TRAIN = _train(
     deepspeed_cpu_offload_optimizer=True,
     is_padding_free=True,
     num_epochs=5,
-    model_path=os.path.join(
-        DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"
-    ),
+    model_path=os.path.join(DEFAULTS._cache_home, "models/instructlab/granite-7b-lab"),
 )
+
 
 def read_train_profile(train_file) -> _train:
     try:
@@ -1525,20 +1505,19 @@ class Lab:
             ctx.fail(self.error_msg)
 
 
-
-
-def render_configs_and_profiles(gpus: int) ->  list[tuple[int, Config, list[dict[str, tuple[int, _train]]]]]:
+# render_configs_and_profiles takes the amount of GPUs on the system and returns a list of the following format:
+# [(MAX_VRAM_FOR_THIS_GROUP, CFG_FOR_THIS_GROUP, [{"TRAIN_PROFILE_NAME": (VRAM_MAX_FOR_PROFILE, TRAIN_PROFILE)}....])]
+def render_configs_and_profiles(
+    gpus: int,
+) -> list[tuple[int, Config, list[dict[str, tuple[int, _train]]]]]:
     single_gpu_confg = Config(
         generate=_generate(
             sdg_scale_factor=10,
             pipeline="full",
             teacher=_serve(
                 model_path="~/.cache/instructlab/models/mistralai/Mistral-7B-Instruct-v0.2",
-                vllm=_serve_vllm(
-                    gpus=1,
-                    llm_family='mixtral'       
-                )
-            )
+                vllm=_serve_vllm(gpus=1, llm_family="mixtral"),
+            ),
         )
     )
     multi_gpu_config = Config(
@@ -1547,31 +1526,25 @@ def render_configs_and_profiles(gpus: int) ->  list[tuple[int, Config, list[dict
             pipeline="full",
             teacher=_serve(
                 model_path="~/.cache/instructlab/models/mistralai/Mistral-7B-Instruct-v0.2",
-                vllm=_serve_vllm(
-                    gpus=gpus,
-                    llm_family='mixtral'       
-                )
-            )
+                vllm=_serve_vllm(gpus=gpus, llm_family="mixtral"),
+            ),
         )
     )
     single_server_gpu_config = Config(
-            serve=_serve(
-                vllm=_serve_vllm(
-                    gpus=1,
-                ),
-                model_path="~/.cache/instructlab/models/instructlab/granite-7b-lab",
+        serve=_serve(
+            vllm=_serve_vllm(
+                gpus=1,
             ),
-            generate=_generate(
+            model_path="~/.cache/instructlab/models/instructlab/granite-7b-lab",
+        ),
+        generate=_generate(
             sdg_scale_factor=10,
             pipeline="full",
             teacher=_serve(
                 model_path="~/.cache/instructlab/models/mistralai/Mistral-7B-Instruct-v0.2",
-                vllm=_serve_vllm(
-                    gpus=2,
-                    llm_family='mixtral'       
-                )
-            )
-        )
+                vllm=_serve_vllm(gpus=gpus, llm_family="mixtral"),
+            ),
+        ),
     )
     multi_server_gpu_config = Config(
         serve=_serve(
@@ -1582,20 +1555,15 @@ def render_configs_and_profiles(gpus: int) ->  list[tuple[int, Config, list[dict
         ),
         generate=_generate(
             teacher=_serve(
-            pipeline="full",
+                pipeline="full",
                 model_path="~/.cache/instructlab/models/mistralai/Mixtral-8x7B-Instruct-v0.1",
-                vllm=_serve_vllm(
-                    gpus=2,
-                    llm_family='mixtral'       
-                )
+                vllm=_serve_vllm(gpus=gpus, llm_family="mixtral"),
             )
-        )
+        ),
     )
     macos_config = Config(
         serve=_serve(
-            llama_cpp=_serve_llama_cpp(
-           gpu_layers=15 
-        ),
+            llama_cpp=_serve_llama_cpp(gpu_layers=15),
             model_path="~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf",
         ),
         generate=_generate(
@@ -1603,17 +1571,39 @@ def render_configs_and_profiles(gpus: int) ->  list[tuple[int, Config, list[dict
             pipeline="full",
             teacher=_serve(
                 model_path="~/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf",
-            )
-        )
+            ),
+        ),
     )
 
-
     return [
-        (16, single_gpu_confg, [{"NVIDIA RTX 3070/3080/4070/4080": (16, SINGLE_CONSUMER_GPU_TRAIN)}]),
-        (24, single_server_gpu_config, [{"NVIDIA A100/H100/L40/L4": (24, SINGLE_SERVER_GPU_TRAIN)}]),
-        (48, multi_gpu_config, [{"NVIDIA RTX 3070/3080/4070/4080": (48, MULTI_CONSUMER_GPU_TRAIN)}]),
-        (640, multi_server_gpu_config, [{"NVIDIA 2x A100/H100": (160, TWO_GPU_TRAIN_AH)}, {"NVIDIA 8x L4": (192, EIGHT_L_FOUR_GPU)}, {"NVIDIA 4x L40": (192, FOUR_L_FORTY_GPU)}, {"NVIDIA 4x A100/H100": (320, FOUR_GPU_TRAIN_AH)}, {"NVIDIA 8x L40": (384, EIGHT_L_FORTY_GPU)}, {"NVIDIA 8x A100 or H100": (640, EIGHT_GPU_TRAIN_AH)}, ]),
-        (0, macos_config, [MACOS_TRAIN]),
+        (
+            16,
+            single_gpu_confg,
+            [{"NVIDIA RTX 3070/3080/4070/4080": (16, SINGLE_CONSUMER_GPU_TRAIN)}],
+        ),
+        (
+            24,
+            single_server_gpu_config,
+            [{"NVIDIA A100/H100/L40/L4": (24, SINGLE_SERVER_GPU_TRAIN)}],
+        ),
+        (
+            48,
+            multi_gpu_config,
+            [{"NVIDIA RTX 3070/3080/4070/4080": (48, MULTI_CONSUMER_GPU_TRAIN)}],
+        ),
+        (
+            640,
+            multi_server_gpu_config,
+            [
+                {"NVIDIA 2x A100/H100": (160, TWO_GPU_TRAIN_AH)},
+                {"NVIDIA 8x L4": (192, EIGHT_L_FOUR_GPU)},
+                {"NVIDIA 4x L40": (192, FOUR_L_FORTY_GPU)},
+                {"NVIDIA 4x A100/H100": (320, FOUR_GPU_TRAIN_AH)},
+                {"NVIDIA 8x L40": (384, EIGHT_L_FORTY_GPU)},
+                {"NVIDIA 8x A100 or H100": (640, EIGHT_GPU_TRAIN_AH)},
+            ],
+        ),
+        (0, macos_config, [{"MacOS M Series GPU": (192, MACOS_TRAIN)}]),
     ]
 
 

--- a/src/instructlab/profile/profile.py
+++ b/src/instructlab/profile/profile.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Third Party
-from click_didyoumean import DYMGroup
 import click
-
 
 # First Party
 from instructlab import clickext
 from instructlab.configuration import storage_dirs_exist
+
 
 @click.group(
     cls=clickext.LazyEntryPointGroup,

--- a/src/instructlab/profile/profile.py
+++ b/src/instructlab/profile/profile.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Third Party
+from click_didyoumean import DYMGroup
+import click
+
+
+# First Party
+from instructlab import clickext
+from instructlab.configuration import storage_dirs_exist
+
+@click.group(
+    cls=clickext.LazyEntryPointGroup,
+    ep_group="instructlab.command.profile",
+)
+@click.pass_context
+# pylint: disable=redefined-outer-name
+def profile(ctx):
+    """Command Group for Interacting with performance Profiles in instructlab.
+
+    If this is your first time running ilab, it's best to start with `ilab config init` to create the environment.
+    """
+    ctx.parent.obj.ensure_config(ctx)
+    if not storage_dirs_exist():
+        click.secho(
+            "Some ilab storage directories do not exist yet. Please run `ilab config init` before continuing.",
+            fg="red",
+        )
+        raise click.exceptions.Exit(1)
+    ctx.obj = ctx.parent.obj
+    ctx.default_map = ctx.parent.default_map

--- a/src/instructlab/profile/set.py
+++ b/src/instructlab/profile/set.py
@@ -13,49 +13,63 @@ import click
 # First Party
 from instructlab import utils
 from instructlab import clickext
-from instructlab.configuration import render_configs_and_profiles, DEFAULTS
+from instructlab.configuration import render_configs_and_profiles, DEFAULTS, Config, _train, write_config
 from instructlab.model.backends.backends import is_model_gguf, is_model_safetensors
 from instructlab.utils import convert_bytes_to_proper_mag, print_table
 
 logger = logging.getLogger(__name__)
 
+PROFILES = ["Single Consumer GPU", "Multi Consumer GPU", "Single Server GPU", "Multi Server GPU", "MacOS"]
 
 @click.command(name="set")
 @clickext.display_params
-@click.command()
-@click.argument(
-    "profile",
-    nargs=-1,
-   #default="default",
-    #type=click.Choice(["default", PROFILE_MAPPINGS.keys()]),
-)
-def set(profile: str):
-    if profile == "":
-        #cfg = get_profile(profile)
-        print()
+@click.pass_context
+def set(ctx):
+    gpus = 0
+    if utils.are_nvidia_gpus_available():
+        gpus = nvidia_smi.nvmlDeviceGetCount()
+    elif not utils.is_macos_with_m_chip():
+        gpus = int(click.prompt("How many Dedicated GPUs do you have?"))
+    profile_mappings = render_configs_and_profiles(gpus)    
+    #vals = list(profile_mappings.values())
+    click.echo("Please choose a system profile to use")
+    click.echo("[0] Choose for me (Hardware defaults)")
+    for i, value in enumerate(PROFILES):
+        click.echo(f"[{i+1}] {value}")
+    profile_selection = click.prompt(
+        "Enter the number of your choice [hit enter for the hardware defaults profile]",
+        type=int,
+        default=0,
+    )
+    if profile_selection == 0:
+        total_vram = 0    
+        for gpu in range(gpus):
+            handle = nvidia_smi.nvmlDeviceGetHandleByIndex(gpu)
+            gpu_info = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)
+            total_vram += int(gpu_info.total)
     else:
-        gpus = 0
-        if utils.are_nvidia_gpus_available():
-            gpus = nvidia_smi.nvmlDeviceGetCount()
-        elif not utils.is_macos_with_m_chip():
-            gpus = int(click.prompt("How many Dedicated GPUs do you have?"))
-        profile_mappings = render_configs_and_profiles(gpus)    
-        vals = list(profile_mappings.values())
-        click.echo("Please choose a system profile to use")
+        cfg = profile_mappings[profile_selection-1][0]
+        names_and_profiles_list = profile_mappings[profile_selection-1][1]
+        #items = (list(vals[profile_selection-1].values()))
+        #print(cfg)
+        click.echo("Please choose a training profile which matches your GPU type")
         click.echo("[0] Choose for me (Hardware defaults)")
-        for i, value in enumerate(vals):
-            entry = dict(value)
-            click.echo(f"[{i+1}] {list(entry.keys())[0]}")
-        profile_selection = click.prompt(
-            "Enter the number of your choice [hit enter for the hardware defaults profile]",
+        for name_and_profile in names_and_profiles_list:
+            for ind, (name, profile) in enumerate(name_and_profile.items()):
+              click.echo(f"[{ind+1}] {name}")
+        train_profile_selection = click.prompt(
+            "Enter the number of your choice [hit enter for the hardware defaults train profile]",
             type=int,
             default=0,
         )
-        if profile_selection == 0:
-            total_vram = 0    
-            for gpu in range(gpus):
-                handle = nvidia_smi.nvmlDeviceGetHandleByIndex(gpu)
-                gpu_info = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)
-                total_vram += int(gpu_info.total)
+        train = (list(names_and_profiles_list[train_profile_selection-1].items())[0][1]) #[1]
+        print(train)
+        cfg.train = train
+        ctx.obj.config = cfg
+        write_config(cfg)
+
+        
+        #print(items[1])
+        #print(cfg_and_profile)
         
            

--- a/src/instructlab/profile/set.py
+++ b/src/instructlab/profile/set.py
@@ -31,7 +31,6 @@ def set(ctx):
     elif not utils.is_macos_with_m_chip():
         gpus = int(click.prompt("How many Dedicated GPUs do you have?"))
     profile_mappings = render_configs_and_profiles(gpus)    
-    #vals = list(profile_mappings.values())
     click.echo("Please choose a system profile to use")
     click.echo("[0] Choose for me (Hardware defaults)")
     for i, value in enumerate(PROFILES):
@@ -50,26 +49,21 @@ def set(ctx):
     else:
         cfg = profile_mappings[profile_selection-1][0]
         names_and_profiles_list = profile_mappings[profile_selection-1][1]
-        #items = (list(vals[profile_selection-1].values()))
-        #print(cfg)
-        click.echo("Please choose a training profile which matches your GPU type")
-        click.echo("[0] Choose for me (Hardware defaults)")
-        for name_and_profile in names_and_profiles_list:
-            for ind, (name, profile) in enumerate(name_and_profile.items()):
-              click.echo(f"[{ind+1}] {name}")
-        train_profile_selection = click.prompt(
-            "Enter the number of your choice [hit enter for the hardware defaults train profile]",
-            type=int,
-            default=0,
-        )
-        train = (list(names_and_profiles_list[train_profile_selection-1].items())[0][1]) #[1]
-        print(train)
+        if len(names_and_profiles_list) > 1:
+            click.echo("Please choose the GPU Training profile that best matches your system")
+            for ind, name_and_profile in enumerate(names_and_profiles_list):
+                for name, profile in name_and_profile.items():
+                    click.echo(f"[{ind}] {name}")
+            train_profile_selection = click.prompt(
+                "Enter the number of your choice [hit enter for the hardware defaults train profile]",
+                type=int,
+                default=0,
+            )
+            train = (list(names_and_profiles_list[train_profile_selection].items())[0][1]) #[1]
+        else:
+            train = (list(names_and_profiles_list[0].items())[0][1])
         cfg.train = train
         ctx.obj.config = cfg
         write_config(cfg)
-
-        
-        #print(items[1])
-        #print(cfg_and_profile)
         
            

--- a/src/instructlab/profile/set.py
+++ b/src/instructlab/profile/set.py
@@ -46,9 +46,20 @@ def set(ctx):
             handle = nvidia_smi.nvmlDeviceGetHandleByIndex(gpu)
             gpu_info = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)
             total_vram += int(gpu_info.total)
+            # total vram can be used to pick a profile, the profiles should be mapped least to greatest in terms of available vram.
+        if total_vram > 0:
+            # this is a map of the maximum amount of vram for the config before moving onto the next one
+            for config_and_profile in profile_mappings:
+                # if the systems vram is < total vram for any of these profiles, then our profile is in here.
+                if total_vram < config_and_profile[0]:
+                    for profile_names_and_values in config_and_profile[2]:
+                       if total_vram < list(profile_names_and_values[0].items())[0][0]:
+                           print("here")
+                           train = (list(profile_names_and_values[0].items())[0][1])
+                    cfg = config_and_profile[1]
     else:
-        cfg = profile_mappings[profile_selection-1][0]
-        names_and_profiles_list = profile_mappings[profile_selection-1][1]
+        cfg = profile_mappings[profile_selection-1][1]
+        names_and_profiles_list = profile_mappings[profile_selection-1][2]
         if len(names_and_profiles_list) > 1:
             click.echo("Please choose the GPU Training profile that best matches your system")
             for ind, name_and_profile in enumerate(names_and_profiles_list):
@@ -59,9 +70,10 @@ def set(ctx):
                 type=int,
                 default=0,
             )
-            train = (list(names_and_profiles_list[train_profile_selection].items())[0][1]) #[1]
+            print(list(names_and_profiles_list[train_profile_selection].items()))
+            train = (list(names_and_profiles_list[train_profile_selection].items())[0][1][1]) #[1]
         else:
-            train = (list(names_and_profiles_list[0].items())[0][1])
+            train = (list(names_and_profiles_list[0].items())[0][1][1])
         cfg.train = train
         ctx.obj.config = cfg
         write_config(cfg)

--- a/src/instructlab/profile/set.py
+++ b/src/instructlab/profile/set.py
@@ -1,26 +1,33 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from pathlib import Path
 import logging
-import os
-import time
-import pynvml
-import nvidia_smi
 
 # Third Party
 import click
+import nvidia_smi
+import pynvml
 
 # First Party
-from instructlab import utils
-from instructlab import clickext
-from instructlab.configuration import render_configs_and_profiles, DEFAULTS, Config, _train, write_config
-from instructlab.model.backends.backends import is_model_gguf, is_model_safetensors
-from instructlab.utils import convert_bytes_to_proper_mag, print_table
+from instructlab import clickext, utils
+from instructlab.configuration import (
+    Config,
+    _train,
+    render_configs_and_profiles,
+    write_config,
+)
+from instructlab.utils import convert_bytes_to_proper_mag
 
 logger = logging.getLogger(__name__)
 
-PROFILES = ["Single Consumer GPU", "Multi Consumer GPU", "Single Server GPU", "Multi Server GPU", "MacOS"]
+PROFILES = [
+    "Single Consumer GPU",
+    "Single Server GPU",
+    "Multi Consumer GPU",
+    "Multi Server GPU",
+    "MacOS",
+]
+
 
 @click.command(name="set")
 @clickext.display_params
@@ -32,7 +39,11 @@ def set(ctx):
         gpus = nvidia_smi.nvmlDeviceGetCount()
     elif not utils.is_macos_with_m_chip():
         gpus = int(click.prompt("How many Dedicated GPUs do you have?"))
-    profile_mappings = render_configs_and_profiles(gpus)    
+    # prorile_mappings is the following format:
+    # [(MAX_VRAM_FOR_THIS_GROUP, CFG_FOR_THIS_GROUP, [{"TRAIN_PROFILE_NAME": (VRAM_MAX_FOR_PROFILE, TRAIN_PROFILE)}....])]
+    # this means we have two sets of vRAM requirements, a top level one to tell us, when looping, if we just skip over this set all together
+    # and an internal vRAM amount PER train profile, so if we are picking the best train profile we choose the one which matches our VRAM Requirements the most.
+    profile_mappings = render_configs_and_profiles(gpus)
     click.echo("Please choose a system profile to use")
     click.echo("[0] Choose for me (Hardware defaults)")
     for i, value in enumerate(PROFILES):
@@ -45,50 +56,77 @@ def set(ctx):
     # if they want us to choose for them:
     # read vRAM, and map it to the profile which best matches.
     train = None
-    config = None
+    cfg = None
     if profile_selection == 0:
-        total_vram = 0    
-        for gpu in range(gpus):
-            handle = nvidia_smi.nvmlDeviceGetHandleByIndex(gpu)
-            gpu_info = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)
-            total_vram += int(gpu_info.total)
-        total_vram = convert_bytes_to_proper_mag(total_vram)[0]
-        print(total_vram)
-            # total vram can be used to pick a profile, the profiles should be mapped least to greatest in terms of available vram.
-        if total_vram > 0:
-            # this is a map of the maximum amount of vram for the config before moving onto the next one
-            for config_and_profile in profile_mappings:
-                # if the systems vram is < total vram for any of these profiles, then our profile is in here.
-                if total_vram < config_and_profile[0]:
-                    for profile_names_and_values in config_and_profile[2]:
-                       if train is not None:
-                           break
-                       for vram_and_profile in list(profile_names_and_values.values()):
-                            print(vram_and_profile)
-                            if total_vram < vram_and_profile[0]:
-                                train = vram_and_profile[1]
-                                print("Found profile: ", train)
-                                break
-                    cfg = config_and_profile[1]
+        train, cfg = choose_configuration_for_hardware(
+            gpus=gpus, profile_mappings=profile_mappings
+        )
     else:
-        cfg = profile_mappings[profile_selection-1][1]
-        names_and_profiles_list = profile_mappings[profile_selection-1][2]
-        if len(names_and_profiles_list) > 1:
-            click.echo("Please choose the GPU Training profile that best matches your system")
-            for ind, name_and_profile in enumerate(names_and_profiles_list):
-                for name, profile in name_and_profile.items():
-                    click.echo(f"[{ind}] {name}")
-            train_profile_selection = click.prompt(
-                "Enter the number of your choice [hit enter for the hardware defaults train profile]",
-                type=int,
-                default=0,
-            )
-            print(list(names_and_profiles_list[train_profile_selection].items()))
-            train = (list(names_and_profiles_list[train_profile_selection].items())[0][1][1]) #[1]
-        else:
-            train = (list(names_and_profiles_list[0].items())[0][1][1])
-    cfg.train = train
-    ctx.obj.config = cfg
-    write_config(cfg)
-        
-           
+        train, cfg = prompt_for_configuration(
+            profile_mappings=profile_mappings, profile_selection=profile_selection
+        )
+    if train is not None and cfg is not None:
+        cfg.train = train
+        ctx.obj.config = cfg
+        write_config(cfg)
+    else:
+        logger.warn(
+            "You tried to initialize a profile with a CPU only machine, please use the defaults provided by `ilab config init`"
+        )
+
+
+# choose_configuration_for_hardware takes the amnt of GPUs on the system, and the profile mappings of vram -> train profile + cfg and returns the ones that
+# match the vRAM requirements.
+def choose_configuration_for_hardware(
+    gpus: int, profile_mappings
+) -> tuple[_train, Config]:
+    total_vram = 0
+    for gpu in range(gpus):
+        handle = nvidia_smi.nvmlDeviceGetHandleByIndex(gpu)
+        gpu_info = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)
+        total_vram += int(gpu_info.total)
+    total_vram = convert_bytes_to_proper_mag(total_vram)[0]
+    # total vram can be used to pick a profile, the profiles should be mapped least to greatest in terms of available vram.
+    train = None
+    cfg = None
+    if total_vram > 0:
+        # this is a map of the maximum amount of vram for the config before moving onto the next one
+        for config_and_profile in profile_mappings:
+            # if the systems vram is < total vram for any of these profiles, then our profile is in here.
+            if total_vram < config_and_profile[0]:
+                for profile_names_and_values in config_and_profile[2]:
+                    if train is not None:
+                        break
+                    for vram_and_profile in list(profile_names_and_values.values()):
+                        if total_vram < vram_and_profile[0]:
+                            train = vram_and_profile[1]
+                            break
+                cfg = config_and_profile[1]
+    return train, cfg
+
+
+def prompt_for_configuration(
+    profile_mappings: list[tuple[int, Config, list[dict[str, tuple[int, _train]]]]],
+    profile_selection: int,
+) -> tuple[_train, Config]:
+    cfg = profile_mappings[profile_selection - 1][1]
+    train = None
+    names_and_profiles_list = profile_mappings[profile_selection - 1][2]
+    if len(names_and_profiles_list) > 1:
+        click.echo(
+            "Please choose the GPU Training profile that best matches your system"
+        )
+        for ind, name_and_profile in enumerate(names_and_profiles_list):
+            for name in name_and_profile:
+                click.echo(f"[{ind}] {name}")
+        train_profile_selection = click.prompt(
+            "Enter the number of your choice [hit enter for the hardware defaults train profile]",
+            type=int,
+            default=0,
+        )
+        train = list(names_and_profiles_list[train_profile_selection].items())[0][1][
+            1
+        ]  # [1]
+    else:
+        train = list(names_and_profiles_list[0].items())[0][1][1]
+    return train, cfg

--- a/src/instructlab/profile/set.py
+++ b/src/instructlab/profile/set.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from pathlib import Path
+import logging
+import os
+import time
+import nvidia_smi
+
+# Third Party
+import click
+
+# First Party
+from instructlab import utils
+from instructlab import clickext
+from instructlab.configuration import render_configs_and_profiles, DEFAULTS
+from instructlab.model.backends.backends import is_model_gguf, is_model_safetensors
+from instructlab.utils import convert_bytes_to_proper_mag, print_table
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(name="set")
+@clickext.display_params
+@click.command()
+@click.argument(
+    "profile",
+    nargs=-1,
+   #default="default",
+    #type=click.Choice(["default", PROFILE_MAPPINGS.keys()]),
+)
+def set(profile: str):
+    if profile == "":
+        #cfg = get_profile(profile)
+        print()
+    else:
+        gpus = 0
+        if utils.are_nvidia_gpus_available():
+            gpus = nvidia_smi.nvmlDeviceGetCount()
+        elif not utils.is_macos_with_m_chip():
+            gpus = int(click.prompt("How many Dedicated GPUs do you have?"))
+        profile_mappings = render_configs_and_profiles(gpus)    
+        vals = list(profile_mappings.values())
+        click.echo("Please choose a system profile to use")
+        click.echo("[0] Choose for me (Hardware defaults)")
+        for i, value in enumerate(vals):
+            entry = dict(value)
+            click.echo(f"[{i+1}] {list(entry.keys())[0]}")
+        profile_selection = click.prompt(
+            "Enter the number of your choice [hit enter for the hardware defaults profile]",
+            type=int,
+            default=0,
+        )
+        if profile_selection == 0:
+            total_vram = 0    
+            for gpu in range(gpus):
+                handle = nvidia_smi.nvmlDeviceGetHandleByIndex(gpu)
+                gpu_info = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)
+                total_vram += int(gpu_info.total)
+        
+           

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -16,6 +16,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import nvidia_smi
 
 # Third Party
 from git import Repo, exc
@@ -664,3 +665,13 @@ def clear_directory(path: pathlib.Path) -> None:
     if path.exists():
         shutil.rmtree(path)
     os.makedirs(path)
+
+
+def are_nvidia_gpus_available() -> bool:
+    """Check if NVIDIA GPUs are available"""
+    try:
+        nvidia_smi.nvmlInit()
+        nvidia_smi.nvmlShutdown()
+    except Exception:
+        return False
+    return True

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -16,7 +16,6 @@ import re
 import shutil
 import subprocess
 import tempfile
-import nvidia_smi
 
 # Third Party
 from git import Repo, exc
@@ -30,6 +29,7 @@ import click
 import git
 import gitdb
 import httpx
+import nvidia_smi
 import yaml
 
 # Local


### PR DESCRIPTION
`ilab profile set` gives users an interactive menu for assigning specific configuration based on their hardware.

A few things this process alters are:

- `ilab data generate` model
- `ilab model serve` model
- GPUs in `ilab model serve` and `ilab data generate`
- sets the train profile for the following scenarions:
      1. single consumer GPU
      2. multi consumer GPU
      3. single server GPU
      4. multi server GPU
      5. MacOS (once MPS support is added)
- there is also a `Choose for me` option which reads the Nvidia cards on the system and assigns a cfg+train profile based off the amount of vRAM

A general output looks like this:


```
ilab profile set
How many Dedicated GPUs do you have?: 8
Please choose a system profile to use
[0] Choose for me (Hardware defaults)
[1] Single Consumer GPU
[2] Single Server GPU
[3] Multi Consumer GPU
[4] Multi Server GPU
[5] MacOS
Enter the number of your choice [hit enter for the hardware defaults profile] [0]: 4
Please choose the GPU Training profile that best matches your system
[0] NVIDIA 2x A100/H100
[1] NVIDIA 8x L4
[2] NVIDIA 4x L40
[3] NVIDIA 4x A100/H100
[4] NVIDIA 8x L40
[5] NVIDIA 8x A100 or H100
Enter the number of your choice [hit enter for the hardware defaults train profile] [0]: 3
```

or if you have it choose for you:

```
 ilab profile set
Please choose a system profile to use
[0] Choose for me (Hardware defaults)
[1] Single Consumer GPU
[2] Single Server GPU
[3] Multi Consumer GPU
[4] Multi Server GPU
[5] MacOS
Enter the number of your choice [hit enter for the hardware defaults profile] [0]: 0
```

the `How many dedicated GPUs do you have?` prompt only shows up if nvidia_smi cannot detect them beforehand.




**Issue resolved by this Pull Request:**
Resolves #2108 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
