### PR TITLE
Begin decoupling listing logic from model list implementation

### DIFF
--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -18,7 +18,7 @@ from instructlab import clickext
 from instructlab.model.backends import backends
 
 # Local
-from ..utils import http_client
+from ..utils import http_client, is_model_gguf, is_model_safetensors
 
 logger = logging.getLogger(__name__)
 
@@ -118,9 +118,9 @@ def validate_model(model: str, model_arg: str = "--model"):
         model_path = pathlib.Path(model)
         valid_model = False
         if model_path.is_dir():
-            valid_model = backends.is_model_safetensors(model_path)
+            valid_model = is_model_safetensors(model_path)
         elif model_path.is_file():
-            valid_model = backends.is_model_gguf(model_path)
+            valid_model = is_model_gguf(model_path)
         if not valid_model:
             click.secho(
                 f"Evaluate '{model_arg}' needs to be passed either a safetensors directory or a GGUF file",

--- a/src/instructlab/model/list.py
+++ b/src/instructlab/model/list.py
@@ -2,9 +2,8 @@
 
 # Standard
 from pathlib import Path
+from typing import List
 import logging
-import os
-import time
 
 # Third Party
 import click
@@ -12,8 +11,7 @@ import click
 # First Party
 from instructlab import clickext
 from instructlab.configuration import DEFAULTS
-from instructlab.model.backends.backends import is_model_gguf, is_model_safetensors
-from instructlab.utils import convert_bytes_to_proper_mag, print_table
+from instructlab.utils import list_models, print_table
 
 logger = logging.getLogger(__name__)
 
@@ -32,102 +30,11 @@ logger = logging.getLogger(__name__)
     help="Also list checkpoints [in addition to existing models].",
     is_flag=True,
 )
-def model_list(model_dirs: list[str], list_checkpoints: bool):
+def model_list(model_dirs: List[str], list_checkpoints: bool):
     """Lists models"""
     # click converts lists into tuples when using multiple
-    model_dirs = list(model_dirs)
-    # if we want to list checkpoints, add that dir to our list
-    if list_checkpoints:
-        model_dirs.append(DEFAULTS.CHECKPOINTS_DIR)
-    data = []
-    for directory in model_dirs:
-        for entry in Path(directory).iterdir():
-            # if file, just tally the size. This must be a GGUF.
-            if entry.is_file() and is_model_gguf(entry):
-                model, age, size = _analyze_gguf(entry)
-                data.append([model, age, size])
-            elif entry.is_dir():
-                for m in _analyze_dir(
-                    entry,
-                    list_checkpoints,
-                    directory,
-                ):
-                    data.append(m)
-    print_table(["Model Name", "Last Modified", "Size"], data)
+    model_path_dirs = [Path(m) for m in model_dirs]
 
-
-# convert_bytes_to_proper_mag takes a dir/file size in Bytes and converts it to the proper Magnitude (MiB, GiB)
-
-
-AnalyzeResultGGUF = list[str]
-AnalyzeResultDir = list[list[str]]
-
-
-def _analyze_gguf(entry: Path) -> AnalyzeResultGGUF:
-    # stat the gguf, add it to the table
-    stat = Path(entry.absolute()).stat(follow_symlinks=False)
-    f_size = stat.st_size
-    adjusted_size, magnitude = convert_bytes_to_proper_mag(f_size)
-    # add to table
-    modification_time = os.path.getmtime(entry.absolute())
-    modification_time_readable = time.strftime(
-        "%Y-%m-%d %H:%M:%S", time.localtime(modification_time)
-    )
-    return [entry.name, modification_time_readable, f"{adjusted_size:.1f} {magnitude}"]
-
-
-def _analyze_dir(
-    entry: Path, list_checkpoints: bool, directory: str
-) -> AnalyzeResultDir:
-    actual_model_name = ""
-    all_files_sizes = 0
-    add_model = False
-    models = []
-    # walk entire dir.
-    for root, _, files in os.walk(entry.as_posix()):
-        normalized_path = os.path.normpath(root)
-        # Split the path into its components
-        parts = normalized_path.split(os.sep)
-        # Get the last two or three (for checkpoints) parts and join them back into a path
-        printed_parts = os.path.join(parts[-2], parts[-1])
-        if directory == DEFAULTS.CHECKPOINTS_DIR:
-            printed_parts = os.path.join(parts[-3], parts[-2], parts[-1])
-        # if this is a dir it could be:
-        # top level repo dir `instructlab/`
-        # top level model dir `instructlab/granite-7b-lab`
-        # checkpoint top level dir `step-19`
-        # any lower level dir: `instructlab/granite-7b-lab/.huggingface/download.....`
-        # so, check if model is valid Safetensor, GGUF, or list it regardless w/ `--list-checkpoints`
-        # if --list-checkpoints is specified, we will list all checkpoints in the checkpoints dir regardless of the validity
-        if is_model_safetensors(Path(normalized_path)) or is_model_gguf(
-            Path(normalized_path)
-        ):
-            actual_model_name = printed_parts
-            all_files_sizes = 0
-            add_model = True
-        else:
-            if list_checkpoints and directory is DEFAULTS.CHECKPOINTS_DIR:
-                logging.debug("Including model regardless of model validity")
-            else:
-                continue
-        for f in files:
-            # stat each file in the dir, add the size in Bytes, then convert to proper magnitude
-            full_file = os.path.join(root, f)
-            # follow symlinks. We need to do this for OCI registry models
-            stat = Path(full_file).stat(follow_symlinks=True)
-            all_files_sizes += stat.st_size
-        adjusted_all_sizes, magnitude = convert_bytes_to_proper_mag(all_files_sizes)
-        if add_model:
-            # add to table
-            modification_time = os.path.getmtime(entry.absolute())
-            modification_time_readable = time.strftime(
-                "%Y-%m-%d %H:%M:%S", time.localtime(modification_time)
-            )
-            models.append(
-                [
-                    actual_model_name,
-                    modification_time_readable,
-                    f"{adjusted_all_sizes:.1f} {magnitude}",
-                ]
-            )
-    return models
+    data = list_models(model_path_dirs, list_checkpoints)
+    data_as_lists = [list(item) for item in data]  # this is to satisfy mypy
+    print_table(["Model Name", "Last Modified", "Size"], data_as_lists)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -15,6 +15,7 @@ import pytest
 from instructlab import lab
 from instructlab.model.backends import backends, common
 from instructlab.model.backends.vllm import build_vllm_cmd
+from instructlab.utils import is_model_safetensors
 
 
 # helper function to create dummy valid and invalid safetensor or bin model directories
@@ -106,7 +107,7 @@ def test_is_model_safetensors_or_bin_valid(
     model_path = tmp_path / model_dir
     create_safetensors_or_bin_model_files(model_path, model_file_type, expected)
 
-    val = backends.is_model_safetensors(model_path)
+    val = is_model_safetensors(model_path)
     assert val == expected
 
 


### PR DESCRIPTION
We currently handle all operations within the implementations of the CLI commands
themselves. This commit begins to refactor this by moving the implementation of
ilab model list to have the raw machinery exist in a seperate module named `machinery`

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
