### PR TITLE
docs: Fix line break issue in Mermaid diagram in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ After you have added knowledge and skills to the taxonomy, you can perform the f
 graph TD;
   download-->chat
   chat[Chat with the LLM]-->add
-  add[Add new knowledge\nor skill to taxonomy]-->generate[generate new\nsynthetic training data]
+  add[Add new knowledge<br/>or skill to taxonomy]-->generate[generate new<br/>synthetic training data]
   generate-->train
-  train[Re-train]-->|Chat with\nthe re-trained LLM\nto see the results|chat
+  train[Re-train]-->|Chat with<br/>the re-trained LLM<br/>to see the results|chat
+
 ```
 
 For an overview of the full workflow, see the [workflow diagram](./docs/workflow.png).


### PR DESCRIPTION
This Pull Request fixes the line break issue in the Mermaid diagram within the README.md file. The `\n` has been replaced with `<br/>` to ensure proper rendering of line breaks in the diagram.