### PR TITLE
refactor: move Closeable and ServerException to common

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -28,19 +28,11 @@ import uvicorn
 # Local
 from ...configuration import _serve as serve_config
 from ...utils import split_hostport
-from .common import CHAT_TEMPLATE_AUTO, LLAMA_CPP, VLLM
+from .common import CHAT_TEMPLATE_AUTO, LLAMA_CPP, VLLM, Closeable
 
 logger = logging.getLogger(__name__)
 
 SUPPORTED_BACKENDS = frozenset({LLAMA_CPP, VLLM})
-
-
-class Closeable(typing.Protocol):
-    def close(self) -> None: ...
-
-
-class ServerException(Exception):
-    """An exception raised when serving the API."""
 
 
 class UvicornServer(uvicorn.Server):

--- a/src/instructlab/model/backends/common.py
+++ b/src/instructlab/model/backends/common.py
@@ -2,6 +2,7 @@
 from typing import Tuple
 import logging
 import pathlib
+import typing
 
 # Local
 from ...configuration import get_model_family
@@ -23,6 +24,14 @@ templates = [
         "template": "{{ bos_token }}\n{% for message in messages %}\n{% if message['role'] == 'user' %}\n{{ '[INST] ' + message['content'] + ' [/INST]' }}\n{% elif message['role'] == 'assistant' %}\n{{ message['content'] + eos_token}}\n{% endif %}\n{% endfor %}",
     },
 ]
+
+
+class Closeable(typing.Protocol):
+    def close(self) -> None: ...
+
+
+class ServerException(Exception):
+    """An exception raised when serving the API."""
 
 
 def get_model_template(

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -22,7 +22,6 @@ from ...client import check_api_base
 from ...configuration import get_api_base
 from .backends import (
     BackendServer,
-    ServerException,
     UvicornServer,
     free_tcp_ipv4_port,
     get_uvicorn_config,
@@ -33,6 +32,7 @@ from .common import (
     CHAT_TEMPLATE_AUTO,
     CHAT_TEMPLATE_TOKENIZER,
     LLAMA_CPP,
+    ServerException,
     get_model_template,
     verify_template_exists,
 )

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -20,8 +20,6 @@ from ...client import check_api_base
 from ...configuration import get_api_base
 from .backends import (
     BackendServer,
-    Closeable,
-    ServerException,
     free_tcp_ipv4_port,
     safe_close_all,
     shutdown_process,
@@ -30,6 +28,8 @@ from .common import (
     CHAT_TEMPLATE_AUTO,
     CHAT_TEMPLATE_TOKENIZER,
     VLLM,
+    Closeable,
+    ServerException,
     get_model_template,
     verify_template_exists,
 )

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -12,7 +12,7 @@ import click
 # First Party
 from instructlab import clickext, log, utils
 from instructlab.model.backends import backends
-from instructlab.model.backends.backends import ServerException
+from instructlab.model.backends.common import ServerException
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The backends module, along with the llama_cpp and vllm modules,
have a circular dependencies, which is considered an anti-pattern.

Move Closeable and ServerException to reduce the circular dependencies.

Current state of [Circular dependency](https://en.wikipedia.org/wiki/Circular_dependency):
```mermaid
graph LR;
  backends --> llama_cpp
  llama_cpp --> backends
  backends --> vllm
  vllm --> backends
```
Desired state of [Acyclic dependencies](https://en.wikipedia.org/wiki/Acyclic_dependencies_principle):

```mermaid
graph LR;
  backends --> llama_cpp
  llama_cpp -->common
  backends --> common
  backends --> vllm
  vllm --> common
```