### PR TITLE
Move source model deletion to end of convert

### DIFF
--- a/src/instructlab/model/convert.py
+++ b/src/instructlab/model/convert.py
@@ -93,9 +93,6 @@ def convert(
         )
         raise click.exceptions.Exit(1)
 
-    logger.info(f"deleting {source_model_dir}...")
-    shutil.rmtree(source_model_dir)
-
     model_dir_fused_pt = f"{model_name}-trained"
     # this converts MLX to PyTorch
     convert_between_mlx_and_pytorch(
@@ -124,3 +121,6 @@ def convert(
 
     logger.info(f"deleting {model_dir_fused_pt}/{model_name}.gguf...")
     os.remove(os.path.join(model_dir_fused_pt, f"{model_name}.gguf"))
+
+    logger.info(f"deleting {source_model_dir}...")
+    shutil.rmtree(source_model_dir)


### PR DESCRIPTION
This commit addresses an issue where the source model directory (checkpoints) was being deleted prematurely during the conversion process. The problem occured when the checkpoints directory was passed in an incorrect format. As a result, users would lose their entire checkpoints directory and be forced to retrain their model.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
