### PR TITLE
ci: Remove oci download from mac runner

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands =
     {envpython} -m instructlab --version
     unit: {envpython} -m pytest {posargs:tests}
     unitcov: {envpython} -W error::UserWarning -m pytest --cov=instructlab --cov-report term --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html {posargs:tests -m "not (examples or slow)"}
-    functional: ./scripts/functional-tests.sh
+    functional: ./scripts/functional-tests.sh -s
 allowlist_externals =
     functional: ./scripts/functional-tests.sh
 


### PR DESCRIPTION
This change removes the OCI download test from the mac runner test path since space is limited.  And since the mac runners are running inside a sandbox, there isn't much we can do to cleanup the existing space.

The other change we could consider making would be to upload a much smaller model that would save on download time/cost and still leave enough space to test on mac runners.

Resolves #2171 with #2177


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
