### PR TITLE
add repository and release option to the config

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -3,7 +3,7 @@
 # Standard
 from os import path
 from re import match
-from typing import Any, Optional, Union
+from typing import Any, List, Optional, Union
 import enum
 import logging
 import os
@@ -525,6 +525,19 @@ class _train(BaseModel):
     )
 
 
+class _download(BaseModel):
+    """Class describing configuration of the 'download' sub-command."""
+
+    repositories: List[str] = Field(
+        default=[DEFAULTS.MERLINITE_GGUF_REPO, DEFAULTS.MISTRAL_GGUF_REPO],
+        description="Hugging Face or OCI repository of the model to download",
+    )
+    releases: List[str] = Field(
+        default=["main", "main"],
+        description="The revision of the model to download, e.g. a branch, tag, or commit hash for Hugging Face repositories and tag or commit hash for OCI repositories.",
+    )
+
+
 class Config(BaseModel):
     """Configuration for the InstructLab CLI.
     Config options are defined by the respective subclasses and are loaded into a single 'Config' object here
@@ -563,6 +576,10 @@ class Config(BaseModel):
         default=CONFIG_VERSION,
         description="Configuration file structure version.",
         frozen=True,  # don't allow this to be changed anywhere in the code
+    )
+    # download configuration
+    download: _download = Field(
+        default_factory=_download, description="Download configuration section."
     )
 
 

--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -256,24 +256,14 @@ class OCIDownloader(Downloader):
     "-rp",
     "repositories",
     multiple=True,
-    default=[
-        DEFAULTS.MERLINITE_GGUF_REPO,
-        DEFAULTS.MISTRAL_GGUF_REPO,
-    ],  # TODO: add to config.yaml
-    show_default=True,
-    help="Hugging Face or OCI repository of the model to download.",
+    cls=clickext.ConfigOption,
 )
 @click.option(
     "--release",
     "-rl",
     "releases",
     multiple=True,
-    default=[
-        "main",
-        "main",
-    ],  # TODO: add to config.yaml
-    show_default=True,
-    help="The revision of the model to download - e.g. a branch, tag, or commit hash for Hugging Face repositories and tag or commit hash for OCI repositories.",
+    cls=clickext.ConfigOption,
 )
 @click.option(
     "--filename",

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -28,6 +28,19 @@ chat:
   # Renders vertical overflow if enabled, displays ellipses otherwise.
   # Default: True
   visible_overflow: true
+# Download configuration section.
+download:
+  # The revision of the model to download, e.g. a branch, tag, or commit hash for
+  # Hugging Face repositories and tag or commit hash for OCI repositories.
+  # Default: ['main', 'main']
+  releases:
+    - main
+    - main
+  # Hugging Face or OCI repository of the model to download
+  # Default: ['instructlab/merlinite-7b-lab-GGUF', 'TheBloke/Mistral-7B-Instruct-v0.2-GGUF']
+  repositories:
+    - instructlab/merlinite-7b-lab-GGUF
+    - TheBloke/Mistral-7B-Instruct-v0.2-GGUF
 # Evaluate configuration section.
 evaluate:
   # Base taxonomy branch


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

In `download` sub-cmd, add the values of `--repository` and `--release` options to config
```
@click.command()
@click.option(
    "--repository",
    default=DEFAULTS.MERLINITE_GGUF_REPO,  # TODO: add to config.yaml
    show_default=True,
    help="Hugging Face or OCI repository of the model to download.",
)
@click.option(
    "--release",
    default="main",  # TODO: add to config.yaml
    show_default=True,
    help="The revision of the model to download - e.g. a branch, tag, or commit hash for Hugging Face repositories and tag or commit hash for OCI repositories.",
)

```

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
