### PR TITLE
Ehanch gguf file check

### DIFF
--- a/src/instructlab/config/show.py
+++ b/src/instructlab/config/show.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
+
 # Standard
-import sys
 
 # Third Party
-from ruamel.yaml import YAMLError, ruamel
+from ruamel.yaml import YAMLError, ruamel, compat
 import click
+from rich.console import Console
+from rich.syntax import Syntax
 
 # First Party
 from instructlab import clickext, configuration
@@ -19,10 +21,14 @@ yaml.indent(mapping=2, sequence=4, offset=2)
 @clickext.display_params
 def show(ctx: click.Context) -> None:
     """Displays the current config as YAML"""
-    # TODO: make this use pretty colors like jq/yq
+    # use pretty colors like jq/yq
+    console = Console()
     try:
         commented_map = configuration.config_to_commented_map(ctx.obj.config)
+        stream = compat.StringIO()
+        yaml.dump(commented_map, stream)
+        syntax = Syntax(stream.getvalue(), "yaml", theme="monokai", line_numbers=True)
+        console.print(syntax)
     except YAMLError as e:
         click.secho(f"Error loading config as YAML: {e}", fg="red")
         ctx.exit(2)
-    yaml.dump(commented_map, sys.stdout)

--- a/src/instructlab/config/show.py
+++ b/src/instructlab/config/show.py
@@ -18,8 +18,9 @@ yaml.indent(mapping=2, sequence=4, offset=2)
 
 @click.command()
 @click.pass_context
+@click.option('--color', '-c', is_flag=True, help="Enable colored output.")
 @clickext.display_params
-def show(ctx: click.Context) -> None:
+def show(ctx: click.Context, color: bool) -> None:
     """Displays the current config as YAML"""
     # use pretty colors like jq/yq
     console = Console()
@@ -27,8 +28,14 @@ def show(ctx: click.Context) -> None:
         commented_map = configuration.config_to_commented_map(ctx.obj.config)
         stream = compat.StringIO()
         yaml.dump(commented_map, stream)
-        syntax = Syntax(stream.getvalue(), "yaml", theme="monokai", line_numbers=True)
-        console.print(syntax)
+        if color and console.color_system:
+            syntax = Syntax(stream.getvalue(), "yaml", theme="monokai", line_numbers=True)
+            console.print(syntax)
+        else:
+            print(stream.getvalue())
     except YAMLError as e:
         click.secho(f"Error loading config as YAML: {e}", fg="red")
         ctx.exit(2)
+    except Exception as e:
+        click.secho(f"An unexpected error occurred: {e}", fg="red")
+        ctx.exit(1)

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -95,12 +95,19 @@ def is_model_gguf(model_path: pathlib.Path) -> bool:
         with model_path.open("rb") as f:
             first_four_bytes = f.read(4)
 
-        # Convert the first four bytes to an integer
-        first_four_bytes_int = int(struct.unpack("<I", first_four_bytes)[0])
+        try:
+            # Convert the first four bytes to an integer
+            first_four_bytes_int = int(struct.unpack("<I", first_four_bytes)[0])
+        except struct.error as e:
+            logger.error(f"Failed to unpack the first four bytes of {model_path}: {e}")
+            return False
 
         return first_four_bytes_int == GGUF_MAGIC
     except IsADirectoryError as exc:
-        logger.debug(f"GGUF Path is a directory, returning {exc}")
+        logger.debug(f"GGUF Path {model_path} is a directory, returning {exc}")
+        return False
+    except Exception as exc:
+        logger.debug(f"Error reading file {model_path}: {exc}")
         return False
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves # if any invalid files under the model directory, it will fail
```
$ ilab model list
Traceback (most recent call last):
  File "/Users/riddle/ai/projects/instructlab-dev/venv/bin/ilab", line 8, in <module>
    sys.exit(ilab())
             ^^^^^^
  File "/Users/riddle/ai/projects/instructlab-dev/venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/riddle/ai/projects/instructlab-dev/venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/riddle/ai/projects/instructlab-dev-2024/venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/riddle/ai/projects/instructlab-dev-2024/venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/riddle/ai/projects/instructlab-dev/venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/riddle/ai/projects/instructlab-dev/venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/riddle/ai/projects/instructlab-dev/instructlab/src/instructlab/clickext.py", line 306, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/Users/riddle/ai/projects/instructlab-dev/instructlab/src/instructlab/model/list.py", line 41, in model_list
    if entry.is_file() and is_model_gguf(entry):
                           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/riddle/ai/projects/instructlab-dev/instructlab/src/instructlab/model/backends/backends.py", line 151, in is_model_gguf
    first_four_bytes_int = int(struct.unpack("<I", first_four_bytes)[0])
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
struct.error: unpack requires a buffer of 4 bytes
```

--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if nessessary.
- [ ] E2E Workflow tests have been added, if necessary.
