### PR TITLE
ci: add disk check step and update AMI for all e2e runners

### DIFF
--- a/.github/workflows/e2e-aws-custom.yml
+++ b/.github/workflows/e2e-aws-custom.yml
@@ -139,6 +139,10 @@ jobs:
           python3.11 -m pip install bitsandbytes
           python3.11 -m pip install ${{ github.event.inputs.ilab_install_target }}
 
+      - name: Check disk
+        run: |
+          df -h
+
       - name: Run e2e test
         run: |
           . venv/bin/activate

--- a/.github/workflows/e2e-aws-custom.yml
+++ b/.github/workflows/e2e-aws-custom.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-00c51d9c1374eda97
+          ec2-image-id: ami-01a89eee1adde309c
           ec2-instance-type: ${{ github.event.inputs.instance_type }}
           subnet-id: subnet-02d230cffd9385bd4
           security-group-id: sg-06300447c4a5fbef3

--- a/.github/workflows/e2e-nvidia-a10g-x1.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x1.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-00c51d9c1374eda97
+          ec2-image-id: ami-01a89eee1adde309c
           ec2-instance-type: g5.4xlarge
           subnet-id: subnet-02d230cffd9385bd4
           security-group-id: sg-06300447c4a5fbef3

--- a/.github/workflows/e2e-nvidia-a10g-x1.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x1.yml
@@ -135,10 +135,9 @@ jobs:
           python3.11 -m pip install packaging wheel setuptools-scm
           python3.11 -m pip install .[cuda]
 
-      - name: ilab system info
+      - name: Check disk
         run: |
-          . venv/bin/activate
-          ilab system info
+          df -h
 
       - name: Run e2e test
         run: |

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -138,10 +138,9 @@ jobs:
           python3.11 -m pip install packaging wheel setuptools-scm
           python3.11 -m pip install .[cuda] -r requirements-vllm-cuda.txt
 
-      - name: ilab system info
+      - name: Check disk
         run: |
-          . venv/bin/activate
-          ilab system info
+          df -h
 
       - name: Run e2e test
         env:

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-03f6686697972e40a
+          ec2-image-id: ami-01a89eee1adde309c
           ec2-instance-type: g6e.12xlarge
           subnet-id: subnet-024298cefa3bedd61
           security-group-id: sg-06300447c4a5fbef3

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          ec2-image-id: ami-00c51d9c1374eda97
+          ec2-image-id: ami-01a89eee1adde309c
           ec2-instance-type: g4dn.2xlarge
           subnet-id: subnet-02d230cffd9385bd4
           security-group-id: sg-06300447c4a5fbef3

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -127,6 +127,10 @@ jobs:
           python3.11 -m pip install packaging wheel setuptools-scm
           python3.11 -m pip install .[cuda]
 
+      - name: Check disk
+        run: |
+          df -h
+
       - name: Run e2e test
         run: |
           . venv/bin/activate


### PR DESCRIPTION
`ilab system info` step has been removed from some jobs as this is now run as part of the E2E scripts themselves

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [x] E2E Workflow tests have been added, if necessary.
