### PR TITLE
fix: report server errors for chat/generate/eval

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -387,31 +387,6 @@ test_no_chat_logs(){
         '
 }
 
-
-test_temp_server_ignore_internal_messages(){
-    # shellcheck disable=SC2016
-    expect -c '
-        set timeout 60
-        spawn ilab model chat
-        expect "Starting a temporary server at"
-        send "hello!\r"
-        sleep 5
-        send "\003"
-        expect {
-            "Disconnected from client (via refresh/close)" { exit 1 }
-        }
-        send "exit\r"
-        expect {
-            "Traceback (most recent call last):" { set exp_result 1 }
-            default { set exp_result 0 }
-        }
-        if { $exp_result != 0 } {
-            puts stderr "Error: ilab model chat command failed"
-            exit 1
-        }
-    '
-}
-
 test_server_welcome_message(){
     # test that the server welcome message is displayed
     ilab model serve --log-file serve.log &
@@ -631,8 +606,6 @@ cleanup
 test_temp_server_sigint
 cleanup
 test_no_chat_logs
-cleanup
-test_temp_server_ignore_internal_messages
 cleanup
 test_server_chat_template
 cleanup

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from contextlib import redirect_stderr, redirect_stdout
 from time import sleep
 from typing import Optional, cast
 import logging
 import multiprocessing
-import os
 import pathlib
 
 # Third Party
@@ -20,7 +18,7 @@ import llama_cpp.server.app as llama_app
 # Local
 from ...client import check_api_base
 from ...configuration import get_api_base
-from .backends import UvicornServer, get_uvicorn_config, is_temp_server_running
+from .backends import UvicornServer, get_uvicorn_config
 from .common import (
     API_ROOT_WELCOME_MESSAGE,
     CHAT_TEMPLATE_AUTO,
@@ -200,21 +198,7 @@ def server(
     )
     s = UvicornServer(config)
 
-    # If this is not the main process, this is the temp server process that ran in the background
-    # after `ilab model chat` was executed.
-    # In this case, we want to redirect stdout to null to avoid cluttering the chat with messages
-    # returned by the server.
-    if is_temp_server_running():
-        # TODO: redirect temp server logs to a file instead of hidding the logs completely
-        # Redirect stdout and stderr to null
-        with (
-            open(os.devnull, "w", encoding="utf-8") as f,
-            redirect_stdout(f),
-            redirect_stderr(f),
-        ):
-            s.run()
-    else:
-        s.run()
+    s.run()
 
     if queue:
         queue.close()

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -186,7 +186,7 @@ def chat(
     """Runs a chat using the modified model"""
     # pylint: disable=import-outside-toplevel
     # First Party
-    from instructlab.model.backends.llama_cpp import is_temp_server_running
+    from instructlab.model.backends.backends import is_temp_server_running
 
     users_endpoint_url = cfg.get_api_base(ctx.obj.config.serve.host_port)
 


### PR DESCRIPTION
When the internal server crashes, the errors will be displayed in the chat, as well as the progress logs from generate and other related commands.

Fixes: https://github.com/instructlab/instructlab/issues/889

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if nessessary.
- [ ] E2E Workflow tests have been added, if necessary.
