### PR TITLE
chore: replace platformdirs with xdg-base-dirs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.19
+
+### Breaking Changes
+
+* InstructLab now uses XDG-based directories on macOS, similar to Linux.
+  Users are advised to re-initialize their config files and remove cached models.
+
 ## v0.18.1
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -332,8 +332,8 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
    ```shell
    Welcome to InstructLab CLI. This guide will help you to setup your environment.
    Please provide the following values to initiate the environment [press Enter for defaults]:
-   Path to taxonomy repo [/home/user/.local/share/instructlab/taxonomy]: 
-   Path to your model [/home/user/.cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf]: 
+   Path to taxonomy repo [/home/user/.local/share/instructlab/taxonomy]:
+   Path to your model [/home/user/.cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf]:
    Generating `/home/user/.config/instructlab/config.yaml`...
    Please choose a train profile to use:
    [0] No profile (CPU-only)
@@ -343,7 +343,7 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
    [4] L40_x4.yaml
    [5] L40_x8.yaml
    [6] L4_x8.yaml
-   Enter the number of your choice [hit enter for the default CPU-only profile] [0]:  
+   Enter the number of your choice [hit enter for the default CPU-only profile] [0]:
    Using default CPU-only train profile.
    Initialization completed successfully, you're ready to start using `ilab`. Enjoy!
    ```
@@ -365,8 +365,6 @@ After running `ilab config init` your directories will look like the following o
  2. `~/.local/share/instructlab/datasets/`: Contains data output from the SDG phase, built on modifications to the taxonomy repository.
  3. `~/.local/share/instructlab/taxonomy/`: Contains the skill and knowledge data.
  4. `~/.local/share/instructlab/checkpoints/`: Contains the output of the training process
-
- On MacOS, these directories will be under `Library/Application Support/instructlab`. This directory setup is temporary in 0.18.0 and will mimic the Linux paths in future releases. The models directory will be under `Library/Caches/instructlab`.
 
 ### 📥 Download the model
 
@@ -579,7 +577,7 @@ Before following these instructions, ensure the existing model you are adding sk
    ...
    ```
 
-   The synthetic data set will be two files in the newly created in the datasets directory. On Linux this will be: `~/.local/share/instructlab/datasets` and on MacOS this will be `~/Library/Application Support/instructlab/datasets`. These files will be named `skills_train_msgs_*.jsonl` and `knowledge_train_msgs_*.jsonl`.
+   The synthetic data set will be two files in the newly created in the datasets directory: `~/.local/share/instructlab/datasets`. These files will be named `skills_train_msgs_*.jsonl` and `knowledge_train_msgs_*.jsonl`.
 
 2. Verify the files have been created by running the `ls datasets` command. Note: you must be in your `XDG_DATA_HOME/instructlab` directory.
 
@@ -660,7 +658,7 @@ Training has experimental support for GPU acceleration with Nvidia CUDA or AMD R
 ilab model train --device=cuda
 ```
 
-This version of `ilab model train` outputs brand-new models that can be served in the `~/.local/share/instructlab/checkpoints` directory on Linux and `~/Library/Application Support/instructlab/checkpoints` on MacOS.  These models can be run through `ilab model evaluate` to choose the best one.
+This version of `ilab model train` outputs brand-new models that can be served in the `~/.local/share/instructlab/checkpoints` directory.  These models can be run through `ilab model evaluate` to choose the best one.
 
 #### Train the model locally with multi-phase training and GPU acceleration
 
@@ -722,7 +720,7 @@ resources. You can download it via `ilab model download`.
 Below is an example of running MMLU on a local model with minimal tasks:
 
 ```bash
-$ export INSTRUCTLAB_EVAL_MMLU_MIN_TASKS=true   # don't set this if you want to run full MMLU 
+$ export INSTRUCTLAB_EVAL_MMLU_MIN_TASKS=true   # don't set this if you want to run full MMLU
 $ export ILAB_MODELS_DIR=$HOME/.local/share/instructlab/models
 $ ilab model evaluate --benchmark mmlu --model $ILAB_MODELS_DIR/instructlab/granite-7b-lab
 ...
@@ -743,7 +741,7 @@ mmlu_astronomy - 0.55
 Below is an example of running MMLU on a Hugging Face model with minimal tasks:
 
 ```bash
-$ export INSTRUCTLAB_EVAL_MMLU_MIN_TASKS=true   # don't set this if you want to run full MMLU 
+$ export INSTRUCTLAB_EVAL_MMLU_MIN_TASKS=true   # don't set this if you want to run full MMLU
 $ ilab model evaluate --benchmark mmlu --model instructlab/granite-7b-lab
 ...
 # KNOWLEDGE EVALUATION REPORT

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ numpy>=1.23.5,<2.0.0 ; python_version == '3.10'
 numpy>=1.26.4,<2.0.0 ; python_version >= '3.11'
 openai>=1.13.3
 peft>=0.9.0
-platformdirs>=4.2
 prompt-toolkit>=3.0.38
 pydantic>=2.7.4
 pydantic_yaml>=1.2.0
@@ -41,3 +40,4 @@ transformers>=4.40.0 ; python_version == '3.10'
 transformers>=4.41.2 ; python_version >= '3.11'
 trl>=0.9.4
 wandb>=0.16.4
