### PR TITLE
fix: Use pip to install InstructLab on container images

### DIFF
--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -14,10 +14,9 @@ RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/cu
     && export XLA_TARGET=cuda120 \
     && export XLA_FLAGS=--xla_gpu_cuda_data_dir=/usr/local/cuda
 
-ARG GIT_TAG=stable
-RUN if [[ "$(uname -m)" != "aarch64" ]]; then export CFLAGS="-mno-avx"; fi && \
-    CMAKE_ARGS="-DLLAMA_CUBLAS=on" python3.11 -m pip install -r https://raw.githubusercontent.com/instructlab/instructlab/${GIT_TAG}/requirements.txt --force-reinstall --no-cache-dir llama-cpp-python
-RUN python3.11 -m pip install git+https://github.com/instructlab/instructlab.git@${GIT_TAG}
+#RUN python3.11 -m pip install instructlab
+RUN CMAKE_ARGS="-DLLAMA_CUDA=on -DLLAMA_NATIVE=off" python3.11 -m pip install instructlab packaging wheel \
+   && python3.11 -m pip install instructlab[cuda]
 
 CMD ["/bin/bash"]
 


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

This PR addresses #2265.

What I tested:
1. Built the InstructLab image without making changes to the container file - it worked and installed ilab 0.18.4. I tried using `torch.cuda.is_enabled()` but it returned False.
2. Changed the container file to use pip and was able to spin up a container to verify that the ilab version instaleld was 0.18.4.

A couple of questions:
1. Are there any tests I need to run on the image?
2. I have removed the conditional to install `llama-cpp-python` with CUBLAS. Is this done by the pip installation, or would I need to find a way to get the InstructLab version being installed from pip to force the `llama-cpp-python` reinstall?
3. Does the "type" of the commit message sound right?

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if nessessary.
- [ ] E2E Workflow tests have been added, if necessary.
