### PR TITLE
Implement phased training bookkeeping and better restarting

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -165,3 +165,5 @@ XTX
 Xu
 YAML
 Zsh
+resumeable
+yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
   configuration.
 * `ilab model train` now supports `--pipeline`. The supported pipelines are `simple`, `full`, and `accelerated`. Simple preserves the functionality found in `--legacy` and current MacOS training. Full introduces a new training loop optimized for CPU and MacOS performance. `accelerated` allows users with dedicated graphics cards to run the full fine tuning and multi-phase training found in our training library.
 * `--device` in `ilab model train` now supports `mps` which stands for Metal Performance Shaders. This is a PyTorch device for MacOS training that allows us to utilize the same code path for Linux and MacOS.
+* Multi-phase training with `ilab model train --strategy lab-multiphase` is now resumeable! In the case of a machine failure or an incidental stop, progress is tracked in a new `journal` file, rendered in yaml.
+  Upon restarting training, the user can confirm whether they would like to proceed with a pre-existing training run (one that might have only evaluated a few checkpoints of the first eval phase, for instance)
+  or restart from scratch.
 
 ## v0.18.1
 

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -483,6 +483,10 @@ class _train(BaseModel):
         default_factory=lambda: DEFAULTS.PHASED_DIR,
         description="Base directory for organization of end-to-end intermediate outputs.",
     )
+    training_journal: str | None = Field(
+        default=None,
+        description="Optional path to a yaml file that tracks the progress of multiphase training.",
+    )
 
 
 class Config(BaseModel):

