### PR TITLE
fix: mypy complaining about ruamel

### DIFF
--- a/src/instructlab/config/show.py
+++ b/src/instructlab/config/show.py
@@ -3,8 +3,8 @@
 import sys
 
 # Third Party
+from ruamel.yaml import YAMLError, ruamel
 import click
-import ruamel.yaml
 
 # First Party
 from instructlab import clickext, configuration
@@ -22,7 +22,7 @@ def show(ctx: click.Context) -> None:
     # TODO: make this use pretty colors like jq/yq
     try:
         commented_map = configuration.config_to_commented_map(ctx.obj.config)
-    except ruamel.yaml.YAMLError as e:
+    except YAMLError as e:
         click.secho(f"Error loading config as YAML: {e}", fg="red")
         ctx.exit(2)
     yaml.dump(commented_map, sys.stdout)


### PR DESCRIPTION
On macOS, mypy fails with:

```
src/instructlab/config/show.py:7: error: Skipping analyzing "ruamel":
module is installed, but missing library stubs or py.typed marker
[import-untyped]
```

We don't need to install the stubs. So just importing what we need makes mypy pass. Most likely because our imports are well-typed.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if nessessary.
- [ ] E2E Workflow tests have been added, if necessary.
