### PR TITLE
fix: allow skopeo copy output to show up on terminal

### DIFF
--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -220,10 +220,10 @@ class OCIDownloader(Downloader):
         logger.debug(f"Running skopeo command: {command}")
 
         try:
-            subprocess.run(command, check=True, capture_output=True, text=True)
+            subprocess.run(command, check=True, text=True)
         except subprocess.CalledProcessError as e:
             click.secho(
-                f"Failed to run skopeo command: {e}.\nstdout: {e.stdout}.\nstderr: {e.stderr}",
+                f"Failed to run skopeo command: {e}. \nstderr: {e.stderr}",
                 fg="red",
             )
             raise click.exceptions.Exit(1)


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

Removes `check_output=true` when running the skopeo downlaod as a subprocess to allow its output to show up on the terminal

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
