### PR TITLE
amend release strategy

### DIFF
--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -65,7 +65,7 @@ The following are the steps for how Y-stream and Z-stream releases gets cut.
 1. Validate the release branch with an [E2E test](ci.md).
 1. Create a new release on GitHub targeting the release branch and using the previous Z-Stream tag as the previous release (e.g. `0.15.0` precedes `0.15.1`).
 1. Move the `stable` tag to the new release (note this tag is set to be deprecated on September 1st, 2024 - users should use PyPi to install the latest "stable" release)
-1. Announce release via the following:
+1. If changes warrant an announcement, announce via the following:
     - The `#announce` channel on Slack
     - The `announce` mailing list
 


### PR DESCRIPTION
we have been sending slack and email announcements for each z-stream we release. This should be amended to be up to the release team if an announcement is necessary. Not all releases with ~1 or 2 commits warrant multiple messages

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
