### PR TITLE
add .bin support to `ilab model download`

### DIFF
--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -80,8 +80,8 @@ class HFDownloader(Downloader):
             if self.ctx.obj is not None:
                 hf_logging.set_verbosity(self.ctx.obj.config.general.log_level.upper())
             files = list_repo_files(repo_id=self.repository, token=self.hf_token)
-            if any(".safetensors" in fname for fname in files):
-                self.download_safetensors()
+            if any(re.search(r"\.(safetensors|bin)$", fname) for fname in files):
+                self.download_entire_hf_repo()
             else:
                 self.download_gguf()
 
@@ -109,7 +109,7 @@ class HFDownloader(Downloader):
             )
             raise click.exceptions.Exit(1)
 
-    def download_safetensors(self) -> None:
+    def download_entire_hf_repo(self) -> None:
         try:
             local_dir = os.path.join(self.download_dest, self.repository)
             os.makedirs(name=local_dir, exist_ok=True)


### PR DESCRIPTION
if an HF repo doesn't have .safetensors, just .bin, `ilab model download` should still understand that it needs to download the entire repo.

add support for downloading .bin models

resolves #2022

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
