### PR TITLE
fix:mmlu_branch external serving not using base model

### DIFF
--- a/src/instructlab/model/evaluate.py
+++ b/src/instructlab/model/evaluate.py
@@ -738,13 +738,14 @@ def evaluate(
             m_paths = [model, base_model]
             overall_scores = []
             individual_scores_list = []
-            for evaluator in evaluators:
+            for i, evaluator in enumerate(evaluators):
+                m_path = m_paths[i]
                 server = None
                 try:
                     server, api_base = launch_server(
                         ctx,
-                        model,
-                        model,
+                        m_path,
+                        m_path,
                         None,
                         gpus,
                         backend,


### PR DESCRIPTION
As part of adding external serving for mmlu, the model_paths list wasn't being referenced as it should and was always passing the new model.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
