### PR TITLE
feat: make flash-attention toggle a first-class option

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -448,6 +448,10 @@ class _train(BaseModel):
         default=1,
         description="Number of GPUs to use for training. This value is not supported in legacy training or MacOS.",
     )
+    disable_flash_attn: Optional[bool] = Field(
+        default=False,
+        description="Whether or not we should disable the use of flash-attention during training. This is useful when using older GPUs.",
+    )
     additional_args: dict[str, typing.Any] = Field(
         default_factory=dict,
         description="Additional arguments to pass to the training script. These arguments are passed as key-value pairs to the training script.",

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -296,6 +296,7 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     config_sections=ADDITIONAL_ARGUMENTS,
     required=True,  # default from config
 )
+@click.option("--disable-flash-attn", is_flag=True, cls=clickext.ConfigOption)
 @click.option(
     "--strategy",
     type=click.Choice(

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -264,6 +264,10 @@ train:
   # Allow CPU offload for deepspeed optimizer.
   # Default: False
   deepspeed_cpu_offload_optimizer: false
+  # Whether or not we should disable the use of flash-attention during training.
+  # This is useful when using older GPUs.
+  # Default: False
+  disable_flash_attn: false
   # Pick a distributed training backend framework for GPU accelerated full fine-
   # tuning.
   # Default: deepspeed


### PR DESCRIPTION
Previously, the `disable_flash_attn` training flag was set as an additional argument that was hidden
away. However; we run into problems when running E2E testing in training where it cannot run on a T4
system (Volta GPU). This commit resolves that issue by promoting `disable_flash_attn` as a
first-class argument that can be passed as a CLI argument

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
