### PR TITLE
add sys prompt to config

### DIFF
--- a/src/instructlab/cli/model/chat.py
+++ b/src/instructlab/cli/model/chat.py
@@ -154,6 +154,11 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     help="Disable decorations for chat responses.",
 )
+@click.option(
+    "--system-prompt",
+    type=click.STRING,
+    cls=clickext.ConfigOption,
+)
 @click.pass_context
 @clickext.display_params
 def chat(
@@ -180,6 +185,7 @@ def chat(
     embedding_model_path,
     top_k,
     no_decoration,
+    system_prompt,
 ):
     """Runs a chat using the modified model"""
 
@@ -219,6 +225,7 @@ def chat(
         embedding_model_path,
         top_k,
         no_decoration,
+        system_prompt,
         backend_type=ctx.obj.config.serve.server.backend_type,
         host=ctx.obj.config.serve.server.host,
         port=ctx.obj.config.serve.server.port,

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -184,6 +184,10 @@ class _chat(BaseModel):
         default=1.0,
         description="Controls the randomness of the model's responses. Lower values make the output more deterministic, while higher values produce more random results.",
     )
+    system_prompt: Optional[str] = Field(
+        default=None,
+        description="Custom system prompt. If not provided, it will use the default context.",
+    )
 
 
 class _serve_vllm(BaseModel):

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -589,6 +589,7 @@ def chat_model(
     embedding_model_path,
     top_k,
     no_decoration,
+    system_prompt,
     backend_type,
     host,
     port,
@@ -764,6 +765,7 @@ def chat_model(
             backend_type=backend_type,
             params=params,
             no_decoration=no_decoration,
+            system_prompt=system_prompt,
         )
     except ChatException as exc:
         print(f"{RED}Executing chat failed with: {exc}{RESET}")
@@ -794,6 +796,7 @@ def chat_cli(
     visible_overflow,
     params,
     no_decoration,
+    system_prompt,
 ):
     """Starts a CLI-based chat with the server"""
     client = OpenAI(
@@ -828,7 +831,12 @@ def chat_cli(
         logger.info(f"Context {context} not found in the config file. Using default.")
         context = "default"
     loaded["name"] = context
-    sys_prompt = CONTEXTS.get(context, "default")(get_model_arch(pathlib.Path(model)))
+    if system_prompt:
+        sys_prompt = system_prompt
+    else:
+        sys_prompt = CONTEXTS.get(context, "default")(
+            get_model_arch(pathlib.Path(model))
+        )
     loaded["messages"] = [{"role": "system", "content": sys_prompt}]
 
     # Instantiate retriever if RAG is enabled

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -19,6 +19,9 @@ chat:
   # Filepath of a dialog session file.
   # Default: None
   session:
+  # Custom system prompt. If not provided, it will use the default context.
+  # Default: None
+  system_prompt:
   # Controls the randomness of the model's responses. Lower values make the output
   # more deterministic, while higher values produce more random results.
   # Default: 1.0


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

```
$ ilab model chat --help
Usage: ilab model chat [OPTIONS] [QUESTION]...

  Runs a chat using the modified model

Options:
  --system-prompt TEXT            Custom system prompt. If not provided, it
                                  will use the default context. [default:
                                  <None>; config: 'chat.system_prompt']
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if nessessary.
- [ ] E2E Workflow tests have been added, if necessary.

Easy updates: can change the system prompt without touching the code.
Customization: Users can set their own prompt to fit different needs.
Consistency: Ensures the same prompt is used everywhere.
Flexibility: Prepares for future use of multiple prompts.
Better organization: Keeps settings separate from the code.
