### PR TITLE
refactor: move safe_close_all() to common

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -5,7 +5,6 @@ from time import monotonic, sleep
 from types import FrameType
 from typing import Optional, Tuple
 import abc
-import contextlib
 import json
 import logging
 import multiprocessing
@@ -27,7 +26,7 @@ import uvicorn
 # Local
 from ...configuration import _serve as serve_config
 from ...utils import split_hostport
-from .common import CHAT_TEMPLATE_AUTO, LLAMA_CPP, VLLM, Closeable
+from .common import CHAT_TEMPLATE_AUTO, LLAMA_CPP, VLLM, Closeable, safe_close_all
 
 logger = logging.getLogger(__name__)
 
@@ -87,12 +86,6 @@ class BackendServer(abc.ABC):
     @abc.abstractmethod
     def get_backend_type(self):
         """Return which type of backend this is, llama-cpp or vllm"""
-
-
-def safe_close_all(resources: typing.Iterable[Closeable]):
-    for resource in resources:
-        with contextlib.suppress(Exception):
-            resource.close()
 
 
 def is_model_safetensors(model_path: pathlib.Path) -> bool:

--- a/src/instructlab/model/backends/common.py
+++ b/src/instructlab/model/backends/common.py
@@ -1,5 +1,6 @@
 # Standard
 from typing import Tuple
+import contextlib
 import logging
 import pathlib
 import socket
@@ -77,3 +78,9 @@ def free_tcp_ipv4_port(host: str) -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind((host, 0))
         return int(s.getsockname()[-1])
+
+
+def safe_close_all(resources: typing.Iterable[Closeable]):
+    for resource in resources:
+        with contextlib.suppress(Exception):
+            resource.close()

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -18,7 +18,7 @@ import httpx
 # Local
 from ...client import check_api_base
 from ...configuration import get_api_base
-from .backends import BackendServer, safe_close_all, shutdown_process
+from .backends import BackendServer, shutdown_process
 from .common import (
     CHAT_TEMPLATE_AUTO,
     CHAT_TEMPLATE_TOKENIZER,
@@ -27,6 +27,7 @@ from .common import (
     ServerException,
     free_tcp_ipv4_port,
     get_model_template,
+    safe_close_all,
     verify_template_exists,
 )
 


### PR DESCRIPTION
The backends module, along with the llama_cpp and vllm modules,
have a circular dependencies, which is considered an anti-pattern.

Move safe_close_all() to reduce the circular dependencies.


Current state of [Circular dependency](https://en.wikipedia.org/wiki/Circular_dependency):
```mermaid
graph LR;
  subgraph backends
    x[safe_close_all]
    style x opacity:0
    select_backend
    style select_backend opacity:0
  end
  backends -->  vllm
  linkStyle 0 opacity:0
  select_backend -->  vllm --> x
 ```
Desired state of [Acyclic dependencies](https://en.wikipedia.org/wiki/Acyclic_dependencies_principle):

```mermaid
graph LR;
  subgraph backends
    a[ ]
    style a opacity:0
    select_backend
    style select_backend opacity:0
  end
  backends -->  vllm
  linkStyle 0 opacity:0
  select_backend -->  vllm -->x
  subgraph common
    x[safe_close_all]
    style x opacity:0
  end
```