### PR TITLE
refactor: move free_tcp_ipv4_port() to common

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -12,7 +12,6 @@ import multiprocessing
 import os
 import pathlib
 import signal
-import socket
 import struct
 import subprocess
 import sys
@@ -398,19 +397,6 @@ def wait_for_stable_vram_cuda(timeout: int) -> Tuple[bool, bool]:
             torch.cuda.empty_cache()
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.debug("Could not free cuda cache: %s", e)
-
-
-def free_tcp_ipv4_port(host: str) -> int:
-    """Ask the OS for a random, ephemeral, and bindable TCP/IPv4 port
-
-    Note: The idea of finding a free port is bad design and subject to
-    race conditions. Instead vLLM and llama-cpp should accept port 0 and
-    have an API to return the actual listening port. Or they should be able
-    to use an existing socket like a systemd socket activation service.
-    """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind((host, 0))
-        return int(s.getsockname()[-1])
 
 
 def is_temp_server_running():

--- a/src/instructlab/model/backends/common.py
+++ b/src/instructlab/model/backends/common.py
@@ -2,6 +2,7 @@
 from typing import Tuple
 import logging
 import pathlib
+import socket
 import typing
 
 # Local
@@ -63,3 +64,16 @@ def verify_template_exists(path):
         raise IsADirectoryError(
             "Chat templates paths must point to a file: {}".format(path)
         )
+
+
+def free_tcp_ipv4_port(host: str) -> int:
+    """Ask the OS for a random, ephemeral, and bindable TCP/IPv4 port
+
+    Note: The idea of finding a free port is bad design and subject to
+    race conditions. Instead vLLM and llama-cpp should accept port 0 and
+    have an API to return the actual listening port. Or they should be able
+    to use an existing socket like a systemd socket activation service.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, 0))
+        return int(s.getsockname()[-1])

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -23,7 +23,6 @@ from ...configuration import get_api_base
 from .backends import (
     BackendServer,
     UvicornServer,
-    free_tcp_ipv4_port,
     get_uvicorn_config,
     is_temp_server_running,
 )
@@ -33,6 +32,7 @@ from .common import (
     CHAT_TEMPLATE_TOKENIZER,
     LLAMA_CPP,
     ServerException,
+    free_tcp_ipv4_port,
     get_model_template,
     verify_template_exists,
 )

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -18,18 +18,14 @@ import httpx
 # Local
 from ...client import check_api_base
 from ...configuration import get_api_base
-from .backends import (
-    BackendServer,
-    free_tcp_ipv4_port,
-    safe_close_all,
-    shutdown_process,
-)
+from .backends import BackendServer, safe_close_all, shutdown_process
 from .common import (
     CHAT_TEMPLATE_AUTO,
     CHAT_TEMPLATE_TOKENIZER,
     VLLM,
     Closeable,
     ServerException,
+    free_tcp_ipv4_port,
     get_model_template,
     verify_template_exists,
 )

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -13,7 +13,7 @@ import pytest
 
 # First Party
 from instructlab import lab
-from instructlab.model.backends import backends
+from instructlab.model.backends import backends, common
 from instructlab.model.backends.vllm import build_vllm_cmd
 
 
@@ -42,7 +42,7 @@ def create_safetensors_or_bin_model_files(
 
 def test_free_port():
     host = "localhost"
-    port = backends.free_tcp_ipv4_port(host)
+    port = common.free_tcp_ipv4_port(host)
     # check that port is bindable
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind((host, port))


### PR DESCRIPTION
The backends module, along with the llama_cpp and vllm modules,
have a circular dependencies, which is considered an anti-pattern.

Move free_tcp_ipv4_port() to reduce the circular dependencies.


Current state of [Circular dependency](https://en.wikipedia.org/wiki/Circular_dependency):
```mermaid
graph LR;
  subgraph backends
    x[free_tcp_ipv4_port]
    style x opacity:0
    select_backend
    style select_backend opacity:0
  end
  backends --> llama_cpp & vllm
  linkStyle 0,1 opacity:0
  select_backend --> llama_cpp & vllm --> x
 ```
Desired state of [Acyclic dependencies](https://en.wikipedia.org/wiki/Acyclic_dependencies_principle):

```mermaid
graph LR;
  subgraph backends
    a[ ]
    style a opacity:0
    select_backend
    style select_backend opacity:0
  end
  backends --> llama_cpp & vllm
  linkStyle 0,1 opacity:0
  select_backend --> llama_cpp & vllm -->x
  subgraph common
    x[free_tcp_ipv4_port]
    style x opacity:0
  end
```
