### PR TITLE
fix: mismatch between requirements action trigger and automerge criteria

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
     paths:
       - '**.py'
       - 'pyproject.toml'
-      - 'requirements*.txt'
+      - 'requirements**.txt'
       - 'tox.ini'
       - .pylintrc
       - '.github/workflows/lint.yml' # This workflow
@@ -21,7 +21,7 @@ on:
     paths:
       - '**.py'
       - 'pyproject.toml'
-      - 'requirements*.txt'
+      - 'requirements**.txt'
       - 'tox.ini'
       - .pylintrc
       - '.github/workflows/lint.yml' # This workflow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - '**.py'
       - 'pyproject.toml'
-      - 'requirements*.txt'
+      - 'requirements**.txt'
       - 'tox.ini'
       - 'scripts/*.sh' # Used by this workflow
       - '.github/workflows/test.yml' # This workflow
@@ -22,7 +22,7 @@ on:
     paths:
       - '**.py'
       - 'pyproject.toml'
-      - 'requirements*.txt'
+      - 'requirements**.txt'
       - 'tox.ini'
       - 'scripts/*.sh' # Used by this workflow
       - '.github/workflows/test.yml' # This workflow


### PR DESCRIPTION
Seen in https://github.com/instructlab/instructlab/pull/2409

Mergify expects `lint` and `test` to run on changes to requirements files at the top level of the repository as well as in the `requirements/` directory, but those actions were not getting triggered in the latter scenario.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
