### PR TITLE
e2e: only run PR job if certain files are changed

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -28,6 +28,7 @@ pull_request_rules:
     # e2e workflow
     - or:
       - and:
+        # note this should match the triggering criteria in 'e2e-nvidia-t4-x1.yml'
         - check-success=e2e-workflow-complete
         - or:
           - files~=\.py$

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -3,10 +3,12 @@
 name: E2E (NVIDIA Tesla T4 x1)
 
 on:
+  # run against every merge commit to 'main' and release branches
   push:
     branches:
       - main
       - release-*
+  # only run on PRs that touch certain regex paths
   pull_request_target:
     types:
       - opened
@@ -15,6 +17,14 @@ on:
     branches:
       - main
       - release-*
+    paths:
+      # note this should match the merging criteria in 'mergify.yml'
+      - '**.py'
+      - 'pyproject.toml'
+      - 'requirements**.txt'
+      - 'scripts/basic-workflow-tests.sh' # Used by this workflow
+      - 'scripts/test-data/**'
+      - '.github/workflows/e2e-nvidia-t4-x1.yml' # This workflow
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
currently the E2E PR job runs on every single PR
this commit aligns the triggering criteria for
the job with the mergify automerge criteria

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
