### PR TITLE
fix: remove unnecessary default lambda

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -728,6 +728,10 @@ class _train(BaseModel):
     phased_mt_bench_judge: str | None = Field(
         default=None, description="Judge model path for phased MT-Bench evaluation."
     )
+    phased_base_dir: str | None = Field(
+        default_factory=lambda: DEFAULTS.PHASED_DIR,
+        description="Base directory for organization of end-to-end intermediate outputs.",
+    )
 
     @model_validator(mode="before")
     def fill_defaults(

--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -58,21 +58,18 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--taxonomy-path",
     type=click.Path(),
-    default=lambda: DEFAULTS.TAXONOMY_DIR,
-    show_default="The default taxonomy path used by instructlab, located in the data directory.",
+    cls=clickext.ConfigOption,
     help="Path to where the taxonomy is located.",
 )
 @click.option(
     "--taxonomy-base",
-    default=DEFAULTS.TAXONOMY_BASE,
-    show_default=True,
+    cls=clickext.ConfigOption,
     help="Base git-ref to use for taxonomy, use 'empty' for the entire repo contents.",
 )
 @click.option(
     "--output-dir",
     type=click.Path(),
-    default=lambda: DEFAULTS.DATASETS_DIR,
-    show_default="The default output directory used by instructlab, located in the data directory.",
+    cls=clickext.ConfigOption,
     help="Path to output generated files.",
 )
 @click.option(

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -58,14 +58,12 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     cls=clickext.ConfigOption,
     required=True,  # default from config
     help="Base directory where data is stored.",
-    default=lambda: DEFAULTS.DATASETS_DIR,
 )
 @click.option(
     "--ckpt-output-dir",
     type=click.Path(),
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    default=lambda: DEFAULTS.CHECKPOINTS_DIR,
     help="output directory to store checkpoints in during training",
 )
 @click.option(
@@ -73,7 +71,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     type=click.Path(),
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    default=lambda: DEFAULTS.INTERNAL_DIR,
     help="output directory to store training data in",
 )
 @click.option(
@@ -321,7 +318,7 @@ def clickpath_setup(is_dir: bool) -> click.Path:
 @click.option(
     "--phased-base-dir",
     type=clickpath_setup(is_dir=True),
-    default=lambda: DEFAULTS.PHASED_DIR,
+    cls=clickext.ConfigOption,
     help="Base directory for organization of end-to-end intermediate outputs.",
 )
 @click.option(

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -299,6 +299,9 @@ train:
   # Number of epochs to run training for.
   # Default: 10
   num_epochs: 10
+  # Base directory for organization of end-to-end intermediate outputs.
+  # Default: /data/instructlab/phased
+  phased_base_dir: /data/instructlab/phased
   # Judge model path for phased MT-Bench evaluation.
   # Default: None
   phased_mt_bench_judge: /cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0


### PR DESCRIPTION
Wherever it was easily feasable, the `default=lambda:` options from the click option were removed. The defaults are coming from the internal Config object.

Partially solves: https://github.com/instructlab/instructlab/issues/1684
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