+xdg-base-dirs>=6.0.1

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -64,20 +64,22 @@ function init_test_script() {
     local prev_home="${HOME}"
 
     printf 'initializing test script...\n'
-    HOME="${TEST_DIR}"  # to ensure platformdirs uses the test directory for the duration of this script
+    HOME="${TEST_DIR}"  # to ensure xdg-base-dirs uses the test directory for the duration of this script
     printf 'changing home directory to "%s", was: "%s"\n' "${HOME}" "${prev_home}"
 
     # DO NOT REMOVE THE VARIABLE ASSIGNMENTS BELOW
     # They might seem redundant given that `mkdir -p`` is called later, but they are necessary to
     # ensure the directories are created by ilab CLI
-    # get the directories from the platformdirs library
-    CONFIG_DIR=$(python -c "import platformdirs; print(platformdirs.user_config_dir())")
-    DATA_DIR=$(python -c "import platformdirs; print(platformdirs.user_data_dir())")
-    CACHE_DIR=$(python -c "import platformdirs; print(platformdirs.user_cache_dir())")
+    # get the directories from the xdg-base-dirs library
+    # Get configuration, data, and cache directories using Python
+    CONFIG_DIR=$(python -c "import xdg_base_dirs; print(xdg_base_dirs.xdg_config_home())")
+    DATA_DIR=$(python -c "import xdg_base_dirs; print(xdg_base_dirs.xdg_data_home())")
+    CACHE_DIR=$(python -c "import xdg_base_dirs; print(xdg_base_dirs.xdg_cache_home())")
 
-    configdir_script=$(printf 'import platformdirs; print(platformdirs.user_config_dir("%s"))' "${PACKAGE_NAME}")
-    datadir_script=$(printf 'import platformdirs; print(platformdirs.user_data_dir("%s"))' "${PACKAGE_NAME}")
-    cachedir_script=$(printf 'import platformdirs; print(platformdirs.user_cache_dir("%s"))' "${PACKAGE_NAME}")
+    # Define package-specific directories
+    configdir_script=$(printf 'import xdg_base_dirs, os; print(os.path.join(xdg_base_dirs.xdg_config_home(), "%s"))' "${PACKAGE_NAME}")
+    datadir_script=$(printf 'import xdg_base_dirs, os; print(os.path.join(xdg_base_dirs.xdg_data_home(), "%s"))' "${PACKAGE_NAME}")
+    cachedir_script=$(printf 'import xdg_base_dirs, os; print(os.path.join(xdg_base_dirs.xdg_cache_home(), "%s"))' "${PACKAGE_NAME}")
 
     ILAB_CONFIGDIR_LOCATION=$(python -c "${configdir_script}")
     ILAB_CONFIG_FILE="${ILAB_CONFIGDIR_LOCATION}/config.yaml"

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -30,9 +30,9 @@ from pydantic import (
 from pydantic_core import PydanticUndefined
 from ruamel.yaml import YAML, CommentedMap
 from typing_extensions import deprecated as Deprecated
+from xdg_base_dirs import xdg_cache_home, xdg_config_home, xdg_data_home
 import click
 import httpx
-import platformdirs
 
 # Local
 from . import log
@@ -119,10 +119,9 @@ class _InstructlabDefaults:
         Utility function which is mostly used for testing purposes to clear the cache.
         Otherwise, all tests will used cached temporary directories and cause errors.
         """
-        pd = platformdirs.PlatformDirs(appname=ILAB_PACKAGE_NAME)
-        self._cache_home = pd.user_cache_dir
-        self._config_dir = pd.user_config_dir
-        self._data_dir = pd.user_data_dir
+        self._cache_home = os.path.join(xdg_cache_home(), ILAB_PACKAGE_NAME)
+        self._config_dir = os.path.join(xdg_config_home(), ILAB_PACKAGE_NAME)
+        self._data_dir = os.path.join(xdg_data_home(), ILAB_PACKAGE_NAME)
 
     @property
     def CHECKPOINTS_DIR(self) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ import shutil
 import typing
 
 # Third Party
-import platformdirs
+from xdg_base_dirs import xdg_cache_home, xdg_data_home
 import pydantic
 import pytest
 import yaml
@@ -27,8 +27,8 @@ class TestConfig:
         # to catch any errors if we are doing things incorrectly over there
         package_name = "instructlab"
         internal_dirname = "internal"
-        data_dir = platformdirs.user_data_dir(package_name)
-        cache_dir = platformdirs.user_cache_dir(package_name)
+        cache_dir = os.path.join(xdg_cache_home(), package_name)
+        data_dir = os.path.join(xdg_data_home(), package_name)
         default_model = f"{cache_dir}/models/merlinite-7b-lab-Q4_K_M.gguf"
 
         assert cfg.general is not None
@@ -88,7 +88,7 @@ class TestConfig:
 
     def _assert_model_defaults(self, cfg):
         package_name = "instructlab"
-        cache_dir = platformdirs.user_cache_dir(package_name)
+        cache_dir = os.path.join(xdg_cache_home(), package_name)
         default_model = f"{cache_dir}/models/merlinite-7b-lab-Q4_K_M.gguf"
 
         assert cfg.chat is not None


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

Currently we use the `platformdirs` package to automatically pick the platform specific system directories that are used by instructlab. While this works fine on linux with XDG dirs, On macOS this means usage of `/Users/<user>/Library/Application Support/...` which is awkward and hard to use
This PR replaces `platformdirs` with `xdg-base-dirs` to standardize the dirs across linux and macOS

acc to https://pypi.org/project/xdg-base-dirs/ `xdg-base-dirs` functions take XDG env vars into account so we get env var support for free with this package 

There is a consideration to be made that we are making a change to the project's dependencies by making this switch so that should be taken into account 

**Issue resolved by this Pull Request:**
Resolves #1747 


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
