### PR TITLE
fix: mypy linting on MacOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,9 @@ exclude = [
   "^src/instructlab/train/lora_mlx/models/llama\\.py$",
   "^src/instructlab/train/lora_mlx/models/mixtral\\.py$",
   "^src/instructlab/train/lora_mlx/models/models\\.py$",
+  "^src/instructlab/train/lora_mlx/models/phi2\\.py$",
+  "^src/instructlab/train/lora_mlx/models/lora\\.py$",
+  "^src/instructlab/train/lora_mlx/utils\\.py$",
 ]
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
Mypy was failing to lint classes using the mlx dependency because mlx is conditionally imported only on macOS. Since mypy performs static analysis, it requires access to all imported modules to analyze their types. Running mypy in an environment without mlx installed (e.g., on
    Windows or Linux) resulted in no linting errors while failing on
MacOS.

To avoid failing on MacOS we added a few files to the exclude list, so these will be skipped by mypy when running.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
