### PR TITLE
feat: use default and description from Pydantic model

### DIFF
--- a/src/instructlab/data/generate.py
+++ b/src/instructlab/data/generate.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
     cls=clickext.ConfigOption,
     config_sections="teacher",
     show_default=False,
-    help="Name of the model used during generation.",
 )
 @click.option(
     "--num-cpus",
@@ -59,18 +58,15 @@ logger = logging.getLogger(__name__)
     "--taxonomy-path",
     type=click.Path(),
     cls=clickext.ConfigOption,
-    help="Path to where the taxonomy is located.",
 )
 @click.option(
     "--taxonomy-base",
     cls=clickext.ConfigOption,
-    help="Base git-ref to use for taxonomy, use 'empty' for the entire repo contents.",
 )
 @click.option(
     "--output-dir",
     type=click.Path(),
     cls=clickext.ConfigOption,
-    help="Path to output generated files.",
 )
 @click.option(
     "--rouge-threshold",
@@ -142,7 +138,6 @@ logger = logging.getLogger(__name__)
     "--pipeline",
     type=click.STRING,
     cls=clickext.ConfigOption,
-    help="Data generation pipeline to use. Available: simple, full, or a valid path to a directory of pipeline workflow YAML files. Note that 'full' requires a larger teacher model, Mixtral-8x7b.",
 )
 @click.option(
     "--batch-size",
@@ -160,7 +155,6 @@ logger = logging.getLogger(__name__)
     type=click.IntRange(min=0),
     cls=clickext.ConfigOption,
     config_sections="teacher.vllm",
-    help="Number of GPUs to run generation on",
 )
 @click.pass_context
 @clickext.display_params

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -93,21 +93,18 @@ def is_openai_server_and_serving_model(
     "--model",
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="Model name to print in chat process",
 )
 @click.option(
     "-c",
     "--context",
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="Name of system context in config file.",
 )
 @click.option(
     "-s",
     "--session",
     type=click.File("r"),
     cls=clickext.ConfigOption,
-    help="Filepath of a dialog session file.",
 )
 @click.option(
     "-qq",
@@ -121,13 +118,11 @@ def is_openai_server_and_serving_model(
     is_flag=True,
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="Use model greedy decoding. Useful for debugging and reproducing errors.",
 )
 @click.option(
     "--max-tokens",
     type=click.INT,
     cls=clickext.ConfigOption,
-    help="Set a maximum number of tokens to request from the model endpoint.",
 )
 @click.option(
     "--endpoint-url",

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -383,14 +383,12 @@ def launch_server(
     "--model",
     type=click.STRING,
     cls=clickext.ConfigOption,
-    help="Model to be evaluated - can be a local path or the name of a Hugging Face repository",
 )
 @click.option(
     "--base-model",
     type=click.STRING,
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="Base model to compare with 'model' for mt_bench_branch and mmlu_branch - can be a local path or the name of a Hugging Face repository",
 )
 @click.option(
     "--benchmark",
@@ -403,61 +401,52 @@ def launch_server(
     type=click.STRING,
     cls=clickext.ConfigOption,
     config_sections="mt_bench",
-    help="Model to be used as a judge for running mt_bench or mt_bench_branch - must be a local path to a downloaded model",
 )
 @click.option(
     "--output-dir",
     type=click.Path(),
     cls=clickext.ConfigOption,
     config_sections="mt_bench",
-    help="The directory to use for evaluation output from mt_bench or mt_bench_branch",
 )
 @click.option(
     "--max-workers",
     type=click.INT,
     cls=clickext.ConfigOption,
     config_sections="mt_bench",
-    help="Max parallel workers to run the evaluation with for mt_bench or mt_bench_branch",
 )
 @click.option(
     "--taxonomy-path",
     type=click.Path(),
     cls=clickext.ConfigOption,
     config_sections="mt_bench_branch",
-    help="Taxonomy git repo path for running mt_bench_branch",
 )
 @click.option(
     "--branch",
     type=click.STRING,
     cls=clickext.ConfigOption,
-    help="Branch of taxonomy repo to eval QNAs against model",
 )
 @click.option(
     "--base-branch",
     type=click.STRING,
     cls=clickext.ConfigOption,
-    help="Base branch of taxonomy repo to eval QNAs against model for mt_bench_branch",
 )
 @click.option(
     "--few-shots",
     type=click.INT,
     cls=clickext.ConfigOption,
     config_sections="mmlu",
-    help="Number of examples. Needed for running mmlu or mmlu_branch.",
 )
 @click.option(
     "--batch-size",
     type=click.STRING,
     cls=clickext.ConfigOption,
     config_sections="mmlu",
-    help="Batch size for mmlu and mmlu_branch evaluation. Valid values are a positive integer, 'auto' to select the largest batch size that will fit in memory, or 'auto:N' to reselect the largest batch size N times'.",
 )
 @click.option(
     "--tasks-dir",
     type=click.Path(),
     cls=clickext.ConfigOption,
     config_sections="mmlu_branch",
-    help="Path where all the MMLU Branch tasks are stored. Needed for running mmlu_branch.",
 )
 @click.option(
     "--gpus",

--- a/src/instructlab/model/serve.py
+++ b/src/instructlab/model/serve.py
@@ -40,7 +40,6 @@ signal.signal(signal.SIGTERM, signal_handler)
     type=click.Path(path_type=pathlib.Path),
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="Path to the model used during generation.",
 )
 @click.option(
     "--gpu-layers",
@@ -48,7 +47,6 @@ signal.signal(signal.SIGTERM, signal_handler)
     cls=clickext.ConfigOption,
     config_sections="llama_cpp",
     required=True,  # default from config
-    help="The number of layers to put on the GPU. -1 moves all layers. The rest will be on the CPU.",
 )
 @click.option(
     "--num-threads",
@@ -61,8 +59,8 @@ signal.signal(signal.SIGTERM, signal_handler)
     type=click.INT,
     cls=clickext.ConfigOption,
     config_sections="llama_cpp",
-    help="The context size is the maximum number of tokens considered by the model, for both the prompt and response. Defaults to 4096.",
 )
+# TODO: fix me, cli has model-family, but config option has llm-family :-/
 @click.option(
     "--model-family",
     type=str,
@@ -77,29 +75,19 @@ signal.signal(signal.SIGTERM, signal_handler)
 @click.option(
     "--chat-template",
     type=str,
-    help=(
-        "Which chat template to use in serving the model, either 'auto', "
-        "'tokenizer', or a path to a jinja formatted template file. \n"
-        " 'auto' (the default) indicates serve will decide which template to use.\n"
-        " 'tokenizer' indicates the model's tokenizer config will be preferred"
-    ),
+    cls=clickext.ConfigOption,
 )
 @click.option(
     "--backend",
     type=click.Choice(tuple(backends.SUPPORTED_BACKENDS)),
     cls=clickext.ConfigOption,
     required=False,  # auto-detect
-    help=(
-        "The backend to use for serving the model.\n"
-        "Automatically detected based on the model file properties.\n"
-    ),
 )
 @click.option(
     "--gpus",
     type=click.IntRange(min=0),
     cls=clickext.ConfigOption,
     config_sections="vllm",
-    help="Number of GPUs to use when serving this model",
 )
 @click.pass_context
 @clickext.display_params

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -57,21 +57,18 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     type=click.Path(file_okay=True),
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="Base directory where data is stored.",
 )
 @click.option(
     "--ckpt-output-dir",
     type=click.Path(),
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="output directory to store checkpoints in during training",
 )
 @click.option(
     "--data-output-dir",
     type=click.Path(),
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="output directory to store training data in",
 )
 @click.option(
     "--input-dir",
@@ -102,7 +99,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     type=click.Path(),
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="HuggingFace model repo path, in the format of <namespace>/<repo_name>.",
     default=DEFAULTS.MODEL_REPO,
 )
 @click.option(
@@ -126,7 +122,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     type=click.INT,
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="The number of times the training data is passed through the training algorithm. Please note that this value is used on Linux platforms only.",
 )
 @click.option(
     "--device",
@@ -157,28 +152,24 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     type=int,
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="maximum length, in tokens, of a single sample.",
 )
 @click.option(
     "--max-batch-len",
     type=int,
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="maximum overall length of samples processed in a given batch.",
 )
 @click.option(
     "--effective-batch-size",
     type=int,
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="total batch size across all GPUs",
 )
 @click.option(
     "--save-samples",
     type=int,
     cls=clickext.ConfigOption,
     required=True,  # default from config
-    help="The number of samples processed in between checkpoints.",
 )
 @click.option(
     "--learning-rate",
@@ -186,7 +177,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     cls=clickext.ConfigOption,
     config_sections=ADDITIONAL_ARGUMENTS,
     required=True,  # default from config
-    help="learning rate for training",
 )
 @click.option(
     "--warmup-steps",
@@ -194,7 +184,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     cls=clickext.ConfigOption,
     config_sections=ADDITIONAL_ARGUMENTS,
     required=True,  # default from config
-    help="warmup steps for training",
 )
 @click.option(
     "--deepspeed-cpu-offload-optimizer",
@@ -202,7 +191,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     cls=clickext.ConfigOption,
     required=True,  # default from config
     # config_section="deepspeed_options",
-    help="if true enables optimizer offload",
 )
 @click.option(
     "--deepspeed-cpu-offload-optimizer-ratio",
@@ -210,7 +198,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     cls=clickext.ConfigOption,
     required=True,  # default from config
     config_sections=ADDITIONAL_ARGUMENTS,
-    help="cpu offload optimizer ratio",
 )
 @click.option(
     "--deepspeed-cpu-offload-optimizer-pin-memory",
@@ -218,7 +205,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     cls=clickext.ConfigOption,
     required=True,  # default from config
     config_sections=ADDITIONAL_ARGUMENTS,
-    help="if true pin memory when using cpu optimizer",
 )
 # below flags are invalid if lora == false
 @click.option(
@@ -226,21 +212,18 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     type=int,
     cls=clickext.ConfigOption,
     # config_section="lora",
-    help="rank of update matricies",
 )
 @click.option(
     "--lora-alpha",
     type=int,
     cls=clickext.ConfigOption,
     config_sections=ADDITIONAL_ARGUMENTS,
-    help="how influential/strong lora tune will be",
 )
 @click.option(
     "--lora-dropout",
     type=float,
     cls=clickext.ConfigOption,
     config_sections=ADDITIONAL_ARGUMENTS,
-    help="dropout for LoRA layers",
 )
 @click.option(
     "--lora-target-modules",
@@ -248,27 +231,23 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     config_sections=ADDITIONAL_ARGUMENTS,
     multiple=True,
     default=[],
-    help="LoRA modules to use",
 )
 @click.option(
     "--lora-quantize-dtype",
     type=str,
     cls=clickext.ConfigOption,
     default=None,
-    help="quantization data type to use when training a LoRA.",
 )
 @click.option(
     "--is-padding-free",
     cls=clickext.ConfigOption,
     type=bool,
-    help="whether or not we are training a padding free transformer.",
 )
 @click.option(
     "--gpus",
     "nproc_per_node",
     cls=clickext.ConfigOption,
     type=int,
-    help="this is the number of GPUs to use. This is a torch specific arg and must be called nproc-per-node",
 )
 @click.option(
     "--nnodes",
@@ -276,7 +255,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     cls=clickext.ConfigOption,
     config_sections=ADDITIONAL_ARGUMENTS,
     required=True,  # default from config
-    help="number of machines in the training pool.",
 )
 @click.option(
     "--node-rank",
@@ -284,7 +262,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     cls=clickext.ConfigOption,
     config_sections=ADDITIONAL_ARGUMENTS,
     required=True,  # default from config
-    help="the rank of this machine in the training group.",
 )
 @click.option(
     "--rdzv-id",
@@ -292,7 +269,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     cls=clickext.ConfigOption,
     config_sections=ADDITIONAL_ARGUMENTS,
     required=True,  # default from config
-    help="this is the training group ID. So, if there are multiple matching endpoints, only the machines with matching IDs can connect.",
 )
 @click.option(
     "--rdzv-endpoint",
@@ -300,7 +276,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     cls=clickext.ConfigOption,
     config_sections=ADDITIONAL_ARGUMENTS,
     required=True,  # default from config
-    help="this is the rendezvous endpoint which other torchrun jobs will join on.",
 )
 @click.option(
     "--legacy",
@@ -319,7 +294,6 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     "--phased-base-dir",
     type=clickpath_setup(is_dir=True),
     cls=clickext.ConfigOption,
-    help="Base directory for organization of end-to-end intermediate outputs.",
 )
 @click.option(
     "--phased-phase1-data",
@@ -330,19 +304,16 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     "--phased-phase1-num-epochs",
     cls=clickext.ConfigOption,
     type=click.IntRange(min=1),
-    help="Number of epochs to run for first phase of end-to-end training.",
 )
 @click.option(
     "--phased-phase1-samples-per-save",
     cls=clickext.ConfigOption,
     type=click.IntRange(min=0),
-    help="Number of samples to train on between saves for first phase of end-to-end training.",
 )
 @click.option(
     "--phased-phase1-effective-batch-size",
     cls=clickext.ConfigOption,
     type=click.IntRange(min=1),
-    help="Total size of a training batch over all GPUs for Phase 1",
 )
 @click.option(
     "--phased-phase2-data",
@@ -353,26 +324,22 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     "--phased-phase2-num-epochs",
     cls=clickext.ConfigOption,
     type=click.IntRange(min=1),
-    help="Number of epochs to run for second phase of end-to-end training.",
 )
 @click.option(
     "--phased-phase2-samples-per-save",
     cls=clickext.ConfigOption,
     type=click.IntRange(min=0),
-    help="Number of samples to train on between saves for second phase of end-to-end training.",
 )
 @click.option(
     "--phased-phase2-effective-batch-size",
     cls=clickext.ConfigOption,
     type=click.IntRange(min=1),
-    help="Total size of a training batch over all GPUs for Phase 2",
 )
 @click.option(
     "--phased-mt-bench-judge",
     # type=clickpath_setup(is_dir=True), # want this in the future, can't guarantee it exists so can't enforce it this way.
     type=click.Path(dir_okay=True, file_okay=False, path_type=pathlib.Path),
     cls=clickext.ConfigOption,
-    help="MT-Bench judge. Should be absolute path to local judge model directory. Download with `ilab model download` if necessary.",
 )
 @click.option(
     "--skip-user-confirm",


### PR DESCRIPTION
Our Pydantic model, referred to internally as Config, serves as the source of truth for default values and descriptions. When a Click CLI option is also present in the Config, it should inherit its default value and description from the corresponding Config field. When applying the cls=clickext.ConfigOption configuration to a Click option, fields such as “default” and “help” should not be specified, as these will automatically be derived from the Config object.

So this is how you should write an option that exists in the Config (ultimately in config.yaml) AND has a CLI option:

```
my_config_option: StrictStr = Field(
    default="my_default_value",
    description="Great description of what the option does",
)

@click.option(
    "--my-config-option",
    type=click.STRING,
    cls=clickext.ConfigOption,
)
```

That's all. Later we could try to do the same for the type, so we don't need `type=click.STRING`. It's a bit more tedious and is a larger change.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
