### PR TITLE
fix: stabilize checkpoint selection logic

### DIFF
--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -1163,7 +1163,11 @@ def _run_phased_training(
             )
 
         phase1_checkpoints = sorted(
-            list(phase1_checkpoints_dir_hf.iterdir()), reverse=True
+            list(phase1_checkpoints_dir_hf.iterdir()),
+            reverse=True,
+            # XXX(osilkin): This line takes the checkpoint name "samples_NNN" and tells sorted
+            #               to use the last NNN string as an integer
+            key=lambda x: int(str(x).rsplit("_", maxsplit=1)[-1]),
         )
 
         if len(phase1_checkpoints) == 0:


### PR DESCRIPTION
The current implementation of checkpoint selection has a bug which is a result of the `sorted` function
not being able to correctly compare strings which all have an equal prefix and a numeric suffix.
This commit fixes that bug by explicitly telling `sorted` how to perform the comparison between items.

Fixes #2362 

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
