### PR TITLE
refactor: move is_temp_server_running() to common.py

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -4,7 +4,6 @@
 from typing import Optional, Tuple
 import json
 import logging
-import multiprocessing
 import pathlib
 import struct
 import sys
@@ -185,11 +184,6 @@ def get(model_path: pathlib.Path, backend: str | None) -> str:
             )
 
     return backend
-
-
-def is_temp_server_running():
-    """Check if the temp server is running."""
-    return multiprocessing.current_process().name != "MainProcess"
 
 
 def select_backend(

--- a/src/instructlab/model/backends/common.py
+++ b/src/instructlab/model/backends/common.py
@@ -2,6 +2,7 @@
 from typing import Tuple
 import contextlib
 import logging
+import multiprocessing
 import pathlib
 import socket
 import typing
@@ -55,6 +56,11 @@ def get_model_template(
                 bos_token = "<s>"
 
     return template, eos_token, bos_token
+
+
+def is_temp_server_running():
+    """Check if the temp server is running."""
+    return multiprocessing.current_process().name != "MainProcess"
 
 
 def verify_template_exists(path):

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -24,7 +24,6 @@ import uvicorn
 # Local
 from ...client import check_api_base
 from ...configuration import get_api_base
-from .backends import is_temp_server_running
 from .common import (
     API_ROOT_WELCOME_MESSAGE,
     CHAT_TEMPLATE_AUTO,
@@ -33,6 +32,7 @@ from .common import (
     ServerException,
     free_tcp_ipv4_port,
     get_model_template,
+    is_temp_server_running,
     verify_template_exists,
 )
 from .server import BackendServer, ServerConfig

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -195,7 +195,7 @@ def chat(
     """Runs a chat using the modified model"""
     # pylint: disable=import-outside-toplevel
     # First Party
-    from instructlab.model.backends.backends import is_temp_server_running
+    from instructlab.model.backends.common import is_temp_server_running
 
     users_endpoint_url = cfg.get_api_base(ctx.obj.config.serve.host_port)
 


### PR DESCRIPTION
The backends module, along with the llama_cpp module,
have a circular dependencies, which is considered an anti-pattern.

Move is_temp_server_running to common.py
to eliminate the circular dependency
llama_cpp.py -> backends.py.
