### PR TITLE
chore: rename distributed_training_backend -> distributed_backend

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -426,7 +426,7 @@ class _train(BaseModel):
     fsdp_cpu_offload_optimizer: bool = Field(
         default=False, description="Allow CPU offload for FSDP optimizer."
     )
-    distributed_training_backend: DistributedBackend = Field(
+    distributed_backend: DistributedBackend = Field(
         default=DistributedBackend.DEEPSPEED,
         description="Pick a distributed training backend framework for GPU accelerated full fine-tuning.",
         validate_default=True,  # ensures that the 'use_enum_values' flag takes effect on the default value
@@ -1301,9 +1301,7 @@ def map_train_to_library(ctx, params):
 
     train_args.deepspeed_options = ds_args
     train_args.fsdp_options = fsdp_args
-    train_args.distributed_backend = DistributedBackend(
-        params["distributed_training_backend"]
-    )
+    train_args.distributed_backend = DistributedBackend(params["distributed_backend"])
     train_args.lora = lora_args
     if params["pipeline"] == "full":
         train_args.disable_flash_attn = True

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -221,7 +221,7 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     cls=clickext.ConfigOption,
 )
 @click.option(
-    "--distributed-training-backend",
+    "--distributed-backend",
     type=str,
     cls=clickext.ConfigOption,
 )
@@ -420,7 +420,7 @@ def train(
     pipeline: str,
     training_journal: pathlib.Path | None,
     force_clear_phased_cache: bool,
-    distributed_training_backend,
+    distributed_backend,
     **kwargs,
 ):
     """
@@ -514,12 +514,11 @@ def train(
 
     if strategy == SupportedTrainingStrategies.LAB_MULTIPHASE.value:
         if (
-            distributed_training_backend
-            and distributed_training_backend
-            not in DistributedBackend._value2member_map_
+            distributed_backend
+            and distributed_backend not in DistributedBackend._value2member_map_
         ):
             raise ctx.fail(
-                f"Invalid training backend option '{distributed_training_backend}' specified. Please specify either `fsdp` or `deepspeed`"
+                f"Invalid training backend option '{distributed_backend}' specified. Please specify either `fsdp` or `deepspeed`"
             )
 
         # pull the trainrandom.randinting and torch args from the flags

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -267,7 +267,7 @@ train:
   # Pick a distributed training backend framework for GPU accelerated full fine-
   # tuning.
   # Default: deepspeed
-  distributed_training_backend: deepspeed
+  distributed_backend: deepspeed
   # The number of samples in a batch that the model should see before its parameters
   # are updated.
   # Default: 3840


### PR DESCRIPTION
To promote consistency in documentation between the CLI and the training library, this PR
updates the named of the parameter responsible for selecting between FSDP & deepspeed to
"distributed_backend", since it is already assumed to be a part of training, this
eliminates redundancy.

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