--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -695,21 +695,19 @@ def evaluate(
 
         elif benchmark == Benchmark.MMLU:
             # Third Party
-            from instructlab.eval.mmlu import MMLUEvaluator
+            from instructlab.eval.mmlu import MMLU_TASKS, MMLUEvaluator
 
-            min_tasks = os.environ.get("INSTRUCTLAB_EVAL_MMLU_MIN_TASKS")
-            if min_tasks is not None:
-                tasks = ["mmlu_abstract_algebra", "mmlu_anatomy", "mmlu_astronomy"]
-                evaluator = MMLUEvaluator(
-                    model,
-                    tasks=tasks,
-                    few_shots=few_shots,
-                    batch_size=batch_size,
-                )
-            else:
-                evaluator = MMLUEvaluator(
-                    model, few_shots=few_shots, batch_size=batch_size
-                )
+            tasks = MMLU_TASKS
+            if os.environ.get("INSTRUCTLAB_EVAL_MMLU_MIN_TASKS") is not None:
+                tasks = tasks[:4]
+
+            evaluator = MMLUEvaluator(
+                model,
+                tasks=tasks,
+                few_shots=few_shots,
+                batch_size=batch_size,
+            )
+
             server = None
             try:
                 server, api_base, _ = launch_server(

--- a/src/instructlab/model/phased_training.py
+++ b/src/instructlab/model/phased_training.py
@@ -1,0 +1,198 @@
+# Standard
+import datetime
+import enum
+import fcntl
+import logging
+import os
+import pathlib
+import typing
+import uuid
+
+# Third Party
+import pydantic
+import rich
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class TrainingPhases(enum.Enum):
+    TRAIN1 = "train1"
+    TRAIN2 = "train2"
+    EVAL1 = "eval1"
+    EVAL2 = "eval2"
+    DONE = "done"
+
+
+AutoDatetimeField = pydantic.Field(
+    default_factory=lambda: datetime.datetime.now(datetime.UTC)
+)
+
+
+class EvalResult(pydantic.BaseModel):
+    """Single checkpoint's final score"""
+
+    ended_at_utc: datetime.datetime = AutoDatetimeField
+    checkpoint: pydantic.DirectoryPath
+    score: float
+
+    @pydantic.field_serializer("checkpoint", "ended_at_utc")
+    def call_str_constructor(self, val: typing.Any) -> str:
+        return str(val)
+
+
+class EvalPhaseModel(pydantic.BaseModel):
+    """Stores info about evaluation phase"""
+
+    started_at_utc: datetime.datetime = AutoDatetimeField
+    ended_at_utc: datetime.datetime | None = None
+    checkpoints: list[pydantic.DirectoryPath]
+    finished_checkpoints: list[pydantic.DirectoryPath] = []
+    results: list[EvalResult] = []
+    best_checkpoint: EvalResult | None = None
+
+    @pydantic.field_serializer(
+        "checkpoints",
+        "finished_checkpoints",
+    )
+    def pathlibPath_list_to_str(self, paths: list[pathlib.Path]) -> list[str]:
+        return [str(path) for path in paths]
+
+    @pydantic.field_serializer("ended_at_utc")
+    def serialize_optional_datetime(self, val: datetime.datetime | None):
+        if val:
+            return str(val)
+        return val
+
+
+class TrainPhaseModel(pydantic.BaseModel):
+    """Stores info about training phase. Doesn't store training args because user can get those elsewhere, e.g. config."""
+
+    started_at_utc: datetime.datetime = AutoDatetimeField
+    ended_at_utc: datetime.datetime | None = None
+    checkpoints: pydantic.DirectoryPath
+    # TODO: might want training args here, but can't currently do it
+    # without side-effects because model instance is changed inside of _training_phase
+
+    @pydantic.field_serializer("checkpoints")
+    def call_str_constructor(self, val: typing.Any) -> str:
+        return str(val)
+
+    @pydantic.field_serializer("ended_at_utc")
+    def serialize_optional_datetime(self, val: datetime.datetime | None):
+        if val:
+            return str(val)
+        return val
+
+
+class JournalModel(pydantic.BaseModel):
+    run_id: uuid.UUID = pydantic.Field(default_factory=uuid.uuid4)
+    started_at_utc: datetime.datetime = AutoDatetimeField
+    ended_at_utc: datetime.datetime | None = None
+    current_phase: TrainingPhases = TrainingPhases.TRAIN1
+    train_1: TrainPhaseModel | None = None
+    eval_1: EvalPhaseModel | None = None
+    train_2: TrainPhaseModel | None = None
+    eval_2: EvalPhaseModel | None = None
+    final_output: EvalResult | None = None
+
+    @pydantic.field_serializer("current_phase")
+    def enum_to_value(self, enum_val: TrainingPhases) -> str:
+        return str(enum_val.value)
+
+    @pydantic.field_serializer("run_id")
+    def object_to_str(self, value: typing.Any) -> str:
+        return str(value)
+
+    @pydantic.field_serializer("ended_at_utc")
+    def serialize_optional_datetime(self, val: datetime.datetime | None):
+        if val:
+            return str(val)
+        return val
+
+
+class TrainingJournal:
+    def __init__(self, journalfile: pathlib.Path):
+        if journalfile.is_dir():
+            raise ValueError(
+                f"Given journal path is to an existing directory: '{str(journalfile)}'"
+            )
+
+        # not a dir. Could not exist, or be a file.
+
+        self.was_loaded: bool = False
+        self.journalfile = journalfile
+        if journalfile.is_file():
+            logger.debug(f"Received journal that is a file: {journalfile}")
+            with open(journalfile, "r", encoding="utf-8") as f:
+                model_dict = yaml.safe_load(stream=f)
+
+            try:
+                self.journal = JournalModel.parse_obj(model_dict)
+                self.was_loaded = True
+                logger.debug("Parsed journal from journalfile.")
+            except pydantic.ValidationError as e:
+                logging.error(
+                    f"Tried to load Journal but encountered an error. If provided, journal must be parseable. {e}"
+                )
+                self.journal = JournalModel()
+        else:
+            logger.debug(
+                f"Reference to journal wasn't a file. Initializing empty object. {journalfile}"
+            )
+            self.journal = JournalModel()
+
+    def create_empty_journal(self) -> None:
+        # makes empty file available at `journalfile` path
+        self.journalfile.parent.mkdir(exist_ok=True, parents=True)
+        self.journalfile.touch(exist_ok=True)
+
+    def commit(self, create_new: bool = False) -> None:
+        if create_new:
+            self.create_empty_journal()
+
+        # try dumping before we open file for writing so yaml parsing can fail before we
+        # destroy file content.
+        _ = yaml.safe_dump(self.journal.model_dump())
+
+        # implementation by @leseb
+        with open(self.journalfile, "w", encoding="utf-8") as f:
+            # Acquire an exclusive lock to prevent other processes from writing
+            fcntl.flock(f, fcntl.LOCK_EX)
+
+            # Write journal's content
+            yaml.safe_dump(data=self.journal.model_dump(), stream=f)
+
+            # Flush the buffer to ensure data is moved to OS buffer
+            f.flush()
+
+            # Call fsync to ensure the data is physically written to disk
+            os.fsync(f.fileno())
+        logger.debug("Model written to disk")
+
+    @property
+    def current_phase(self) -> TrainingPhases:
+        return self.journal.current_phase
+
+    @current_phase.setter
+    def current_phase(self, new_phase: TrainingPhases) -> None:
+        self.journal.current_phase = new_phase
+
+    @staticmethod
+    def now_utc() -> datetime.datetime:
+        """Static helper method for current time in UTC"""
+        return datetime.datetime.now(datetime.UTC)
+
+    @staticmethod
+    def best_checkpoint(phase_model: EvalPhaseModel) -> EvalResult:
+        """Returns the EvalResult object with the highest score."""
+        return sorted(phase_model.results, reverse=True, key=lambda c: c.score)[0]
+
+    def print_model_rich(self) -> str:
+        """
+        Prints model in color, with indentation. Meant to be executed at runtime with
+        a logging statement if desired. 'rich' doesn't have a 'format' option so this
+        is a not-terrible way to get good output.
+        """
+        rich.print(self.journal, flush=True)
+        return ""

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -332,6 +332,9 @@ train:
   # Number of samples the model should see before saving a checkpoint.
   # Default: 250000
   save_samples: 250000
+  # Optional path to a yaml file that tracks the progress of multiphase training.
+  # Default: None
+  training_journal:
 # Configuration file structure version.
 # Default: 1.0.0
 version: 1.0.0


### PR DESCRIPTION
# enables restart in the event of a system crash, GPU hang, etc.

Adds a TrainingJournal object that represents a JournalModel pydantic
class. During phased training, an instance of the JournalModel is
updated and written to disk as progress is made.

In the event of an untimely exit from the training process, a
'journalfile.yaml' by convention, or a 'yaml' file by another name, can
be loaded into a "JournalModel" object and training can resume.

To-do:
- [x] rebase
- [ ] add functional test
- [x] update docs (Kelly is doing this)
- [x] update changelog

# Explanation of behavior

Phased training is started with a command like:

```bash
ilab model train --strategy lab-multiphase \
--phased-phase1-data ./knowledge-data.jsonl \
--phased-phase2-data ./skills-data.jsonl
```

This will run phased training, storing checkpoints and metadata in `$HOME/.local/share/instructlab/phased`. 
Among the metadata stored is now a file `$HOME/.local/share/instructlab/phased/journalfile.yaml`, named by convention. This behavior can be overridden by passing `--training-journal` to `ilab model train` which takes any file, attempts to parse it as yaml, and then attempts to load that yaml object into a Pydantic configuration model.

In the `journalfile.yaml`, information about the state of training is stored in a human-readable format. Most relevant are sections such as `current_phase` and `train_1` or `eval_1`. `current_phase` is updated each time a given phase finishes: e.g. when `train_1` finishes, its final step is to set `current_phase=eval_1`. 

If there's a failure within a phase, training will resume from the `current_phase`, expecting that the training artifacts (checkpoints, evaluation metadata) haven't been changed or corrupted.

By default, this should be transparent to the user. If they choose not to clear their existing training cache (when prompted at the beginning of phased training) the existing `journalfile.yaml` will be read, and training will resume from wherever they left off.

## By example

Imagine that the first phase of training has completed. All of the checkpoints (5 checkpoints, for the sake of example) for this phase have been saved to `$HOME/.local/share/instructlab/phased/phase1/checkpoints/hf_format`. 

MMLU successfully evaluates 3/5 checkpoints, storing their scores and paths in the `journalfile.yaml` but then a GPU freezes, and the training must be aborted.

The user may simply re-run training as they did initially, choosing NOT to delete the checkpoints / journal currently in cache.

The training process will read the `journalfile.yaml`, reinitialize the queue of checkpoints to be evaluated along with the in-process cache of previously evaluated checkpoint scores, and continue working.