### PR TITLE
add a model remove subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update vLLM to version 0.6.6.post1. As a requirement for this new vLLM version, PyTorch is updated to 2.5.1
 - `ilab model chat` now has `--no-decoration` option to display chat responses without decoration.
+- A new command `ilab model remove` has been introduced so users can now remove the model via `ilab` CLI.
 
 ## v0.23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ issues = "https://github.com/instructlab/instructlab/issues"
 "train" = "instructlab.cli.model.train:train"
 "list" = "instructlab.cli.model.list:model_list"
 "upload" = "instructlab.cli.model.upload:upload"
+"remove" = "instructlab.cli.model.remove:remove"
 
 [project.entry-points."instructlab.command.rag"]
 "convert" = "instructlab.cli.rag.convert:convert"

--- a/src/instructlab/cli/model/remove.py
+++ b/src/instructlab/cli/model/remove.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+
+# Third Party
+import click
+
+# First Party
+from instructlab import clickext
+from instructlab.configuration import DEFAULTS
+from instructlab.model.remove import RemovalError, remove_model
+
+
+@click.command(name="remove")
+@clickext.display_params
+@click.option(
+    "-m",
+    "--model",
+    required=True,
+    help="Specify the model name to remove (check with 'ilab model list' first), e.g., merlinite-7b-lab-Q4_K_M.gguf or instructlab/merlinite-7b-pt.",
+)
+@click.option(
+    "-f",
+    "--force",
+    is_flag=True,
+    help="Used to forcefully remove a model. Use with caution as it permanently deletes the model from the storage directory without further confirmation.",
+)
+@click.option(
+    "-md",
+    "--model-dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    default=DEFAULTS.MODELS_DIR,
+    help=f"Specify the base directory for models. [default: {DEFAULTS.MODELS_DIR}]",
+)
+def remove(model: str, force: bool, model_dir: str):
+    """Remove model"""
+    try:
+        if force or click.confirm(
+            f"Are you sure you want to remove the model '{model}'?", default=False
+        ):
+            click.echo(f"Removing model: {model}.")
+            remove_model(model, model_dir)
+            click.echo(f"Model {model} has been removed.")
+        else:
+            click.secho("Aborted deletion.", fg="yellow")
+    except RemovalError as e:
+        click.secho(str(e), fg="red")
+        raise click.exceptions.Exit(1)

--- a/src/instructlab/model/remove.py
+++ b/src/instructlab/model/remove.py
@@ -1,0 +1,64 @@
+# Standard
+from pathlib import Path
+import logging
+import shutil
+
+# First Party
+from instructlab.configuration import DEFAULTS
+from instructlab.model.backends.backends import is_model_gguf, is_model_safetensors
+
+logger = logging.getLogger(__name__)
+
+
+class RemovalError(Exception):
+    """Custom exception for removal errors."""
+
+
+def remove_model(model: str, model_dir: str):
+    """Remove model and optionally clear the cache."""
+    models_dir = Path(model_dir)
+    model_path = models_dir / model
+    base_dir_str = models_dir.name + "/"
+    cache_model_path = model
+
+    # Without <username> model dir and start with models/
+    if model.startswith(base_dir_str):
+        remove_models_path = model[len(base_dir_str) :]
+        model_path = models_dir / remove_models_path
+        cache_model_path = remove_models_path
+
+    if not model_path.exists():
+        raise RemovalError(f"Model {model} does not exist in {models_dir}.")
+
+    if model_path.is_file() and is_model_gguf(model_path):
+        pass
+    elif model_path.is_dir() and is_model_safetensors(model_path):
+        # With username model dir e.g. <username>/model
+        if base_dir_str not in model:
+            username_part = model.split("/")[0]
+            username_path = models_dir / username_part
+            sub_dirs = [d for d in username_path.iterdir() if d.is_dir()]
+            if len(sub_dirs) == 1:
+                model_path = username_path
+    else:
+        raise RemovalError(
+            f"Model at {model_path} is not a valid .gguf file or safetensors model directory."
+        )
+
+    # Remove the specified file or directory.
+    try:
+        if model_path.is_file():
+            logger.debug(f"Removing model file: {model}.")
+            model_path.unlink()
+        elif model_path.is_dir():
+            logger.debug(f"Removing model directory: {model}.")
+            shutil.rmtree(model_path)
+        logger.debug(f"Model {model} has been removed.")
+
+        # Remove cache if exists
+        oci_dir = Path(DEFAULTS.OCI_DIR) / cache_model_path
+        if oci_dir.exists():
+            shutil.rmtree(oci_dir)
+            logger.debug(f"Cache for model '{model}' has been removed.")
+    except OSError as e:
+        raise RemovalError(f"Error while trying to remove {model}: {e}") from e

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,9 @@
 # Standard
+from pathlib import Path
 from unittest import mock
+import json
 import pathlib
+import struct
 
 # Third Party
 import yaml
@@ -67,3 +70,40 @@ def vllm_setup_test(runner, args, mock_popen, *_mock_args):
 def assert_tps(args, tps):
     assert args[-2] == "--tensor-parallel-size"
     assert args[-1] == tps
