### PR TITLE
ci: remove cuda image build for "stable" tag

### DIFF
--- a/.github/workflows/image-cuda.yml
+++ b/.github/workflows/image-cuda.yml
@@ -18,46 +18,8 @@ on:
 
 # Note that the current containerfile builds against a git ref.
 # It is not built against the current source tree. So, we test
-# build the image against `stable` and `main` if the file changes.
+# build the image against `main` if the file changes.
 jobs:
-  build_cuda_image_stable:
-    name: Build CUDA image for stable
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Harden Runner"
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-      - name: "Checkout"
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-
-      - name: Free disk space
-        uses: ./.github/actions/free-disk-space
-
-      - uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
-
-      - name: Extract metadata (tags, labels) for gotbot image
-        id: gobot_meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}/instructlab-cuda
-
-      - name: Build and push gobot image
-        uses: docker/build-push-action@32945a339266b759abcbdc89316275140b0fc960 # v6.8.0
-        with:
-          context: .
-          platforms: linux/amd64
-          build-args: |
-            GIT_TAG=stable
-          push: false
-          tags: ${{ steps.gobot_meta.outputs.tags }}
-          labels: ${{ steps.gobot_meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          file: containers/cuda/Containerfile
-
   build_cuda_image_main:
     name: Build CUDA image for main
     runs-on: ubuntu-latest


### PR DESCRIPTION
we no longer maintain the stable tag, ergo we
should no longer build it as part of this CI job

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
