### PR TITLE
refactor: remove unused argument prompt_file_path

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -177,10 +177,6 @@ class _InstructlabDefaults:
         return path.join(self._data_dir, STORAGE_DIR_NAMES.INTERNAL)
 
     @property
-    def PROMPT_FILE(self) -> str:
-        return path.join(self.INTERNAL_DIR, "prompt.txt")
-
-    @property
     def SEED_FILE(self) -> str:
         return path.join(self.INTERNAL_DIR, "seed_tasks.json")
 
@@ -474,10 +470,6 @@ class _generate(BaseModel):
     output_dir: StrictStr = Field(
         default_factory=lambda: DEFAULTS.DATASETS_DIR,
         description="Directory where generated datasets are stored.",
-    )
-    prompt_file: StrictStr = Field(
-        default_factory=lambda: DEFAULTS.PROMPT_FILE,
-        description="Path to prompt file to be used for generation.",
     )
     # TODO: remove this? It's not used anywhere, was removed by 19b9f4794f79ef81578c00c901bac3ee9db8c046
     seed_file: StrictStr = Field(

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -217,11 +217,6 @@ def generate(
             fg="yellow",
         )
 
-    prompt_file_path = DEFAULTS.PROMPT_FILE
-
-    if ctx.obj is not None:
-        prompt_file_path = ctx.obj.config.generate.prompt_file
-
     # If batch size is not set explicitly, default to 8
     # Once https://github.com/instructlab/sdg/issues/224 is resolved we can
     # pass batch_size=None to the library instead
@@ -315,7 +310,6 @@ def generate(
             taxonomy=taxonomy_path,
             taxonomy_base=taxonomy_base,
             output_dir=output_dir,
-            prompt_file_path=prompt_file_path,
             rouge_threshold=rouge_threshold,
             console_output=not quiet,
             yaml_rules=yaml_rules,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,7 +67,6 @@ class TestConfig:
         assert cfg.generate.sdg_scale_factor == 30
         assert cfg.generate.chunk_word_count == 1000
         assert cfg.generate.output_dir == f"{data_dir}/datasets"
-        assert cfg.generate.prompt_file == f"{data_dir}/{internal_dirname}/prompt.txt"
         assert (
             cfg.generate.seed_file == f"{data_dir}/{internal_dirname}/seed_tasks.json"
         )

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -109,9 +109,6 @@ generate:
   # teacher model, Mixtral-8x7b.
   # Default: simple
   pipeline: simple
-  # Path to prompt file to be used for generation.
-  # Default: /data/instructlab/internal/prompt.txt
-  prompt_file: /data/instructlab/internal/prompt.txt
   # The total number of instructions to be generated.
   # Default: 30
   sdg_scale_factor: 30


### PR DESCRIPTION
instructlab.sdg.generate_data doesn't use argument
`prompt_file_path` anymore.

TODO: remove the argument from generate_data() completely.

