### PR TITLE
chore: remove out-of-date runner config file and lint trigger

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,0 @@
-self-hosted-runner:
-  labels:
-  - ubuntu-gpu

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,6 @@ on:
       - 'requirements*.txt'
       - 'tox.ini'
       - .pylintrc
-      - 'scripts/*.sh' # Used by this workflow
       - '.github/workflows/lint.yml' # This workflow
   pull_request:
     branches:
@@ -25,7 +24,6 @@ on:
       - 'requirements*.txt'
       - 'tox.ini'
       - .pylintrc
-      - 'scripts/*.sh' # Used by this workflow
       - '.github/workflows/lint.yml' # This workflow
 
 env:


### PR DESCRIPTION
- we used to use a self-hosted github gpu runner, this runner is no longer used, thus we can safely remove this config file
- the lint workflow used to use a 'ruff.sh' script, this is no longer the case, ergo we no longer need to trigger under this condition

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
