### PR TITLE
add a setup ilab script for macos

### DIFF
--- a/scripts/ilab-macos-installer.sh
+++ b/scripts/ilab-macos-installer.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+
+# Simple usage guide:
+# This script is designed for macOS users, specifically optimized for Apple Silicon (M1, M2, M3) users.
+# It will install InstructLab in a Python virtual environment with support for Apple Metal (MPS) acceleration
+# for enhanced performance on M-series Macs.
+
+# If you're using an Intel-based Mac, this script will not work, as it is tailored for Apple Silicon (arm64) architecture.
+#
+# Download and run the script:
+#    curl -s https://raw.githubusercontent.com/instructlab/instructlab/refs/heads/main/scripts/ilab-macos-installer.sh | bash
+#
+# Specify INSTALL_DIR environment variable for installation directory
+#    curl -s https://raw.githubusercontent.com/instructlab/instructlab/refs/heads/main/scripts/ilab-macos-installer.sh | bash -s -- /install/path
+
+INSTALL_DIR=${1:-"$HOME/instructlab"}
+OS_TYPE=$(uname)
+OS_ARCH=$(uname -m)
+CPU_BRAND=$(sysctl -n machdep.cpu.brand_string)
+LINK_TARGET_DIR="/usr/local/bin"
+LINK_NAME="$LINK_TARGET_DIR/ilab"
+INDENT_VARIABLE="   "
+
+# Script usage
+usage() {
+    echo "Usage: $0 [-h]"
+    echo "  Specify the installation directory to install."
+    echo "    e.g. ilab-macos-installer.sh /install/path"
+    echo "  If not specified, the default installation directory is: $HOME/instructlab"
+    echo "  -h               Show this help message and exit"
+    exit 0
+}
+
+# Check Python version
+check_python_version() {
+    PYTHON_COMMAND=$1
+    if ! command -v "$PYTHON_COMMAND" &> /dev/null; then
+        echo -e "\nError: $PYTHON_COMMAND is not installed."
+        exit 1
+    fi
+
+    PYTHON_VERSION=$($PYTHON_COMMAND --version 2>&1 | awk '{print $2}')
+    if [[ "$PYTHON_VERSION" =~ ^3\.(10|11) ]]; then
+        echo -e "$INDENT_VARIABLE Detected Python version: $PYTHON_VERSION"
+        return 0
+    else
+        echo -e "$INDENT_VARIABLE Detected Python version: $PYTHON_VERSION (not 3.10 or 3.11)"
+        exit 1
+    fi
+}
+
+# Check if Python binary supports arm64 architecture
+check_python_macho() {
+    PYTHON_FILE_OUTPUT=$(file -b "$(command -v "$INSTALL_DIR"/venv/bin/python)")
+    if [[ "$PYTHON_FILE_OUTPUT" == *"arm64"* ]]; then
+        echo -e "$INDENT_VARIABLE Python binary supports arm64 architecture."
+    else
+        echo -e "$INDENT_VARIABLE Error: Python binary does not support arm64 architecture."
+        echo "$INDENT_VARIABLE Ensure your Python installation is properly configured for arm64."
+        exit 1
+    fi
+}
+
+main() {
+    while getopts "h" opt; do
+        case ${opt} in
+            h )
+                usage
+                ;;
+            * )
+                usage
+                ;;
+        esac
+    done
+
+    echo -e "\n=============================================="
+    echo "$INDENT_VARIABLE Starting InstructLab installation script"
+    echo "=============================================="
+
+    # Check if the operating system is macOS (Darwin)
+    if [ "$OS_TYPE" != "Darwin" ]; then
+        echo -e "\nError: This script is designed to run on macOS only."
+        exit 1
+    fi
+
+    # Try checking python3.11 first (priority), then python3.10, then python3
+    echo -e "\nChecking for supported Python version and CPU brand:"
+    if check_python_version python3.11; then
+        PYTHON_BIN="python3.11"
+    elif check_python_version python3.10; then
+        PYTHON_BIN="python3.10"
+    elif check_python_version python3; then
+        PYTHON_BIN="python3"
+    else
+        echo "Error: Python 3.10 or 3.11 is required but not found."
+        exit 1
+    fi
+
+    echo "$INDENT_VARIABLE Using Python binary: $PYTHON_BIN"
+    echo "$INDENT_VARIABLE Detected CPU brand: $CPU_BRAND"
+    echo "$INDENT_VARIABLE Detected architecture: $OS_ARCH"
+
+    # Create installation directory if it doesn't exist
+    if [ ! -d "$INSTALL_DIR" ]; then
+        echo -e "\nCreating installation directory: \n$INDENT_VARIABLE $INSTALL_DIR"
+        mkdir -p "$INSTALL_DIR"
+    fi
+
+    # Create virtual environment using the correct Python version
+    echo -e "\nCreating virtual environment:"
+    $PYTHON_BIN -m venv --upgrade-deps "$INSTALL_DIR/venv"
+    if [ ! -f "$INSTALL_DIR/venv/bin/pip" ]; then
+        echo -e "\nError: Virtual environment creation failed. Ensure your Python version supports venv."
+        exit 1
+    fi
+    echo "$INDENT_VARIABLE $INSTALL_DIR/venv"
+
+    #  Apple Silicon (M1/M2/M3)
+    if [[ "$OS_ARCH" = "arm64" ]] && [[ "$CPU_BRAND" == *"Apple"* ]]; then
+        echo -e "\nApple Silicon Mac detected. Start checking the environment setup..."
+
+        # Check that Python binary supports arm64
+        check_python_macho
+
+       # Verify that both Python and terminal are running as ARM64
+        PYTHON_ARCH=$("$INSTALL_DIR"/venv/bin/python -c 'import platform; print(platform.machine())')
+        if [ "$PYTHON_ARCH" != "arm64" ] || [ "$(arch)" != "arm64" ]; then
+            echo -e "$INDENT_VARIABLE Error: Either Python or terminal is not running in ARM64 mode."
+            echo "$INDENT_VARIABLE Please ensure both your Python environment and terminal are correctly set up for Apple Silicon."
+            echo "$INDENT_VARIABLE You may need to configure env or reinstall Python as an ARM64 binary, and ensure the terminal is running natively on Apple Silicon."
+            exit 1
+        fi
+
+        echo -e "$INDENT_VARIABLE System environment is correctly configured for Apple Silicon."
+
+        # Clean llama_cpp_python cache and install with MPS support
+        echo -e "\nInstalling InstructLab with Metal support..."
+        "$INSTALL_DIR"/venv/bin/pip cache remove llama_cpp_python
+        "$INSTALL_DIR"/venv/bin/pip install instructlab
+        echo -e "\nInstructLab installed with Apple Metal support."
+    else
+        echo -e "\nUnsupported architecture: $OS_ARCH"
+        echo -e "Cleaning up installation directory:\n$INDENT_VARIABLE $INSTALL_DIR"
+        rm -rf "$INSTALL_DIR"
+        exit 1
+    fi
+
+    # Create symbolic link
+    if [ ! -d "$LINK_TARGET_DIR" ]; then
+        echo -e "\nError: $LINK_TARGET_DIR does not exist." 
+        echo "Specify another link target directory or create it manually for $INSTALL_DIR/venv/bin/ilab."
+        exit 1
+    fi
+
+    if [ ! -w "$LINK_TARGET_DIR" ]; then
+        echo -e "\nError: No write permission to $LINK_TARGET_DIR."
+        echo "Run the script with sudo or choose another directory."
+        echo -e "Alternatively, you can use sudo create the symlink manually for $INSTALL_DIR/venv/bin/ilab"
+        exit 1
+    fi
+
+    echo -e "\nCreating symbolic link..."
+    if ln -sf "$INSTALL_DIR/venv/bin/ilab" "$LINK_NAME"; then
+        echo -e "$INDENT_VARIABLE Created soft link: $LINK_NAME -> $INSTALL_DIR/venv/bin/ilab"
+    else
+        echo -e "$INDENT_VARIABLE Error: Failed to create soft link."
+        exit 1
+    fi
+
+    # Check if InstructLab was installed correctly
+    echo -e "\nRunning 'ilab --help' to check the installation..."
+    ilab --help || { echo "Error: 'ilab' command not found. Recheck that InstructLab was installed correctly."; }
+
+    echo -e "\n============================================================"
+    echo -e "$INDENT_VARIABLE InstructLab installation completed successfully."
+    echo -e "\nNext step:\n    Run 'ilab config init' to initialize your configuration."
+    echo -e "============================================================"
+}
+
+main "$@"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,3 +103,9 @@ def cli_runner(
 def testdata_path() -> typing.Generator[pathlib.Path, None, None]:
     """Path to local test data directory"""
     yield TESTS_PATH / "testdata"
+
+
+@pytest.fixture
+def scripts_path() -> typing.Generator[pathlib.Path, None, None]:
+    """Path to the scripts directory"""
+    yield TESTS_PATH.parent / "scripts"

--- a/tests/test_macos_install.py
+++ b/tests/test_macos_install.py
@@ -1,0 +1,61 @@
+# Standard
+import pathlib
+import platform
+import subprocess
+
+# Third Party
+import pytest
+
+
+@pytest.mark.skipif(
+    platform.system() != "Darwin" and platform.machine() != "arm64",
+    reason="Test only runs on macOS with Apple Silicon",
+)
+def test_create_and_validate_virtualenv(
+    scripts_path: pathlib.Path, tmp_path: pathlib.Path
+):
+    dest_dir = "test-install-instructlab"
+
+    # Run the setup script
+    setup_script = scripts_path / "ilab-macos-installer.sh"
+    result = subprocess.run(
+        ["bash", str(setup_script), str(tmp_path / dest_dir)],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+
+    # Verify that the venv was created
+    venv_python = tmp_path / dest_dir / "venv" / "bin" / "python"
+    assert venv_python.exists()
+
+    # Verify the Python version in the venv
+    python_version_result = subprocess.run(
+        [str(venv_python), "--version"], capture_output=True, check=True, text=True
+    )
+    assert python_version_result.returncode == 0
+    assert (
+        "3.10" in python_version_result.stdout or "3.11" in python_version_result.stdout
+    )
+
+    # Ensure that the required packages are installed
+    pip_list_result = subprocess.run(
+        [str(tmp_path / dest_dir / "venv" / "bin" / "pip"), "list"],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    assert pip_list_result.returncode == 0
+    assert "instructlab" in pip_list_result.stdout
+
+    # Run 'ilab --help' to verify the installation
+    ilab_help_result = subprocess.run(
+        [str(tmp_path / dest_dir / "venv" / "bin" / "ilab"), "--help"],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    assert ilab_help_result.returncode == 0
+    assert "Usage:" in ilab_help_result.stdout


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

Due to macOS is one of the more popular user bases, and deployment instructions(warnings, notes) can become increasingly detailed, so providing a setup script will help users get started quickly.

```
$ curl -s http://test-test-test.com/files/ilab-macos-installer.sh |bash

or  curl -s http://test-test-test.com/files/ilab-macos-installer.sh |bash -s -- /Users/test-user/test-test

==============================================
    Starting InstructLab installation script
==============================================

Checking for supported Python version and CPU brand:
    Detected Python version: 3.11.11
    Using Python binary: python3.11
    Detected CPU brand: Apple M3 Pro
    Detected architecture: arm64

Creating installation directory:
    /Users/test-user/instructlab

Creating virtual environment:
    /Users/test-user/instructlab/venv

Apple Silicon Mac detected. Start checking the environment setup...
    Python binary supports arm64 architecture.
    System environment is correctly configured for Apple Silicon.

Installing InstructLab with Metal support...
Files removed: 1
Collecting instructlab
...
InstructLab installed with Apple Metal support.

Creating symbolic link...
    Created soft link: /usr/local/bin/ilab -> /Users/test-user/instructlab/venv/bin/ilab

Running 'ilab --help' to check the installation...
Usage: ilab [OPTIONS] COMMAND [ARGS]...

  CLI for interacting with InstructLab.

  If this is your first time running ilab, it's best to start with `ilab
  config init` to create the environment.

Options:
  --config PATH  Path to a configuration file.  [default:
                 /Users/test-user/.config/instructlab/config.yaml]
  -v, --verbose  Enable debug logging (repeat for even more verbosity)
  --version      Show the version and exit.
  --help         Show this message and exit.

Commands:
  config    Command Group for Interacting with the Config of InstructLab.
  data      Command Group for Interacting with the Data generated by...
  model     Command Group for Interacting with the Models in InstructLab.
  system    Command group for all system-related command calls
  taxonomy  Command Group for Interacting with the Taxonomy of InstructLab.

Aliases:
  chat      model chat
  generate  data generate
  serve     model serve
  train     model train

============================================================
    InstructLab installation completed successfully.

Next step:
    Run 'ilab config init' to initialize your configuration.
============================================================

```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
