### PR TITLE
fix: AMD should not trigger auto detection

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -220,7 +220,7 @@ def hw_auto_detect() -> tuple[str | None, int | None, _train, bool]:
     gpu_name = ""
     edited_cfg = False
     # try nvidia
-    if torch.cuda.is_available():
+    if torch.cuda.is_available() and torch.version.hip is None:
         click.echo("Detecting Hardware...")
         gpus = torch.cuda.device_count()
         for i in range(gpus):


### PR DESCRIPTION
due to ROCM's translation layer w/ CUDA, the torch.cuda.is_available() check evaluates to true. Since we don't have profiles for AMD yet, this code should not try to match the hw to an existing profile

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
