### PR TITLE
ci: Add check for disk space on mac to debug when runner is out of space

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -3,7 +3,9 @@ description: 'Frees disk space on the runner'
 runs:
   using: "composite"
   steps:
-    - run: |
+    - name: 'Free Disk Space Linux'
+      if: matrix.platform != 'macos-latest'
+      run: |
         df -h
         sudo docker rmi "$(docker image ls -aq)" >/dev/null 2>&1 || true
         sudo rm -rf \
@@ -16,4 +18,11 @@ runs:
         sudo apt-get autoremove -y >/dev/null 2>&1
         sudo apt-get autoclean -y >/dev/null 2>&1
         df -h
+      shell: bash
+    - name: 'Check Disk Space Mac'
+      if: matrix.platform == 'macos-latest'
+      run: |
+        df -h
+        echo "df -h for $TMPDIR"
+        df -h "$TMPDIR"
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,8 +64,6 @@ jobs:
           fetch-depth: 0
 
       - name: Free disk space
-        # TODO: remove the below line once this issue is resolved: https://github.com/instructlab/instructlab/issues/2171
-        if: matrix.platform != 'macos-latest'
         uses: ./.github/actions/free-disk-space
 
       - name: Install the expect package


### PR DESCRIPTION
Related to #2171 

Even though there isn't cleanup to be done on the mac runners, we can at least print out the disk info for debug purposes.
This change includes a global df as well as checking where $TMPDIR (and the corresponding runner sandbox) is located.

Output on mac runner:
```
Prepare all required actions
Run ./.github/actions/free-disk-space
Run df -h
Filesystem        Size    Used   Avail Capacity iused ifree %iused  Mounted on
/dev/disk3s1s1   [2](https://github.com/instructlab/instructlab/actions/runs/10648266505/job/29517133109?pr=2177#step:5:2)95Gi   9.6Gi    19Gi    35%    404k  194M    0%   /
devfs            19[5](https://github.com/instructlab/instructlab/actions/runs/10648266505/job/29517133109?pr=2177#step:5:6)Ki   195Ki     0Bi   100%     674     0  100%   /dev
/dev/disk3s6     295Gi    20Ki    19Gi     1%       0  194M    0%   /System/Volumes/VM
/dev/disk3s2     295Gi   4.9Gi    19Gi    22%     [15](https://github.com/instructlab/instructlab/actions/runs/10648266505/job/29517133109?pr=2177#step:5:17)3  194M    0%   /System/Volumes/Preboot
/dev/disk3s4     295Gi   288Ki    19Gi     1%      23  194M    0%   /System/Volumes/Update
/dev/disk1s2     500Mi    20Ki   495Mi     1%       0  5.1M    0%   /System/Volumes/xarts
/dev/disk1s1     500Mi    96Ki   495Mi     1%      20  5.1M    0%   /System/Volumes/iSCPreboot
/dev/disk1s3     500Mi   196Ki   495Mi     1%      [17](https://github.com/instructlab/instructlab/actions/runs/10648266505/job/29517133109?pr=2177#step:5:19)  5.1M    0%   /System/Volumes/Hardware
/dev/disk3s5     295Gi   261Gi    19Gi    94%    2.2M  194M    1%   /System/Volumes/Data
map auto_home      0Bi     0Bi     0Bi   100%       0     0     -   /System/Volumes/Data/home
df -h for /var/folders/m4/5dz5h26x329cqq4fx333f8gm0000gn/T/
Filesystem      Size    Used   Avail Capacity iused ifree %iused  Mounted on
/dev/disk3s5   295Gi   261Gi    [19](https://github.com/instructlab/instructlab/actions/runs/10648266505/job/29517133109?pr=2177#step:5:21)Gi    94%    2.2M  194M    1%   /System/Volumes/Data
```

Output on ubuntu runner:
```
Prepare all required actions
Run ./.github/actions/free-disk-space
Run df -h
  df -h
  sudo docker rmi "$(docker image ls -aq)" >/dev/null [2](https://github.com/instructlab/instructlab/actions/runs/10646647201/job/29513724307?pr=2177#step:5:2)>&1 || true
  sudo rm -rf \
    /usr/share/dotnet /usr/local/lib/android /opt/ghc \
    /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
    /usr/lib/jvm || true
  sudo apt install aptitude -y >/dev/null 2>&1
  sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1
  sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1
  sudo apt-get autoremove -y >/dev/null 2>&1
  sudo apt-get autoclean -y >/dev/null 2>&1
  df -h
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    LC_ALL: en_US.UTF-8
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   [5](https://github.com/instructlab/instructlab/actions/runs/10646647201/job/29513724307?pr=2177#step:5:6)1G   22G  70% /
tmpfs           7.9G  172K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb15      105M  [6](https://github.com/instructlab/instructlab/actions/runs/10646647201/job/29513724307?pr=2177#step:5:7).1M   99M   6% /boot/efi
/dev/sda1        [7](https://github.com/instructlab/instructlab/actions/runs/10646647201/job/29513724307?pr=2177#step:5:8)4G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   32G   41G  44% /
tmpfs           7.[9](https://github.com/instructlab/instructlab/actions/runs/10646647201/job/29513724307?pr=2177#step:5:10)G  172K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb15      [10](https://github.com/instructlab/instructlab/actions/runs/10646647201/job/29513724307?pr=2177#step:5:11)5M  6.1M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   [12](https://github.com/instructlab/instructlab/actions/runs/10646647201/job/29513724307?pr=2177#step:5:13)K  1.6G   1% /run/user/1001
```

Needs https://github.com/instructlab/instructlab/pull/2178 before tests will pass.


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
