### PR TITLE
Deprecate aliased commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 * InstructLab now uses XDG-based directories on macOS, similar to Linux.
   Users are advised to re-initialize their config files and remove cached models.
 * Removed unused argument `--rouge-threshold` of `ilab data generate`
+* Removed the following aliased commands:
+  * `convert`
+  * `diff`
+  * `download`
+  * `evaluate`
+  * `init`
+  * `list`
+  * `sysinfo`
+  * `test`
 
 ## v0.18.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,17 +70,9 @@ issues = "https://github.com/instructlab/instructlab/issues"
 
 [project.entry-points."instructlab.command.alias"]
 "chat" = "instructlab.model.chat:chat"
-"convert" = "instructlab.model.convert:convert"
-"diff" = "instructlab.taxonomy.diff:diff"
-"download" = "instructlab.model.download:download"
-"evaluate" = "instructlab.model.evaluate:evaluate"
 "generate" = "instructlab.data.generate:generate"
-"init" = "instructlab.config.init:init"
 "serve" = "instructlab.model.serve:serve"
-"sysinfo" = "instructlab.system.info:info"
-"test" = "instructlab.model.test:test"
 "train" = "instructlab.model.train:train"
-"list" = "instructlab.model.list:model_list"
 
 [tool.setuptools_scm]
 version_file = "src/instructlab/_version.py"

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -559,7 +559,7 @@ ilab --version
 ilab system info
 
 # pipe 3 carriage returns to ilab config init to get past the prompts
-echo -e "\n\n\n" | ilab init
+echo -e "\n\n\n" | ilab config init
 
 # Enable Debug in func tests with debug level 1
 sed -i.bak -e 's/log_level:.*/log_level: DEBUG/g;' "${ILAB_CONFIG_FILE}"

--- a/src/instructlab/clickext.py
+++ b/src/instructlab/clickext.py
@@ -73,17 +73,10 @@ class ExpandAliasesGroup(LazyEntryPointGroup):
             cmd = self.alias_eps[cmd_name].load()
             if typing.TYPE_CHECKING:
                 assert isinstance(cmd, click.Command)
-            group, primary = self.get_alias_info(cmd_name)
-            click.echo(
-                "You are using an aliased command, this will be deprecated "
-                "in a future release. Please consider using "
-                f"`ilab {group} {primary}` instead"
-            )
             # if some storage dirs do not exist
-            # AND the command is not `ilab init`
             # AND the --config flag is not customized, then we error
             if not storage_dirs_exist() and (
-                primary != "init" and ctx.params["config_file"] == DEFAULTS.CONFIG_FILE
+                ctx.params["config_file"] == DEFAULTS.CONFIG_FILE
             ):
                 click.secho(
                     "Some ilab storage directories do not exist yet. Please run `ilab config init` before continuing.",

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -134,16 +134,8 @@ subcommands: list[Command] = [
 aliases = [
     "serve",
     "train",
-    "convert",
     "chat",
-    "test",
-    "evaluate",
-    "init",
-    "download",
-    "diff",
     "generate",
-    "sysinfo",
-    "list",
 ]
 
 
@@ -209,14 +201,6 @@ def test_cli_help_matches_field_description(cli_runner: CliRunner):
                         "- ", "-"
                     )
                     assert str(description) in normalize_output, normalize_output
-
-
-@pytest.mark.parametrize("alias", aliases)
-def test_ilab_cli_deprecated_help(alias: str, cli_runner):
-    cmd = ["--config", "DEFAULT", alias, "--help"]
-    result = cli_runner.invoke(lab.ilab, cmd)
-    assert result.exit_code == 0, result.stdout
-    assert "this will be deprecated in a future release" in result.stdout
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lab_config.py
+++ b/tests/test_lab_config.py
@@ -6,7 +6,6 @@ import pathlib
 
 # Third Party
 from click.testing import CliRunner
-import pytest
 import yaml
 
 # First Party
@@ -23,17 +22,8 @@ def test_ilab_config_show(cli_runner: CliRunner) -> None:
     assert configuration.Config(**parsed)
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        (["config", "init", "--non-interactive"]),
-        (
-            ["init", "--non-interactive"]
-        ),  # TODO: remove this test once the deprecated alias 'ilab init' is removed
-    ],
-)
 def test_ilab_config_init_with_env_var_config(
-    cli_runner: CliRunner, tmp_path: pathlib.Path, command: list
+    cli_runner: CliRunner, tmp_path: pathlib.Path
 ) -> None:
     # Common setup code
     cfg = configuration.get_default_config()
@@ -44,6 +34,7 @@ def test_ilab_config_init_with_env_var_config(
         yaml.dump(cfg.model_dump(), f)
 
     # Invoke the CLI command
+    command = ["config", "init", "--non-interactive"]
     result = cli_runner.invoke(
         lab.ilab, command, env={"ILAB_GLOBAL_CONFIG": cfg_file.as_posix()}
     )
@@ -60,19 +51,11 @@ def test_ilab_config_init_with_env_var_config(
     )
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        (["config", "init"]),
-        (
-            ["init"]
-        ),  # TODO: remove this test once the deprecated alias 'ilab init' is removed
-    ],
-)
-def test_ilab_config_init_with_model_path(cli_runner: CliRunner, command: list) -> None:
+def test_ilab_config_init_with_model_path(cli_runner: CliRunner) -> None:
     # Common setup code
     model_path = "path/to/model"
-    command.extend(["--model-path", model_path])
+    command = ["config", "init", "--model-path", model_path]
+
     # Invoke the CLI command
     result = cli_runner.invoke(lab.ilab, command)
     assert result.exit_code == 0, result.stdout


### PR DESCRIPTION
This change removes a majority of the aliased commands, except `chat`,
`generate`, `serve`, and `train`. When a user attempts to use an alias
that was removed, it errors out. If a user types an alias that was kept,
it proceeds with the command.
Also updates the relevant test files.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
