### PR TITLE
Defer running tests until linting workflows successfully complete

### DIFF
--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -30,9 +30,33 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
 jobs:
+  e2e-ready:
+    permissions:
+      checks: read
+    uses: ./.github/workflows/status-checks.yml
+    with:
+      job_names: >- # Space-separated job names to wait on for status checks
+        DCO
+        actionlint
+        markdown-lint
+        shellcheck
+        spellcheck
+        lint-workflow-complete
+
   start-runner:
     name: Start external EC2 runner
+    needs: ["e2e-ready"]
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Status Checks Reusable Workflow
+
+on:
+  workflow_call:
+    inputs:
+      job_names:
+        description: 'Space-separated job names to wait on for status checks'
+        required: true
+        type: string
+      delay:
+        description: 'Period in seconds to wait before first poll of GitHub Check Runs'
+        required: false
+        type: number
+        default: 0
+      interval:
+        description: 'Interval or period in seconds between polling GitHub Check Runs'
+        required: false
+        type: number
+        default: 10
+      timeout:
+        description: 'Timeout in seconds to complete polling GitHub Check Runs'
+        required: false
+        type: number
+        default: 3600
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  checks: read
+
+jobs:
+  status-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - name: "Set status check variables"
+        id: set_variables
+        run: |
+          echo "match_pattern=$(jq -nr '[$ARGS.positional | .[] | split("\\s"; null) | map(select(. != ""))] | flatten | join("|")' --args "${{ inputs.job_names }}")" >> "$GITHUB_OUTPUT"
+
+      - name: "Wait for status checks"
+        uses: poseidon/wait-for-status-checks@6988432d64ad3f9c2608db4ca16fded1b7d36ead # v0.5.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          match_pattern: ${{ steps.set_variables.outputs.match_pattern }}
+          ignore_pattern: '/ ${{ github.job }}' # use pattern to ignore this nested job
+          delay: ${{ inputs.delay }}
+          interval: ${{ inputs.interval }}
+          timeout: ${{ inputs.timeout }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,22 @@ permissions:
   contents: read
 
 jobs:
+  test-ready:
+    permissions:
+      checks: read
+    uses: ./.github/workflows/status-checks.yml
+    with:
+      job_names: >- # Space-separated job names to wait on for status checks
+        DCO
+        actionlint
+        markdown-lint
+        shellcheck
+        spellcheck
+        lint-workflow-complete
+
   test:
     name: "${{ matrix.python }} on ${{ matrix.platform }}"
+    needs: ["test-ready"]
     runs-on: "${{ matrix.platform }}"
     strategy:
       matrix:
@@ -144,6 +158,7 @@ jobs:
           pip cache remove llama_cpp_python
 
   docs:
+    needs: ["test-ready"]
     runs-on: ubuntu-latest
     steps:
       - name: "Harden Runner"


### PR DESCRIPTION
We use a reusable workflow to enable a workflow to wait for jobs in other workflows to complete successfully. If the jobs fail or do not complete in the timeout period, the reusable workflow's job will fail.

**Issue resolved by this Pull Request:**
Resolves #2245

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if nessessary.
- [ ] E2E Workflow tests have been added, if necessary.
