### PR TITLE
refactor: move verify_template_exists to common

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -555,13 +555,3 @@ def select_backend(
         )
     click.secho(f"Unknown backend: {backend}", fg="red")
     raise click.exceptions.Exit(1)
-
-
-def verify_template_exists(path):
-    if not path.exists():
-        raise FileNotFoundError("Chat template file does not exist: {}".format(path))
-
-    if not path.is_file():
-        raise IsADirectoryError(
-            "Chat templates paths must point to a file: {}".format(path)
-        )

--- a/src/instructlab/model/backends/common.py
+++ b/src/instructlab/model/backends/common.py
@@ -44,3 +44,13 @@ def get_model_template(
                 bos_token = "<s>"
 
     return template, eos_token, bos_token
+
+
+def verify_template_exists(path):
+    if not path.exists():
+        raise FileNotFoundError("Chat template file does not exist: {}".format(path))
+
+    if not path.is_file():
+        raise IsADirectoryError(
+            "Chat templates paths must point to a file: {}".format(path)
+        )

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -27,7 +27,6 @@ from .backends import (
     free_tcp_ipv4_port,
     get_uvicorn_config,
     is_temp_server_running,
-    verify_template_exists,
 )
 from .common import (
     API_ROOT_WELCOME_MESSAGE,
@@ -35,6 +34,7 @@ from .common import (
     CHAT_TEMPLATE_TOKENIZER,
     LLAMA_CPP,
     get_model_template,
+    verify_template_exists,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -23,13 +23,13 @@ from .backends import (
     ensure_server,
     safe_close_all,
     shutdown_process,
-    verify_template_exists,
 )
 from .common import (
     CHAT_TEMPLATE_AUTO,
     CHAT_TEMPLATE_TOKENIZER,
     VLLM,
     get_model_template,
+    verify_template_exists,
 )
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
The backends module, along with the llama_cpp and vllm modules,
have a circular dependencies, which is considered an anti-pattern.

Move verify_template_exists() to reduce the circular dependencies.

Current state of [Circular dependency](https://en.wikipedia.org/wiki/Circular_dependency):
```mermaid
graph LR;
  backends --> llama_cpp
  llama_cpp --> backends
  backends --> vllm
  vllm --> backends
```
Desired state of [Acyclic dependencies](https://en.wikipedia.org/wiki/Acyclic_dependencies_principle):

```mermaid
graph LR;
  backends --> llama_cpp
  llama_cpp -->common
  backends --> common
  backends --> vllm
  vllm --> common
```