### PR TITLE
fix full_train.py

### DIFF
--- a/src/instructlab/model/full_train.py
+++ b/src/instructlab/model/full_train.py
@@ -71,7 +71,6 @@ def train(train_args, device):
             effective_batch_size=train_args.effective_batch_size,
             max_batch_len_per_gpu=train_args.max_batch_len,
             is_padding=train_args.is_padding_free,
-            pad_id=tokenizer.pad_token_id,
             dataset=dataset,
             seed=47,
         )


### PR DESCRIPTION
find_packing_max_batch_len_and_grad_accum used to take pad_id, with 0.5.0 in the training library, this has been removed. Change full_train.py accordingly

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
