### PR TITLE
e2e: Use fork of wait-for-status-checks action with needed fix

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -50,7 +50,7 @@ jobs:
           jq -nr '[$ARGS.positional[] | split("\\s"; null) | map(select(. != ""))] | flatten | join("|") | ("match_pattern=(" + . + ")")' --args "${{ inputs.job_ids }}" >> "$GITHUB_OUTPUT"
 
       - name: "Wait for status checks"
-        uses: poseidon/wait-for-status-checks@6988432d64ad3f9c2608db4ca16fded1b7d36ead # v0.5.0
+        uses: bjhargrave/wait-for-status-checks@dce002a192e8eeb4c5b622283216263577ffd5d4 # v0.5.0_1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           match_pattern: ${{ steps.set_variables.outputs.match_pattern }}


### PR DESCRIPTION
We need the fix to support pull_request_target target workflows properly. A bug in the wait-for-status-checks action looks at the wrong commit SHA (the target branch, e.g. main, instead of pull/nnn/head). The bug causes the ready check to look at the jobs from the last commit on the target branch not the last commit on the PR (pull/nnn/head).

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
