### PR TITLE
refactor: run E2E cron job once a day instead of twice

### DIFF
--- a/.github/workflows/e2e-nvidia-a10g-x4.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x4.yml
@@ -4,7 +4,7 @@ name: E2E (NVIDIA A10G x4)
 
 on:
   schedule:
-    - cron:  '0 8,20 * * *' # Runs at 8 AM and 8 PM UTC every day
+    - cron: '0 11 * * *' # Runs at 11AM UTC every day
   workflow_dispatch:
     inputs:
       pr_or_branch:


### PR DESCRIPTION
not a lot of work tends to happen between 8 PM and 8 AM UTC, as such any regressions caught by the
8PM job likely would not be fixed by the 8AM job run

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
