### PR TITLE
train profile auto detection uses values from code not disk

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -15,11 +15,11 @@ import click
 from instructlab import clickext, utils
 from instructlab.configuration import (
     DEFAULTS,
-    PROFILE_MAPPINGS,
     Config,
     _train,
     ensure_storage_directories_exist,
     get_default_config,
+    get_profile_mappings,
     read_config,
     read_train_profile,
     recreate_train_profiles,
@@ -227,6 +227,7 @@ def hw_auto_detect() -> tuple[str | None, int | None, _train, bool]:
             properties = torch.cuda.get_device_properties(i)
             gpu_name = properties.name
             total_vram += properties.total_memory  # memory in B
+
     vram = int(floor(convert_bytes_to_proper_mag(total_vram)[0]))
     if vram == 0:
         return None, None, train, False
@@ -245,7 +246,7 @@ def hw_auto_detect() -> tuple[str | None, int | None, _train, bool]:
 def lookup_card(
     gpu_name, gpu_count, vram
 ) -> tuple[bool, int | None, str | None, _train]:
-    profiles = PROFILE_MAPPINGS
+    profiles = get_profile_mappings()
     card_entry = profiles.get(gpu_name)
     chosen_profile_name = None
     if card_entry is not None:
@@ -268,7 +269,8 @@ def match_profile_based_on_vram(vram) -> tuple[int | None, str | None, _train]:
     chosen_profile_name = None
     chosen_vram = None
     train = _train()
-    for group_gpu_name, list_of_count_vram_and_config in PROFILE_MAPPINGS.items():
+    profiles = get_profile_mappings()
+    for group_gpu_name, list_of_count_vram_and_config in profiles.items():
         for gpu_count_configs in list_of_count_vram_and_config:
             if (
                 not isinstance(gpu_count_configs["gpu_count"], int)

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -844,6 +844,16 @@ SINGLE_A100_H100 = _train(
 )
 
 
+TRAIN_DIR_EXPECTED_FILES = {
+    "A100_H100_x8.yaml",
+    "A100_H100_x4.yaml",
+    "A100_H100_x2.yaml",
+    "L40_x8.yaml",
+    "L40_x4.yaml",
+    "L4_x8.yaml",
+}
+
+
 def get_default_config() -> Config:
     """Generates default configuration for CLI"""
     return Config()
@@ -1131,15 +1141,6 @@ def ensure_storage_directories_exist() -> bool:
 
 # recreate_train_profiles creates all train profiles in the proper directory and takes an argument, overwrite, which will write to the files even if they already exist
 def recreate_train_profiles(overwrite: bool = False) -> bool:
-    TRAIN_DIR_EXPECTED_FILES = {
-        "A100_H100_x8.yaml",
-        "A100_H100_x4.yaml",
-        "A100_H100_x2.yaml",
-        "L40_x8.yaml",
-        "L40_x4.yaml",
-        "L4_x8.yaml",
-    }
-
     fresh_install = False
     profile_dir = os.environ.get(DEFAULTS.ILAB_TRAIN_PROFILE_DIR)
     if profile_dir != "" and profile_dir is not None:
@@ -1354,52 +1355,91 @@ def storage_dirs_exist() -> bool:
     return all(os.path.exists(dirpath) for dirpath in dirs_to_check)
 
 
+# get_profile_mappings reads the profiles from disk where necessary and returns a mapping of the following format
 # {"GPU Name": ({ "gpu_count": NUM_GPUS, "vram_and_config": {"vram": TOTAL_VRAM, "config": TRAIN_CONFIG}})...}
-PROFILE_MAPPINGS = {
-    "L40s": (
-        {"gpu_count": 1, "vram_and_config": {"vram": 80, "config": SINGLE_L40}},
-        {
-            "gpu_count": 4,
-            "vram_and_config": {"vram": 192, "config": FOUR_L_FORTY_GPU},
-        },
-        {
-            "gpu_count": 8,
-            "vram_and_config": {"vram": 384, "config": EIGHT_L_FORTY_GPU},
-        },
-    ),
-    "L4": (
-        {"gpu_count": 1, "vram_and_config": {"vram": 24, "config": SINGLE_L4}},
-        {
-            "gpu_count": 8,
-            "vram_and_config": {"vram": 192, "config": EIGHT_L_FOUR_GPU},
-        },
-    ),
-    "A100": (
-        {
-            "gpu_count": 2,
-            "vram_and_config": {"vram": 160, "config": TWO_GPU_TRAIN_AH},
-        },
-        {
-            "gpu_count": 4,
-            "vram_and_config": {"vram": 320, "config": FOUR_GPU_TRAIN_AH},
-        },
-        {
-            "gpu_count": 8,
-            "vram_and_config": {"vram": 640, "config": EIGHT_GPU_TRAIN_AH},
-        },
-    ),
-    "H100": (
-        {
-            "gpu_count": 2,
-            "vram_and_config": {"vram": 160, "config": TWO_GPU_TRAIN_AH},
-        },
-        {
-            "gpu_count": 4,
-            "vram_and_config": {"vram": 320, "config": FOUR_GPU_TRAIN_AH},
-        },
-        {
-            "gpu_count": 8,
-            "vram_and_config": {"vram": 640, "config": EIGHT_GPU_TRAIN_AH},
-        },
-    ),
-}
+def get_profile_mappings() -> dict[str, tuple[dict[str, object], ...]]:
+    # read the train cfg from disk, and use what is here to build the mappings.
+    profile_names_and_configs = {}
+    for file in TRAIN_DIR_EXPECTED_FILES:
+        cfg_file = os.path.join(DEFAULTS.TRAIN_PROFILE_DIR, file)
+        train_cfg = read_train_profile(cfg_file)
+        # make a dict mapping file names to train cfgs
+        # we need to do this so that if the user overrode the contents of the profiles using the ENV var, we apply that when auto detecting
+        profile_names_and_configs[file] = train_cfg
+
+    profile_mappings = {
+        "L40s": (
+            {"gpu_count": 1, "vram_and_config": {"vram": 80, "config": SINGLE_L40}},
+            {
+                "gpu_count": 4,
+                "vram_and_config": {
+                    "vram": 192,
+                    "config": profile_names_and_configs["L40_x4.yaml"],
+                },
+            },
+            {
+                "gpu_count": 8,
+                "vram_and_config": {
+                    "vram": 384,
+                    "config": profile_names_and_configs["L40_x8.yaml"],
+                },
+            },
+        ),
+        "L4": (
+            {"gpu_count": 1, "vram_and_config": {"vram": 24, "config": SINGLE_L4}},
+            {
+                "gpu_count": 8,
+                "vram_and_config": {
+                    "vram": 192,
+                    "config": profile_names_and_configs["L4_x8.yaml"],
+                },
+            },
+        ),
+        "A100": (
+            {
+                "gpu_count": 2,
+                "vram_and_config": {
+                    "vram": 160,
+                    "config": profile_names_and_configs["A100_H100_x2.yaml"],
+                },
+            },
+            {
+                "gpu_count": 4,
+                "vram_and_config": {
+                    "vram": 320,
+                    "config": profile_names_and_configs["A100_H100_x4.yaml"],
+                },
+            },
+            {
+                "gpu_count": 8,
+                "vram_and_config": {
+                    "vram": 640,
+                    "config": profile_names_and_configs["A100_H100_x8.yaml"],
+                },
+            },
+        ),
+        "H100": (
+            {
+                "gpu_count": 2,
+                "vram_and_config": {
+                    "vram": 160,
+                    "config": profile_names_and_configs["A100_H100_x2.yaml"],
+                },
+            },
+            {
+                "gpu_count": 4,
+                "vram_and_config": {
+                    "vram": 320,
+                    "config": profile_names_and_configs["A100_H100_x4.yaml"],
+                },
+            },
+            {
+                "gpu_count": 8,
+                "vram_and_config": {
+                    "vram": 640,
+                    "config": profile_names_and_configs["A100_H100_x8.yaml"],
+                },
+            },
+        ),
+    }
+    return profile_mappings


### PR DESCRIPTION
`ilab config init` does not honor the profiles written to disk when auto detecting the best one for the system. Fix this by rendering the profile map by reading the applicable profiles from disk

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