+
+
+def create_safetensors_model_directory(
+    directory_path: Path, model_dir_name="test_namespace/testlab_model"
+):
+    """Simulate a safetensors model directory"""
+    full_directory_path = directory_path / model_dir_name
+    full_directory_path.mkdir(parents=True, exist_ok=True)
+
+    json_data = {"key": "value"}
+    required_files = ["config.json", "tokenizer.json", "tokenizer_config.json"]
+
+    for file_name in required_files:
+        with open(full_directory_path / file_name, "w", encoding="utf-8") as f:
+            json.dump(json_data, f)
+
+    safetensors_file = full_directory_path / "test-model.safetensors"
+    # Third Party
+    from safetensors.torch import save_file
+    import torch
+
+    tensors = {
+        "tensor1": torch.randn(3, 3),
+        "tensor2": torch.randn(5, 5),
+    }
+    save_file(tensors, safetensors_file)
+
+
+def create_gguf_file(file_path: Path, gguf_file_name="test-model.gguf"):
+    """Simulate a GGUF file"""
+    GGUF_MAGIC = 0x46554747
+
+    full_file_path = file_path / gguf_file_name
+    full_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(full_file_path, "wb") as f:
+        f.write(struct.pack("<I", GGUF_MAGIC))

--- a/tests/test_lab_model_remove.py
+++ b/tests/test_lab_model_remove.py
@@ -1,0 +1,95 @@
+# Standard
+from pathlib import Path
+
+# Third Party
+from click.testing import CliRunner
+
+# First Party
+from instructlab import lab
+from tests.common import create_gguf_file, create_safetensors_model_directory
+
+
+def test_remove_dir_model(cli_runner: CliRunner, tmp_path):
+    temp_model_dir = tmp_path / "test-models"
+    temp_model_dir.mkdir(parents=True, exist_ok=True)
+    model_dir = Path(temp_model_dir)
+    create_safetensors_model_directory(model_dir)
+    model_dir_name = "test_namespace/testlab_model"
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "remove",
+            "--model",
+            model_dir_name,
+            "--force",
+            "--model-dir",
+            temp_model_dir,
+        ],
+    )
+    assert "Model test_namespace/testlab_model has been removed." in result.output
+    assert result.exit_code == 0
+
+    list_result = cli_runner.invoke(
+        lab.ilab,
+        ["--config=DEFAULT", "model", "list", "--model-dirs", temp_model_dir],
+    )
+    assert model_dir_name not in list_result.output
+    assert list_result.exit_code == 0
+
+
+def test_remove_gguf_model(cli_runner: CliRunner, tmp_path):
+    temp_model_dir = tmp_path / "test-models"
+    temp_model_dir.mkdir(parents=True, exist_ok=True)
+    gguf_file_path = Path(temp_model_dir)
+    create_gguf_file(gguf_file_path)
+    gguf_file_name = "test-model.gguf"
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "remove",
+            "--model",
+            gguf_file_name,
+            "--model-dir",
+            temp_model_dir,
+        ],
+        input="yes\n",
+    )
+    assert "Model test-model.gguf has been removed." in result.output
+    assert result.exit_code == 0
+
+    list_result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "list",
+            "--model-dirs",
+            temp_model_dir,
+        ],
+    )
+    assert gguf_file_name not in list_result.output
+    assert list_result.exit_code == 0
+
+
+def test_remove_not_exist_model(cli_runner: CliRunner, tmp_path):
+    temp_model_dir = tmp_path / "test-models"
+    temp_model_dir.mkdir(parents=True, exist_ok=True)
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "model",
+            "remove",
+            "--model",
+            "test-not-exist",
+            "--model-dir",
+            temp_model_dir,
+            "--force",
+        ],
+    )
+    assert "Model test-not-exist does not exist" in result.output
+    assert result.exit_code != 0


### PR DESCRIPTION
```
$ ilab model remove --help
Usage: ilab model remove [OPTIONS]

  Remove model

Options:
  -m, --model TEXT            Specify the model name to remove (check with
                              'ilab model list' first), e.g.,
                              merlinite-7b-lab-Q4_K_M.gguf or
                              instructlab/merlinite-7b-pt.  [required]
  -f, --force                 Used to forcefully remove a model. Use with
                              caution as it permanently deletes the model from
                              the storage directory without further
                              confirmation.
  -md, --model-dir DIRECTORY  Specify the base directory for models. [default:
                              /Users/user/.cache/instructlab/models]
  --help                      Show this message and exit.

$ ilab model remove --model
Error: Option '--model' requires an argument.

$ ilab model list
+------------------------------+---------------------+---------+
| Model Name                   | Last Modified       | Size    |
+------------------------------+---------------------+---------+
| instructlab/granite-7b-lab   | 2024-09-10 18:49:32 | 12.6 GB |
| merlinite-7b-lab-Q4_K_M.gguf | 2024-09-10 18:43:54 | 4.1 GB  |
+------------------------------+---------------------+---------+

$ ilab model remove --model merlinite-7b-lab-Q4_K_M.gguf
==> Removing model file: merlinite-7b-lab-Q4_K_M.gguf
==> Model file merlinite-7b-lab-Q4_K_M.gguf has been removed.

$ ilab model list
+----------------------------+---------------------+---------+
| Model Name                 | Last Modified       | Size    |
+----------------------------+---------------------+---------+
| instructlab/granite-7b-lab | 2024-09-10 18:49:32 | 12.6 GB |
+----------------------------+---------------------+---------+

$ ilab model remove --model xx
Error: Model xx does not exist in .........
```
