### PR TITLE
Split `ilab model train` click command from functionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ issues = "https://github.com/instructlab/instructlab/issues"
 "evaluate" = "instructlab.model.evaluate:evaluate"
 "serve" = "instructlab.model.serve:serve"
 "test" = "instructlab.model.test:test"
-"train" = "instructlab.model.train:train"
+"train" = "instructlab.cli.model.train:train"
 "list" = "instructlab.model.list:model_list"
 
 [project.entry-points."instructlab.command.system"]
@@ -72,7 +72,7 @@ issues = "https://github.com/instructlab/instructlab/issues"
 "chat" = "instructlab.model.chat:chat"
 "generate" = "instructlab.cli.data.generate:generate"
 "serve" = "instructlab.model.serve:serve"
-"train" = "instructlab.model.train:train"
+"train" = "instructlab.cli.model.train:train"
 
 [tool.setuptools_scm]
 version_file = "src/instructlab/_version.py"
@@ -96,6 +96,8 @@ include = [
   "instructlab",
   "instructlab.chat",
   "instructlab.generator",
+  "instructlab.cli",
+  "instructlab.cli.model",
   "instructlab.train",
   "instructlab.train.lora_mlx",
   "instructlab.train.lora_mlx.models",

--- a/src/instructlab/cli/model/train.py
+++ b/src/instructlab/cli/model/train.py
@@ -428,8 +428,8 @@ def train(
     if is_high_fidelity(device=device) and pipeline == "accelerated":
         train_args, torch_args = map_train_to_library(ctx, ctx.params)
 
-        # Local
-        from . import accelerated_train
+        # First Party
+        from instructlab.model import accelerated_train
 
         try:
             accelerated_train.accelerated_train(
@@ -462,8 +462,8 @@ def train(
         import torch
 
         torch.set_autocast_enabled(False)
-        # Local
-        from . import full_train
+        # First Party
+        from instructlab.model import full_train
 
         train_args, torch_args = map_train_to_library(ctx, ctx.params)
         # if on CPU or MPS, execute full train, which is based
@@ -471,8 +471,8 @@ def train(
         # to fit on most consumer laptops
         full_train.train(train_args=train_args, device=device)
     elif pipeline == "simple":
-        # Local
-        from . import simple_train
+        # First Party
+        from instructlab.model import simple_train
 
         try:
             simple_train.simple_train(

--- a/src/instructlab/model/accelerated_train.py
+++ b/src/instructlab/model/accelerated_train.py
@@ -1,0 +1,642 @@
+# Standard
+import enum
+import functools
+import logging
+import os
+import pathlib
+import pprint
+import typing
+
+# Third Party
+# pylint: disable=ungrouped-imports
+from instructlab.training import DistributedBackend, TorchrunArgs, TrainingArgs
+import click
+
+# First Party
+from instructlab import utils
+from instructlab.configuration import _serve
+from instructlab.model.backends import backends
+
+# Local
+from .phased_training import (
+    EvalPhaseModel,
+    EvalResult,
+    TrainingJournal,
+    TrainingPhases,
+    TrainPhaseModel,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SupportedTrainingStrategies(enum.Enum):
+    """Available advanced training stratefies"""
+
+    LAB_MULTIPHASE: str = "lab-multiphase"
+
+
+def accelerated_train(
+    train_args: TrainingArgs,
+    torch_args: TorchrunArgs,
+    strategy: str | None,
+    distributed_backend: str,
+    phased_phase1_data: pathlib.Path | None,
+    phased_phase2_data: pathlib.Path | None,
+    phased_base_dir: pathlib.Path,
+    phased_phase1_num_epochs: int | None,
+    phased_phase1_samples_per_save: int | None,
+    phased_phase1_effective_batch_size: int | None,
+    phased_phase2_num_epochs: int | None,
+    phased_phase2_samples_per_save: int | None,
+    phased_phase2_effective_batch_size: int | None,
+    enable_serving_output: bool,
+    phased_mt_bench_judge: pathlib.Path | None,
+    skip_user_confirm: bool,
+    force_clear_phased_cache: bool,
+    eval_serve: _serve,
+    eval_gpus: int,
+    training_journal: pathlib.Path | None,
+):
+    # run_training is a dynamic attribute, pylint is not clever enough
+    # to detect it.
+    # Third Party
+    if strategy == SupportedTrainingStrategies.LAB_MULTIPHASE.value:
+        if (
+            distributed_backend
+            and distributed_backend not in DistributedBackend._value2member_map_
+        ):
+            # pylint: disable=broad-exception-raised
+            raise Exception(
+                f"Invalid training backend option '{distributed_backend}' specified. Please specify either `fsdp` or `deepspeed`"
+            )
+
+        # pull the trainrandom.randinting and torch args from the flags
+        # the flags are populated from the config as a base.
+        logger.debug(
+            "Rendered training arguments:\n%s", pprint.pformat(train_args.model_dump())
+        )
+
+        if not (phased_phase1_data and phased_phase2_data):
+            # pylint: disable=broad-exception-raised
+            raise Exception(
+                "End-to-end training minimally requires: `--phased-phase1-data`, and `--phased-phase2-data`. One or more wasn't correctly specified."
+            )
+
+        # if they both exist, must be Path objects
+        if not (phased_phase1_data.exists() and phased_phase2_data.exists()):
+            raise FileNotFoundError(
+                "Data for both phase1 and phase2 must be specified for phased training."
+            )
+
+        mt_bench_judge: pathlib.Path
+        if phased_mt_bench_judge is None:
+            raise FileNotFoundError(
+                "No MT-Bench model was provided with '--phased-mt-bench-judge'"
+            )
+        if not phased_mt_bench_judge.resolve().exists():
+            raise FileNotFoundError(
+                f"MT-Bench model directory could not be found: {phased_mt_bench_judge}\nMust be an absolute path to a model directory."
+            )
+
+        # makes MyPy happy because 'mt_bench_judge' isn't Path | None
+        mt_bench_judge = phased_mt_bench_judge
+
+        if training_journal is None:
+            training_journal = phased_base_dir / "journalfile.yaml"
+        else:
+            # might come in as a str so needs to become a path.
+            training_journal = pathlib.Path(training_journal)
+
+        # try to load journal. May be empty.
+        journal = TrainingJournal(journalfile=training_journal)
+        click.secho("\n\n~~~~~~~~~~~~~STARTING MULTI-PHASE TRAINING~~~~~~~~~~~~~")
+
+        # experimental preference.
+        if phased_phase1_num_epochs != 7:
+            click.secho(
+                f"Running phased training with '{phased_phase1_num_epochs}' epochs.\nNote: 7 epochs is the recommended amount for optimal performance.",
+                fg="yellow",
+            )
+
+        if journal.was_loaded:
+            click.secho(
+                f"There was an existing training journal at: '{str(training_journal)}'"
+            )
+            journal.print_model_rich()
+            click.secho(
+                f"WARNING: Existing training journal state must correspond to state in '{str(phased_base_dir)}'",
+                bg="yellow",
+                fg="black",
+            )
+            click.secho("Alternative behavior is undefined.", bg="yellow", fg="black")
+        else:
+            click.secho(
+                f"No training journal found. Will initialize at: '{str(journal.journalfile)}'",
+                bg="yellow",
+                fg="black",
+            )
+            journal.commit(create_new=True)
+
+        user_clear_cache: bool = False
+        if not skip_user_confirm:
+            click.secho(
+                "Metadata (checkpoints, the training journal) may have been saved from a previous training run."
+            )
+            click.secho(
+                "By default, training will resume from this metadata if it exists."
+            )
+            click.secho(
+                "Alternatively, the metadata can be cleared, and training can start from scratch."
+            )
+            click.secho("\nWould you like to START TRAINING FROM THE BEGINNING?")
+
+            user_clear_cache = click.confirm(
+                "'y' clears metadata to start new training, 'N' tries to resume: "
+            )
+
+        user_clear_cache = user_clear_cache or force_clear_phased_cache
+
+        if user_clear_cache:
+            training_journal.unlink(
+                missing_ok=True
+            )  # delete whatever the old journal was
+            journal = TrainingJournal(
+                journalfile=training_journal
+            )  # create an empty journal
+            journal.commit(create_new=True)  # save it.
+
+        _prepare_phased_base_dir(phased_base_dir, delete_subdirs=user_clear_cache)
+        _run_phased_training(
+            train_args=train_args,
+            torch_args=torch_args,
+            base_dir=phased_base_dir,
+            phase1_data=phased_phase1_data,
+            phase1_num_epochs=phased_phase1_num_epochs,
+            phase1_samples_per_save=phased_phase1_samples_per_save,
+            phase1_checkpoints_dir=phased_base_dir / "phase1" / "checkpoints",
+            phased_phase1_effective_batch_size=phased_phase1_effective_batch_size,
+            phase2_data=phased_phase2_data,
+            phase2_num_epochs=phased_phase2_num_epochs,
+            phase2_samples_per_save=phased_phase2_samples_per_save,
+            phase2_checkpoints_dir=phased_base_dir / "phase2" / "checkpoints",
+            phased_phase2_effective_batch_size=phased_phase2_effective_batch_size,
+            phase2_eval_cache=phased_base_dir / "phase2" / "eval_cache",
+            mtbench_judge=mt_bench_judge,
+            enable_serving_output=enable_serving_output,
+            journal=journal,
+            eval_serve=eval_serve,
+            eval_gpus=eval_gpus,
+        )
+    else:
+        # Third Party
+        from instructlab.training import (
+            run_training,  # pylint: disable=no-name-in-module
+        )
+
+        run_training(train_args=train_args, torch_args=torch_args)
+
+
+def _run_phased_training(
+    train_args: TrainingArgs,
+    torch_args: TorchrunArgs,
+    base_dir: pathlib.Path,
+    phase1_data: pathlib.Path,
+    phase1_num_epochs: int | None,
+    phase1_samples_per_save: int | None,
+    phase1_checkpoints_dir: pathlib.Path,
+    phased_phase1_effective_batch_size: int | None,
+    phase2_data: pathlib.Path,
+    phase2_num_epochs: int | None,
+    phase2_samples_per_save: int | None,
+    phase2_checkpoints_dir: pathlib.Path,
+    phased_phase2_effective_batch_size: int | None,
+    phase2_eval_cache: pathlib.Path,
+    mtbench_judge: pathlib.Path,
+    enable_serving_output: bool,
+    journal: TrainingJournal,
+    eval_serve: _serve,
+    eval_gpus: int,
+) -> None:
+    if journal.current_phase == TrainingPhases.DONE:
+        click.secho(
+            "The selected Training Journal suggests that training has finished, with 'current_phase=done' in the journalfile.",
+            fg="cyan",
+        )
+        return
+
+    # make mypy happy
+    phase_model: TrainPhaseModel | EvalPhaseModel | None = None
+
+    if journal.current_phase == TrainingPhases.TRAIN1:
+        click.secho("Training Phase 1/2...", fg="cyan")
+
+        phase_model = journal.journal.train_1
+        if phase_model is None:
+            phase_model = TrainPhaseModel(checkpoints=phase1_checkpoints_dir)
+            journal.journal.train_1 = phase_model
+        journal.commit()
+
+        _training_phase(
+            train_args=train_args.model_copy(deep=True),
+            torch_args=torch_args,
+            data_path=phase1_data,
+            checkpoint_dir=phase1_checkpoints_dir,
+            num_epochs=phase1_num_epochs,
+            samples_per_save=phase1_samples_per_save,
+            effective_batch_size=phased_phase1_effective_batch_size,
+            # model override not necessary because we expect model to come from ctx.params.model_path.
+        )
+
+        phase_model.ended_at_utc = TrainingJournal.now_utc()
+
+        journal.current_phase = TrainingPhases.TRAIN2
+        journal.commit()
+
+        logger.debug("Finished training #1\n%s", journal.print_model_rich())
+    else:
+        click.secho("SKIPPING: Training Phase 1/2; already in Journal", fg="cyan")
+
+    # if journal.current_phase == TrainingPhases.EVAL1:
+    #     click.secho("MMLU evaluation for Phase 1...", fg="cyan")
+
+    # NOTE: requires hf_format sub-directory. Training sets this up.
+    # phase1_checkpoints_dir = phase1_checkpoints_dir / "hf_format"
+
+    # phase_model = journal.journal.eval_1
+    # if phase_model is None:
+    #     # if it's not None, it already exists and may have 'results', so we shouldn't overwrite it.
+    #     phase_model = EvalPhaseModel(
+    #         checkpoints=list(phase1_checkpoints_dir.iterdir())
+    #     )
+    #     journal.journal.eval_1 = phase_model
+    # journal.commit()
+
+    # best_checkpoint = _evaluate_dir_of_checkpoints(
+    #     eval_func=_mmlu, phase_model=phase_model, journal=journal
+    # )
+
+    # phase_model.best_checkpoint = best_checkpoint
+    # phase_model.ended_at_utc = TrainingJournal.now_utc()
+
+    #     journal.current_phase = TrainingPhases.TRAIN2
+    #     journal.commit()
+    #     logger.debug("Finished eval #1\n%s", journal.print_model_rich())
+    # else:
+    #     click.secho(
+    #         "SKIPPING: MMLU evaluation for Phase 1; already in Journal", fg="cyan"
+    #     )
+
+    if journal.current_phase == TrainingPhases.TRAIN2:
+        click.secho("Training Phase 2/2...", fg="cyan")
+
+        phase_model = journal.journal.train_2
+        if phase_model is None:
+            phase_model = TrainPhaseModel(checkpoints=phase2_checkpoints_dir)
+            journal.journal.train_2 = phase_model
+        journal.commit()
+
+        # if journal.journal.eval_1 is None:
+        #     raise RuntimeError(
+        #         "Training journal field 'eval_1' cannot be None for phase 'train_2'"
+        #     )
+
+        # NOTE:
+        # this is a recent change, implemented to ignore MMLU. We just look at the checkpoints
+        # from the phase 1 training and take the most recent one.
+        phase1_checkpoints_dir_hf = phase1_checkpoints_dir / "hf_format"
+        if not phase1_checkpoints_dir_hf.exists():
+            raise FileNotFoundError(
+                f"{phase1_checkpoints_dir_hf} doesn't exist. This likely means that no checkpoints were saved from phase 1."
+            )
+
+        phase1_checkpoints = sorted(
+            list(phase1_checkpoints_dir_hf.iterdir()),
+            reverse=True,
+            # XXX(osilkin): This line takes the checkpoint name "samples_NNN" and tells sorted
+            #               to use the last NNN string as an integer
+            key=lambda x: int(str(x).rsplit("_", maxsplit=1)[-1]),
+        )
+
+        if len(phase1_checkpoints) == 0:
+            raise FileNotFoundError(
+                f"{phase1_checkpoints_dir_hf} Has no checkpoints. This likely means that no checkpoints were saved from phase 1."
+            )
+
+        next_checkpoint = phase1_checkpoints[0]
+
+        _training_phase(
+            train_args=train_args.model_copy(deep=True),
+            torch_args=torch_args,
+            data_path=phase2_data,
+            checkpoint_dir=phase2_checkpoints_dir,
+            model_override=next_checkpoint,  # type: ignore
+            num_epochs=phase2_num_epochs,
+            samples_per_save=phase2_samples_per_save,
+            effective_batch_size=phased_phase2_effective_batch_size,
+        )
+
+        phase_model.ended_at_utc = TrainingJournal.now_utc()
+
+        journal.current_phase = TrainingPhases.EVAL2
+        journal.commit()
+        logger.debug("Finished training #2\n%s", journal.print_model_rich())
+    else:
+        click.secho("SKIPPING: Training Phase 2/2; already in Journal", fg="cyan")
+
+    if journal.current_phase == TrainingPhases.EVAL2:
+        click.secho("MT-Bench evaluation for Phase 2...", fg="cyan")
+
+        phase2_checkpoints_dir = phase2_checkpoints_dir / "hf_format"
+        phase2_eval_cache = base_dir / "phase2" / "eval_cache"
+        phase_model = journal.journal.eval_2
+        if phase_model is None:
+            # if it's not None, it already exists and may have 'results', so we shouldn't overwrite it.
+            phase_model = EvalPhaseModel(
+                checkpoints=list(phase2_checkpoints_dir.iterdir())
+            )
+            journal.journal.eval_2 = phase_model
+        journal.commit()
+
+        best_checkpoint = _evaluate_dir_of_checkpoints(
+            phase_model=phase_model,
+            journal=journal,
+            eval_func=functools.partial(
+                _mtbench,
+                eval_serve=eval_serve,
+                eval_gpus=eval_gpus,
+                eval_cache=phase2_eval_cache,
+                mtbench_judge=mtbench_judge,
+                enable_serving_output=enable_serving_output,
+            ),
+        )
+
+        phase_model.best_checkpoint = best_checkpoint
+        phase_model.ended_at_utc = TrainingJournal.now_utc()
+
+        journal.current_phase = TrainingPhases.DONE
+        journal.journal.final_output = best_checkpoint
+        journal.journal.ended_at_utc = TrainingJournal.now_utc()
+        journal.commit()
+        logger.debug("Finished eval #2\n%s", journal.print_model_rich())
+
+    else:
+        click.secho(
+            "SKIPPING: MT-Bench evaluation for Phase 2; already in Journal", fg="cyan"
+        )
+
+    output_checkpoint: EvalResult | None = journal.journal.final_output
+    if not output_checkpoint:
+        raise RuntimeError(
+            "At the end of training, but no 'final_output' checkpoint in TrainingJournal"
+        )
+
+    click.secho(
+        f"Training finished! Best final checkpoint: {output_checkpoint.checkpoint} with score: {output_checkpoint.score}\nJournal: {str(journal.journalfile)}",
+        fg="green",
+    )
+
+
+def _training_phase(
+    train_args: TrainingArgs,
+    torch_args: TorchrunArgs,
+    data_path: pathlib.Path,
+    model_override: pathlib.Path | None = None,
+    num_epochs: int | None = None,
+    samples_per_save: int | None = None,
+    checkpoint_dir: pathlib.Path | None = None,
+    effective_batch_size: int | None = None,
+) -> None:
+    """A single step of phased training that supports key param overriding."""
+
+    # Third Party
+    from instructlab.training import run_training  # pylint: disable=no-name-in-module
+
+    logger.debug(
+        f"Phased Training -- training phase -- Overriding data_path: {train_args.data_path} with {data_path}"
+    )
+
+    # NOTE: have to cast pathlib.Path to str because Pydantic models require this. Here and below.
+    train_args.data_path = str(data_path)
+
+    if checkpoint_dir:
+        train_args.ckpt_output_dir = str(checkpoint_dir)
+
+    if model_override:
+        logger.debug(
+            f"Phased Training -- training phase -- Overriding model_path: {train_args.model_path} with {model_override}"
+        )
+        train_args.model_path = str(model_override)
+
+    if num_epochs:
+        logger.debug(
+            f"Phased Training -- training phase -- Overriding num epochs: {train_args.num_epochs} with {num_epochs}"
+        )
+        train_args.num_epochs = num_epochs
+
+    if samples_per_save is not None:
+        logger.debug(
+            f"Phased Training -- training phase -- Overriding samples per save: {train_args.save_samples} with {samples_per_save}"
+        )
+        train_args.save_samples = samples_per_save
+
+    if effective_batch_size:
+        logger.debug(
+            f"Phased Training -- training phase -- Overriding effective batch size: {train_args.effective_batch_size} with {effective_batch_size}"
+        )
+        train_args.effective_batch_size = effective_batch_size
+
+    click.secho(
+        f"TrainingArgs for current phase: {pprint.pformat(train_args)}", fg="cyan"
+    )
+
+    run_training(train_args=train_args, torch_args=torch_args)
+
+
+def _prepare_phased_base_dir(
+    phased_base_dir: pathlib.Path, delete_subdirs: bool = True
+) -> None:
+    """Adds phase1 and phase2 directories in phased_base_dir.
+    In each, adds `checkpoints` and `eval_cache` subdirectories.
+
+    Also adds training `journalfile.yaml`
+
+    Args:
+        phased_base_dir: directory wrapping phase1 and phase2 cached data.
+    """
+
+    logger.debug(f"Phased Training -- Preparing phased base dir: {phased_base_dir}")
+
+    phase1_dir_path = phased_base_dir / "phase1"
+    phase2_dir_path = phased_base_dir / "phase2"
+
+    for p in [phase1_dir_path, phase2_dir_path]:
+        if delete_subdirs:
+            utils.clear_directory(p)
+        _setup_phase_dirs(p)
+
+
+def _setup_phase_dirs(path: pathlib.Path) -> None:
+    """Creates {path}/checkpoints and {path}/eval_cache directories."""
+
+    # TODO: these sub-directory names are hard-coded here but they
+    # could be parameterized in config.
+    logger.debug(f"Phased Training -- Created phase directories for {path}")
+    ckpt_path = path / "checkpoints"
+    eval_cache_path = path / "eval_cache"
+
+    os.makedirs(ckpt_path, exist_ok=True)
+    os.makedirs(eval_cache_path, exist_ok=True)
+
+
+def _mmlu(model: pathlib.Path) -> float:
+    # Third Party
+    from instructlab.eval.mmlu import MMLU_TASKS, MMLUEvaluator
+    import torch
+
+    tasks = MMLU_TASKS
+    if os.environ.get("INSTRUCTLAB_EVAL_MMLU_MIN_TASKS") is not None:
+        tasks = tasks[:4]
+    evaluator = MMLUEvaluator(model, tasks=tasks)
+
+    # type the variable because MyPy doesn't seem to honor the types of the spread tuple
+    ckpt_score: float
+    ckpt_score, _ = evaluator.run()
+
+    logging.debug("Phased Training -- MMLU eval phase -- Clearing PyTorch cache")
+    torch.cuda.empty_cache()
+
+    return ckpt_score
+
+
+def _mtbench(
+    model: pathlib.Path,
+    eval_serve: _serve,
+    eval_gpus: int,
+    eval_cache: pathlib.Path,
+    mtbench_judge: pathlib.Path,
+    enable_serving_output: bool,
+) -> float:
+    # TODO: optimization: run all generations in serial and then do all judgments at once to save time loading/unloading prometheus.
+    # Third Party
+    from instructlab.eval.mt_bench import MTBenchEvaluator
+    import torch
+
+    # First Party
+    from instructlab.model.evaluate import get_gpus, get_model_name, launch_server
+
+    explicit_gpus = None
+    gpus, effective_gpus = get_gpus(eval_serve, eval_gpus)
+    if gpus and gpus > 0:
+        # gpus are specified in config for evaluate
+        logger.debug("Using gpus from config")
+        explicit_gpus = gpus
+    elif effective_gpus > 0:
+        # tensor-parallel size specified in serving config
+        logger.debug("Using gpus from --tensor-parallel-size in config")
+    else:
+        # TODO: Should be parameterized by the user specific for training
+        explicit_gpus = torch.cuda.device_count()
+        effective_gpus = explicit_gpus
+
+    model_name = get_model_name(str(model))
+    judge_model_name = get_model_name(str(mtbench_judge))
+
+    evaluator = MTBenchEvaluator(
+        model_name=model_name,
+        judge_model_name=judge_model_name,
+        output_dir=str(eval_cache),
+        merge_system_user_message=True,  # TODO: expose this to the user
+    )
+
+    server = None
+    model_serve_url = None
+    try:
+        logger.debug("Starting model server for mt-bench answer generation")
+        server, model_serve_url, effective_gpus = launch_server(
+            eval_serve=eval_serve,
+            tls_client_cert=None,
+            tls_client_key=None,
+            tls_client_passwd=None,
+            tls_insecure=False,
+            model=str(model),
+            model_name=model_name,
+            gpus=explicit_gpus,
+            max_workers="auto",
+            enable_serving_output=enable_serving_output,
+            backend=backends.VLLM,
+        )
+        logger.debug("Generating mt-bench answers")
+        evaluator.gen_answers(
+            model_serve_url, max_workers="auto", serving_gpus=effective_gpus
+        )
+    finally:
+        if server is not None:
+            server.shutdown()
+
+    try:
+        logger.debug("Starting model server for mt-bench answer judgment")
+        server, model_serve_url, effective_gpus = launch_server(
+            eval_serve=eval_serve,
+            tls_client_cert=None,
+            tls_client_key=None,
+            tls_client_passwd=None,
+            tls_insecure=False,
+            model=str(mtbench_judge),
+            model_name=judge_model_name,
+            gpus=explicit_gpus,
+            max_workers="auto",
+            backend=backends.VLLM,
+            enable_serving_output=enable_serving_output,
+        )
+        logger.debug("Judging mt-bench answers")
+        mt_bench_results: tuple = evaluator.judge_answers(
+            model_serve_url, max_workers="auto", serving_gpus=effective_gpus
+        )
+        ckpt_score: float = mt_bench_results[0]
+    finally:
+        if server is not None:
+            server.shutdown()
+
+    return ckpt_score
+
+
+def _evaluate_dir_of_checkpoints(
+    eval_func: typing.Callable[..., float],
+    phase_model: EvalPhaseModel,
+    journal: TrainingJournal,
+) -> EvalResult:
+    """Run eval_func on all model checkpoints in a directory."""
+    # TODO: parallelize MMLU over available GPUs
+
+    # doing this to avoid removing checkpoints from same list that we're iterating over.
+    checkpoints_todo = list(
+        set(phase_model.checkpoints) - set(phase_model.finished_checkpoints)
+    )
+
+    if len(checkpoints_todo) == 0:
+        raise RuntimeError(
+            "No checkpoints were evaluated, 'checkpoints_todo' was empty in journal."
+        )
+
+    for checkpoint in checkpoints_todo:
+        logger.debug(str(checkpoint))
+        checkpoint_score = eval_func(model=checkpoint)
+
+        phase_model.results.append(
+            EvalResult(
+                score=checkpoint_score,
+                checkpoint=checkpoint,
+                ended_at_utc=TrainingJournal.now_utc(),
+            )
+        )
+
+        phase_model.finished_checkpoints.append(checkpoint)
+        journal.commit()
+
+        click.secho(
+            f"CHECKPOINT EVALUATION: {str(checkpoint)} SCORED {checkpoint_score}",
+            fg="red",
+            bg="cyan",
+        )
+
+    return TrainingJournal.best_checkpoint(phase_model=phase_model)

--- a/src/instructlab/model/simple_train.py
+++ b/src/instructlab/model/simple_train.py
@@ -1,0 +1,217 @@
+# Standard
+from pathlib import Path
+import logging
+import os
+import pathlib
+import shutil
+
+# First Party
+from instructlab import utils
+from instructlab.configuration import DEFAULTS
+
+# pylint: disable=ungrouped-imports
+
+logger = logging.getLogger(__name__)
+
+
+def simple_train(
+    model_path,
+    skip_preprocessing,
+    skip_quantize,
+    gguf_model_path,
+    tokenizer_dir,
+    data_path,
+    input_dir,
+    ckpt_output_dir,
+    iters,
+    local,
+    num_epochs,
+    device,
+    four_bit_quant,
+):
+    effective_data_dir: pathlib.Path = Path(
+        data_path if data_path else DEFAULTS.DATASETS_DIR
+    )
+
+    train_file = effective_data_dir / "train_gen.jsonl"
+    test_file = effective_data_dir / "test_gen.jsonl"
+
+    # NOTE: If given a data_dir, input-dir is ignored in favor of existing!
+    if not data_path or data_path.strip() == DEFAULTS.DATASETS_DIR:
+        data_path = str(effective_data_dir)
+        if not os.path.exists(input_dir):
+            raise OSError(
+                f"Could not read directory: {input_dir}",
+            )
+
+        try:
+            os.makedirs(data_path, exist_ok=True)
+        except OSError as exc:
+            raise OSError(f"Could not create data dir: {exc}") from exc
+
+        # generated input files reverse sorted by modification time
+        def get_files(directory: str, pattern: str) -> list[str]:
+            return sorted(
+                [str(p) for p in Path(directory).glob(pattern)],
+                key=os.path.getmtime,
+                reverse=True,
+            )
+
+        # ignore the test_file and train_file to prevent it from being copied back onto itself
+        # see: https://github.com/instructlab/instructlab/pull/1685
+        test_files = [
+            f
+            for f in get_files(input_dir, "test_*")
+            if os.path.basename(f) != os.path.basename(test_file)
+        ]
+        train_files = [
+            f
+            for f in get_files(input_dir, "train_*")
+            if os.path.basename(f) != os.path.basename(train_file)
+        ]
+
+        if not train_files or not test_files:
+            raise FileNotFoundError(
+                f"{input_dir} does not contain training or test files, did you run `ilab data generate`?",
+            )
+        if len(train_files) > 1 or len(test_files) > 1:
+            logger.warning(
+                "Found multiple files from `ilab data generate`. Using the most recent generation.",
+            )
+        # The first file is latest
+        logger.debug("train_file=%s", train_files[0])
+        logger.debug("test_file=%s", test_files[0])
+        shutil.copy(train_files[0], train_file)
+        shutil.copy(test_files[0], test_file)
+
+    if utils.is_macos_with_m_chip():
+        # Local
+        from ..mlx_explore.gguf_convert_to_mlx import load
+        from ..mlx_explore.utils import fetch_tokenizer_from_hub
+        from ..train.lora_mlx.convert import convert_between_mlx_and_pytorch
+        from ..train.lora_mlx.lora import load_and_train
+        from ..train.lora_mlx.make_data import make_data
+
+        if not skip_preprocessing:
+            try:
+                make_data(data_dir=data_path)
+            except FileNotFoundError as exc:
+                raise FileNotFoundError(
+                    f"Could not read from data directory: {exc}"
+                ) from exc
+
+        # NOTE we can skip this if we have a way to ship MLX
+        # PyTorch safetensors to MLX safetensors
+        model_dir_local = model_path.replace("/", "-")
+        model_dir_local = f"{ckpt_output_dir}/{model_dir_local}"
+        model_dir_mlx = f"{model_dir_local}-mlx"
+        model_dir_mlx_quantized = f"{model_dir_local}-mlx-q"
+
+        if skip_quantize:
+            dest_model_dir = model_dir_mlx
+            quantize_arg = False
+        else:
+            dest_model_dir = model_dir_mlx_quantized
+            quantize_arg = True
+
+        if tokenizer_dir is not None and gguf_model_path is not None:
+            if not local:
+                tokenizer_dir_local = tokenizer_dir.replace("/", "-")
+                fetch_tokenizer_from_hub(tokenizer_dir, tokenizer_dir_local)
+
+            # no need to pass quantize_arg for now, script automatically detects if quantization is necessary based on whether gguf model is quantized or not
+            load(
+                gguf=gguf_model_path,
+                repo=tokenizer_dir,
+                mlx_path=dest_model_dir,
+            )
+
+            for filename in os.listdir(model_dir_local):
+                shutil.copy(
+                    os.path.join(model_dir_local, filename),
+                    os.path.join(dest_model_dir, filename),
+                )
+            shutil.rmtree(model_dir_local, ignore_errors=True)
+
+        else:
+            # Downloading PyTorch SafeTensor and Converting to MLX SafeTensor
+            convert_between_mlx_and_pytorch(
+                hf_path=model_path,
+                mlx_path=dest_model_dir,
+                quantize=quantize_arg,
+                local=local,
+            )
+
+        adapter_file_path = f"{dest_model_dir}/adapters.npz"
+
+        # train the model with LoRA
+        load_and_train(
+            model=dest_model_dir,
+            train=True,
+            data=data_path,
+            adapter_file=adapter_file_path,
+            iters=iters,
+            save_every=10,
+            steps_per_eval=10,
+        )
+    else:
+        # Local
+        from ..llamacpp.llamacpp_convert_to_gguf import convert_llama_to_gguf
+        from ..train.linux_train import linux_train
+
+        training_results_dir = linux_train(
+            train_file=train_file,
+            test_file=test_file,
+            model_name=model_path,
+            num_epochs=num_epochs,
+            train_device=device,
+            four_bit_quant=four_bit_quant,
+        )
+
+        final_results_dir = training_results_dir / "final"
+        if final_results_dir.exists():
+            shutil.rmtree(final_results_dir)
+        final_results_dir.mkdir()
+
+        gguf_models_dir = Path(DEFAULTS.CHECKPOINTS_DIR)
+        gguf_models_dir.mkdir(exist_ok=True)
+        gguf_models_file = gguf_models_dir / "ggml-model-f16.gguf"
+
+        # Remove previously trained model, its taking up space we may need in the next step
+        gguf_models_file.unlink(missing_ok=True)
+
+        # TODO: Figure out what to do when there are multiple checkpoint dirs.
+        # Right now it's just copying files from the first one numerically not necessarily the best one
+        for fpath in (
+            "checkpoint-*/added_tokens.json",
+            "checkpoint-*/special_tokens_map.json",
+            "checkpoint-*/tokenizer.json",
+            "checkpoint-*/tokenizer.model",
+            "checkpoint-*/tokenizer_config.json",
+            "merged_model/config.json",
+            "merged_model/generation_config.json",
+        ):
+            file_ = next(training_results_dir.glob(fpath))
+            shutil.copy(file_, final_results_dir)
+            logger.info(f"Copied {file_} to {final_results_dir}")
+
+        for file in training_results_dir.glob("merged_model/*.safetensors"):
+            shutil.move(file, final_results_dir)
+            logger.info(f"Moved {file} to {final_results_dir}")
+
+        if four_bit_quant:
+            logger.info(
+                "SKIPPING CONVERSION to gguf. This is unsupported with --4-bit-quant. "
+                + "See https://github.com/instructlab/instructlab/issues/579."
+            )
+            return
+
+        gguf_file_path = convert_llama_to_gguf(model=final_results_dir, pad_vocab=True)
+
+        # Remove safetensors files to save space, were done with them here
+        # and the huggingface lib has them cached
+        for file in final_results_dir.glob("*.safetensors"):
+            file.unlink()
+
+        shutil.move(gguf_file_path, gguf_models_file)
+        logger.info(f"Save trained model to {gguf_models_file}")

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -8,7 +8,6 @@ import logging
 import os
 import pathlib
 import pprint
-import shutil
 import typing
 
 # Third Party
@@ -432,70 +431,6 @@ def train(
     if four_bit_quant and device != "cuda":
         ctx.fail("'--4-bit-quant' option requires '--device=cuda'")
 
-    effective_data_dir: pathlib.Path = Path(
-        data_path if data_path else DEFAULTS.DATASETS_DIR
-    )
-    train_file = effective_data_dir / "train_gen.jsonl"
-    test_file = effective_data_dir / "test_gen.jsonl"
-    ckpt_output_dir = Path(kwargs["ckpt_output_dir"])
-
-    # NOTE: If given a data_dir, input-dir is ignored in favor of existing!
-    if not data_path or data_path.strip() == DEFAULTS.DATASETS_DIR and not strategy:
-        data_path = str(effective_data_dir)
-        if not os.path.exists(input_dir):
-            click.secho(
-                f"Could not read directory: {input_dir}",
-                fg="red",
-            )
-            raise click.exceptions.Exit(1)
-
-        try:
-            os.makedirs(data_path, exist_ok=True)
-        except OSError as exc:
-            click.secho(
-                f"Could not create data dir: {exc}",
-                fg="red",
-            )
-            raise click.exceptions.Exit(1)
-
-        # generated input files reverse sorted by modification time
-        def get_files(directory: str, pattern: str) -> list[str]:
-            return sorted(
-                [str(p) for p in Path(directory).glob(pattern)],
-                key=os.path.getmtime,
-                reverse=True,
-            )
-
-        # ignore the test_file and train_file to prevent it from being copied back onto itself
-        # see: https://github.com/instructlab/instructlab/pull/1685
-        test_files = [
-            f
-            for f in get_files(input_dir, "test_*")
-            if os.path.basename(f) != os.path.basename(test_file)
-        ]
-        train_files = [
-            f
-            for f in get_files(input_dir, "train_*")
-            if os.path.basename(f) != os.path.basename(train_file)
-        ]
-
-        if not train_files or not test_files:
-            click.secho(
-                f"{input_dir} does not contain training or test files, did you run `ilab data generate`?",
-                fg="red",
-            )
-            raise click.exceptions.Exit(1)
-        if len(train_files) > 1 or len(test_files) > 1:
-            click.secho(
-                "Found multiple files from `ilab data generate`. Using the most recent generation.",
-                fg="yellow",
-            )
-        # The first file is latest
-        logger.debug("train_file=%s", train_files[0])
-        logger.debug("test_file=%s", test_files[0])
-        shutil.copy(train_files[0], train_file)
-        shutil.copy(test_files[0], test_file)
-
     if (
         pipeline in ("full", "accelerated")
     ) and strategy != SupportedTrainingStrategies.LAB_MULTIPHASE.value:
@@ -656,142 +591,28 @@ def train(
             # to fit on most consumer laptops
             full_train.train(train_args=train_args, device=device)
         elif pipeline == "simple":
-            if utils.is_macos_with_m_chip() and not strategy:
-                # Local
-                from ..mlx_explore.gguf_convert_to_mlx import load
-                from ..mlx_explore.utils import fetch_tokenizer_from_hub
-                from ..train.lora_mlx.convert import convert_between_mlx_and_pytorch
-                from ..train.lora_mlx.lora import load_and_train
-                from ..train.lora_mlx.make_data import make_data
+            # Local
+            from . import simple_train
 
-                if not skip_preprocessing:
-                    try:
-                        make_data(data_dir=data_path)
-                    except FileNotFoundError as exc:
-                        click.secho(
-                            f"Could not read from data directory: {exc}",
-                            fg="red",
-                        )
-                        raise click.exceptions.Exit(1)
-
-                # NOTE we can skip this if we have a way to ship MLX
-                # PyTorch safetensors to MLX safetensors
-                model_dir_local = model_path.replace("/", "-")
-                model_dir_local = f"{ckpt_output_dir}/{model_dir_local}"
-                model_dir_mlx = f"{model_dir_local}-mlx"
-                model_dir_mlx_quantized = f"{model_dir_local}-mlx-q"
-
-                if skip_quantize:
-                    dest_model_dir = model_dir_mlx
-                    quantize_arg = False
-                else:
-                    dest_model_dir = model_dir_mlx_quantized
-                    quantize_arg = True
-
-                if tokenizer_dir is not None and gguf_model_path is not None:
-                    if not local:
-                        tokenizer_dir_local = tokenizer_dir.replace("/", "-")
-                        fetch_tokenizer_from_hub(tokenizer_dir, tokenizer_dir_local)
-
-                    # no need to pass quantize_arg for now, script automatically detects if quantization is necessary based on whether gguf model is quantized or not
-                    load(
-                        gguf=gguf_model_path,
-                        repo=tokenizer_dir,
-                        mlx_path=dest_model_dir,
-                    )
-
-                    for filename in os.listdir(model_dir_local):
-                        shutil.copy(
-                            os.path.join(model_dir_local, filename),
-                            os.path.join(dest_model_dir, filename),
-                        )
-                    shutil.rmtree(model_dir_local, ignore_errors=True)
-
-                else:
-                    # Downloading PyTorch SafeTensor and Converting to MLX SafeTensor
-                    convert_between_mlx_and_pytorch(
-                        hf_path=model_path,
-                        mlx_path=dest_model_dir,
-                        quantize=quantize_arg,
-                        local=local,
-                    )
-
-                adapter_file_path = f"{dest_model_dir}/adapters.npz"
-
-                # train the model with LoRA
-                load_and_train(
-                    model=dest_model_dir,
-                    train=True,
-                    data=data_path,
-                    adapter_file=adapter_file_path,
+            try:
+                simple_train.simple_train(
+                    model_path=model_path,
+                    skip_preprocessing=skip_preprocessing,
+                    skip_quantize=skip_quantize,
+                    gguf_model_path=gguf_model_path,
+                    tokenizer_dir=tokenizer_dir,
+                    data_path=data_path,
+                    input_dir=input_dir,
+                    ckpt_output_dir=Path(kwargs["ckpt_output_dir"]),
                     iters=iters,
-                    save_every=10,
-                    steps_per_eval=10,
-                )
-            else:
-                # Local
-                from ..llamacpp.llamacpp_convert_to_gguf import convert_llama_to_gguf
-                from ..train.linux_train import linux_train
-
-                training_results_dir = linux_train(
-                    ctx=ctx,
-                    train_file=train_file,
-                    test_file=test_file,
-                    model_name=model_path,
+                    local=local,
                     num_epochs=num_epochs,
-                    train_device=device,
+                    device=device,
                     four_bit_quant=four_bit_quant,
                 )
-
-                final_results_dir = training_results_dir / "final"
-                if final_results_dir.exists():
-                    shutil.rmtree(final_results_dir)
-                final_results_dir.mkdir()
-
-                gguf_models_dir = Path(DEFAULTS.CHECKPOINTS_DIR)
-                gguf_models_dir.mkdir(exist_ok=True)
-                gguf_models_file = gguf_models_dir / "ggml-model-f16.gguf"
-
-                # Remove previously trained model, its taking up space we may need in the next step
-                gguf_models_file.unlink(missing_ok=True)
-
-                # TODO: Figure out what to do when there are multiple checkpoint dirs.
-                # Right now it's just copying files from the first one numerically not necessarily the best one
-                for fpath in (
-                    "checkpoint-*/added_tokens.json",
-                    "checkpoint-*/special_tokens_map.json",
-                    "checkpoint-*/tokenizer.json",
-                    "checkpoint-*/tokenizer.model",
-                    "checkpoint-*/tokenizer_config.json",
-                    "merged_model/config.json",
-                    "merged_model/generation_config.json",
-                ):
-                    file_ = next(training_results_dir.glob(fpath))
-                    shutil.copy(file_, final_results_dir)
-                    logger.info(f"Copied {file_} to {final_results_dir}")
-
-                for file in training_results_dir.glob("merged_model/*.safetensors"):
-                    shutil.move(file, final_results_dir)
-                    logger.info(f"Moved {file} to {final_results_dir}")
-
-                if four_bit_quant:
-                    logger.info(
-                        "SKIPPING CONVERSION to gguf. This is unsupported with --4-bit-quant. "
-                        + "See https://github.com/instructlab/instructlab/issues/579."
-                    )
-                    return
-
-                gguf_file_path = convert_llama_to_gguf(
-                    model=final_results_dir, pad_vocab=True
-                )
-
-                # Remove safetensors files to save space, were done with them here
-                # and the huggingface lib has them cached
-                for file in final_results_dir.glob("*.safetensors"):
-                    file.unlink()
-
-                shutil.move(gguf_file_path, gguf_models_file)
-                logger.info(f"Save trained model to {gguf_models_file}")
+            except Exception as exc:
+                click.secho(f"{exc}", fg="red")
+                raise click.exceptions.Exit(1)
 
 
 # chooses which type of training to run depending on the device provided

--- a/src/instructlab/model/train.py
+++ b/src/instructlab/model/train.py
@@ -3,32 +3,17 @@
 # Standard
 from pathlib import Path
 import enum
-import functools
 import logging
 import os
 import pathlib
-import pprint
-import typing
 
 # Third Party
-from instructlab.training import DistributedBackend, TorchrunArgs, TrainingArgs
-
 # pylint: disable=ungrouped-imports
 import click
 
 # First Party
-from instructlab import clickext, utils
+from instructlab import clickext
 from instructlab.configuration import DEFAULTS, map_train_to_library
-from instructlab.model.backends import backends
-
-# Local
-from .phased_training import (
-    EvalPhaseModel,
-    EvalResult,
-    TrainingJournal,
-    TrainingPhases,
-    TrainPhaseModel,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -424,6 +409,7 @@ def train(
     ):
         ctx.fail("Multi Phase training is only supported with `--pipeline accelerated`")
 
+    # TODO: cdoern, remove this flag
     if not input_dir:
         # By default, generate output-dir is used as train input-dir
         input_dir = ctx.obj.config.generate.output_dir
@@ -438,624 +424,77 @@ def train(
             ctx.fail(
                 f"Data path must be to a valid .jsonl file. Value given: {data_path}"
             )
-
-    if strategy == SupportedTrainingStrategies.LAB_MULTIPHASE.value:
-        if (
-            distributed_backend
-            and distributed_backend not in DistributedBackend._value2member_map_
-        ):
-            raise ctx.fail(
-                f"Invalid training backend option '{distributed_backend}' specified. Please specify either `fsdp` or `deepspeed`"
-            )
-
-        # pull the trainrandom.randinting and torch args from the flags
-        # the flags are populated from the config as a base.
+    # we can use train_args locally to run lower fidelity training
+    if is_high_fidelity(device=device) and pipeline == "accelerated":
         train_args, torch_args = map_train_to_library(ctx, ctx.params)
-        logger.debug(
-            "Rendered training arguments:\n%s", pprint.pformat(train_args.model_dump())
-        )
 
-        if not (phased_phase1_data and phased_phase2_data):
-            raise ctx.fail(
-                "End-to-end training minimally requires: `--phased-phase1-data`, and `--phased-phase2-data`. One or more wasn't correctly specified."
+        # Local
+        from . import accelerated_train
+
+        try:
+            accelerated_train.accelerated_train(
+                train_args=train_args,
+                torch_args=torch_args,
+                strategy=strategy,
+                distributed_backend=distributed_backend,
+                phased_phase1_data=phased_phase1_data,
+                phased_phase2_data=phased_phase2_data,
+                phased_base_dir=phased_base_dir,
+                phased_phase1_num_epochs=phased_phase1_num_epochs,
+                phased_phase1_samples_per_save=phased_phase1_samples_per_save,
+                phased_phase1_effective_batch_size=phased_phase1_effective_batch_size,
+                phased_phase2_num_epochs=phased_phase2_num_epochs,
+                phased_phase2_samples_per_save=phased_phase2_samples_per_save,
+                phased_phase2_effective_batch_size=phased_phase2_effective_batch_size,
+                enable_serving_output=enable_serving_output,
+                phased_mt_bench_judge=phased_mt_bench_judge,
+                skip_user_confirm=skip_user_confirm,
+                force_clear_phased_cache=force_clear_phased_cache,
+                eval_serve=ctx.obj.config.serve,
+                eval_gpus=ctx.obj.config.evaluate.gpus,
+                training_journal=training_journal,
             )
+        except Exception as exc:
+            click.secho(f"Accelerated Training failed with {str(exc)}")
+            raise click.exceptions.Exit(1)
+    elif not is_high_fidelity(device=device) and pipeline == "full":
+        # Third Party
+        import torch
 
-        # if they both exist, must be Path objects
-        if not (phased_phase1_data.exists() and phased_phase2_data.exists()):
-            raise FileNotFoundError(
-                "Data for both phase1 and phase2 must be specified for phased training."
+        torch.set_autocast_enabled(False)
+        # Local
+        from . import full_train
+
+        train_args, torch_args = map_train_to_library(ctx, ctx.params)
+        # if on CPU or MPS, execute full train, which is based
+        # off of the structure of the training repo, just with different optimizers, model sizes, and special data gradient accumulation to get it
+        # to fit on most consumer laptops
+        full_train.train(train_args=train_args, device=device)
+    elif pipeline == "simple":
+        # Local
+        from . import simple_train
+
+        try:
+            simple_train.simple_train(
+                model_path=model_path,
+                skip_preprocessing=skip_preprocessing,
+                skip_quantize=skip_quantize,
+                gguf_model_path=gguf_model_path,
+                tokenizer_dir=tokenizer_dir,
+                data_path=data_path,
+                input_dir=input_dir,
+                ckpt_output_dir=Path(kwargs["ckpt_output_dir"]),
+                iters=iters,
+                local=local,
+                num_epochs=num_epochs,
+                device=device,
+                four_bit_quant=four_bit_quant,
             )
-
-        mt_bench_judge: pathlib.Path
-        if phased_mt_bench_judge is None:
-            ctx.fail("No MT-Bench model was provided with '--phased-mt-bench-judge'")
-        elif not phased_mt_bench_judge.resolve().exists():
-            raise FileNotFoundError(
-                f"MT-Bench model directory could not be found: {phased_mt_bench_judge}\nMust be an absolute path to a model directory."
-            )
-        else:
-            # makes MyPy happy because 'mt_bench_judge' isn't Path | None
-            mt_bench_judge = phased_mt_bench_judge
-
-        if training_journal is None:
-            training_journal = phased_base_dir / "journalfile.yaml"
-        else:
-            # might come in as a str so needs to become a path.
-            training_journal = pathlib.Path(training_journal)
-
-        # try to load journal. May be empty.
-        journal = TrainingJournal(journalfile=training_journal)
-        click.secho("\n\n~~~~~~~~~~~~~STARTING MULTI-PHASE TRAINING~~~~~~~~~~~~~")
-
-        # experimental preference.
-        if phased_phase1_num_epochs != 7:
-            click.secho(
-                f"Running phased training with '{phased_phase1_num_epochs}' epochs.\nNote: 7 epochs is the recommended amount for optimal performance.",
-                fg="yellow",
-            )
-
-        if journal.was_loaded:
-            click.secho(
-                f"There was an existing training journal at: '{str(training_journal)}'"
-            )
-            journal.print_model_rich()
-            click.secho(
-                f"WARNING: Existing training journal state must correspond to state in '{str(phased_base_dir)}'",
-                bg="yellow",
-                fg="black",
-            )
-            click.secho("Alternative behavior is undefined.", bg="yellow", fg="black")
-        else:
-            click.secho(
-                f"No training journal found. Will initialize at: '{str(journal.journalfile)}'",
-                bg="yellow",
-                fg="black",
-            )
-            journal.commit(create_new=True)
-
-        user_clear_cache: bool = False
-        if not skip_user_confirm:
-            click.secho(
-                "Metadata (checkpoints, the training journal) may have been saved from a previous training run."
-            )
-            click.secho(
-                "By default, training will resume from this metadata if it exists."
-            )
-            click.secho(
-                "Alternatively, the metadata can be cleared, and training can start from scratch."
-            )
-            click.secho("\nWould you like to START TRAINING FROM THE BEGINNING?")
-
-            user_clear_cache = click.confirm(
-                "'y' clears metadata to start new training, 'N' tries to resume: "
-            )
-
-        user_clear_cache = user_clear_cache or force_clear_phased_cache
-
-        if user_clear_cache:
-            training_journal.unlink(
-                missing_ok=True
-            )  # delete whatever the old journal was
-            journal = TrainingJournal(
-                journalfile=training_journal
-            )  # create an empty journal
-            journal.commit(create_new=True)  # save it.
-
-        _prepare_phased_base_dir(phased_base_dir, delete_subdirs=user_clear_cache)
-
-        _run_phased_training(
-            ctx=ctx,
-            train_args=train_args,
-            torch_args=torch_args,
-            base_dir=phased_base_dir,
-            phase1_data=phased_phase1_data,
-            phase1_num_epochs=phased_phase1_num_epochs,
-            phase1_samples_per_save=phased_phase1_samples_per_save,
-            phase1_checkpoints_dir=phased_base_dir / "phase1" / "checkpoints",
-            phased_phase1_effective_batch_size=phased_phase1_effective_batch_size,
-            phase2_data=phased_phase2_data,
-            phase2_num_epochs=phased_phase2_num_epochs,
-            phase2_samples_per_save=phased_phase2_samples_per_save,
-            phase2_checkpoints_dir=phased_base_dir / "phase2" / "checkpoints",
-            phased_phase2_effective_batch_size=phased_phase2_effective_batch_size,
-            phase2_eval_cache=phased_base_dir / "phase2" / "eval_cache",
-            mtbench_judge=mt_bench_judge,
-            enable_serving_output=enable_serving_output,
-            journal=journal,
-        )
-
-    else:
-        # we can use train_args locally to run lower fidelity training
-        if is_high_fidelity(device=device) and pipeline == "accelerated":
-            # run_training is a dynamic attribute, pylint is not clever enough
-            # to detect it.
-            # Third Party
-            from instructlab.training import (
-                run_training,  # pylint: disable=no-name-in-module
-            )
-
-            train_args, torch_args = map_train_to_library(ctx, ctx.params)
-
-            run_training(train_args=train_args, torch_args=torch_args)
-        elif not is_high_fidelity(device=device) and pipeline == "full":
-            # Third Party
-            import torch
-
-            torch.set_autocast_enabled(False)
-            # Local
-            from . import full_train
-
-            train_args, torch_args = map_train_to_library(ctx, ctx.params)
-            # if on CPU or MPS, execute full train, which is based
-            # off of the structure of the training repo, just with different optimizers, model sizes, and special data gradient accumulation to get it
-            # to fit on most consumer laptops
-            full_train.train(train_args=train_args, device=device)
-        elif pipeline == "simple":
-            # Local
-            from . import simple_train
-
-            try:
-                simple_train.simple_train(
-                    model_path=model_path,
-                    skip_preprocessing=skip_preprocessing,
-                    skip_quantize=skip_quantize,
-                    gguf_model_path=gguf_model_path,
-                    tokenizer_dir=tokenizer_dir,
-                    data_path=data_path,
-                    input_dir=input_dir,
-                    ckpt_output_dir=Path(kwargs["ckpt_output_dir"]),
-                    iters=iters,
-                    local=local,
-                    num_epochs=num_epochs,
-                    device=device,
-                    four_bit_quant=four_bit_quant,
-                )
-            except Exception as exc:
-                click.secho(f"{exc}", fg="red")
-                raise click.exceptions.Exit(1)
+        except Exception as exc:
+            click.secho(f"{exc}", fg="red")
+            raise click.exceptions.Exit(1)
 
 
 # chooses which type of training to run depending on the device provided
 def is_high_fidelity(device):
     return device in ("cuda", "hpu")
-
-
-def _prepare_phased_base_dir(
-    phased_base_dir: pathlib.Path, delete_subdirs: bool = True
-) -> None:
-    """Adds phase1 and phase2 directories in phased_base_dir.
-    In each, adds `checkpoints` and `eval_cache` subdirectories.
-
-    Also adds training `journalfile.yaml`
-
-    Args:
-        phased_base_dir: directory wrapping phase1 and phase2 cached data.
-    """
-
-    logger.debug(f"Phased Training -- Preparing phased base dir: {phased_base_dir}")
-
-    phase1_dir_path = phased_base_dir / "phase1"
-    phase2_dir_path = phased_base_dir / "phase2"
-
-    for p in [phase1_dir_path, phase2_dir_path]:
-        if delete_subdirs:
-            utils.clear_directory(p)
-        _setup_phase_dirs(p)
-
-
-def _setup_phase_dirs(path: pathlib.Path) -> None:
-    """Creates {path}/checkpoints and {path}/eval_cache directories."""
-
-    # TODO: these sub-directory names are hard-coded here but they
-    # could be parameterized in config.
-    logger.debug(f"Phased Training -- Created phase directories for {path}")
-    ckpt_path = path / "checkpoints"
-    eval_cache_path = path / "eval_cache"
-
-    os.makedirs(ckpt_path, exist_ok=True)
-    os.makedirs(eval_cache_path, exist_ok=True)
-
-
-def _training_phase(
-    train_args: TrainingArgs,
-    torch_args: TorchrunArgs,
-    data_path: pathlib.Path,
-    model_override: pathlib.Path | None = None,
-    num_epochs: int | None = None,
-    samples_per_save: int | None = None,
-    checkpoint_dir: pathlib.Path | None = None,
-    effective_batch_size: int | None = None,
-) -> None:
-    """A single step of phased training that supports key param overriding."""
-
-    # Third Party
-    from instructlab.training import run_training  # pylint: disable=no-name-in-module
-
-    logger.debug(
-        f"Phased Training -- training phase -- Overriding data_path: {train_args.data_path} with {data_path}"
-    )
-
-    # NOTE: have to cast pathlib.Path to str because Pydantic models require this. Here and below.
-    train_args.data_path = str(data_path)
-
-    if checkpoint_dir:
-        train_args.ckpt_output_dir = str(checkpoint_dir)
-
-    if model_override:
-        logger.debug(
-            f"Phased Training -- training phase -- Overriding model_path: {train_args.model_path} with {model_override}"
-        )
-        train_args.model_path = str(model_override)
-
-    if num_epochs:
-        logger.debug(
-            f"Phased Training -- training phase -- Overriding num epochs: {train_args.num_epochs} with {num_epochs}"
-        )
-        train_args.num_epochs = num_epochs
-
-    if samples_per_save is not None:
-        logger.debug(
-            f"Phased Training -- training phase -- Overriding samples per save: {train_args.save_samples} with {samples_per_save}"
-        )
-        train_args.save_samples = samples_per_save
-
-    if effective_batch_size:
-        logger.debug(
-            f"Phased Training -- training phase -- Overriding effective batch size: {train_args.effective_batch_size} with {effective_batch_size}"
-        )
-        train_args.effective_batch_size = effective_batch_size
-
-    click.secho(
-        f"TrainingArgs for current phase: {pprint.pformat(train_args)}", fg="cyan"
-    )
-
-    run_training(train_args=train_args, torch_args=torch_args)
-
-
-def _mmlu(model: pathlib.Path) -> float:
-    # Third Party
-    from instructlab.eval.mmlu import MMLU_TASKS, MMLUEvaluator
-    import torch
-
-    tasks = MMLU_TASKS
-    if os.environ.get("INSTRUCTLAB_EVAL_MMLU_MIN_TASKS") is not None:
-        tasks = tasks[:4]
-    evaluator = MMLUEvaluator(model, tasks=tasks)
-
-    # type the variable because MyPy doesn't seem to honor the types of the spread tuple
-    ckpt_score: float
-    ckpt_score, _ = evaluator.run()
-
-    logging.debug("Phased Training -- MMLU eval phase -- Clearing PyTorch cache")
-    torch.cuda.empty_cache()
-
-    return ckpt_score
-
-
-def _mtbench(
-    ctx,
-    model: pathlib.Path,
-    eval_cache: pathlib.Path,
-    mtbench_judge: pathlib.Path,
-    enable_serving_output: bool,
-) -> float:
-    # TODO: optimization: run all generations in serial and then do all judgments at once to save time loading/unloading prometheus.
-    # Third Party
-    from instructlab.eval.mt_bench import MTBenchEvaluator
-    import torch
-
-    # First Party
-    from instructlab.model.evaluate import get_gpus, get_model_name, launch_server
-
-    # hard-override for local insecure vLLM serving
-    ctx.params["tls_client_cert"] = None
-    ctx.params["tls_client_key"] = None
-    ctx.params["tls_client_passwd"] = None
-    ctx.params["tls_insecure"] = True
-
-    explicit_gpus = None
-    gpus, effective_gpus = get_gpus(ctx, ctx.obj.config.evaluate.gpus)
-    if gpus and gpus > 0:
-        # gpus are specified in config for evaluate
-        logger.debug("Using gpus from config")
-        explicit_gpus = gpus
-    elif effective_gpus > 0:
-        # tensor-parallel size specified in serving config
-        logger.debug("Using gpus from --tensor-parallel-size in config")
-    else:
-        # TODO: Should be parameterized by the user specific for training
-        explicit_gpus = torch.cuda.device_count()
-        effective_gpus = explicit_gpus
-
-    model_name = get_model_name(str(model))
-    judge_model_name = get_model_name(str(mtbench_judge))
-
-    evaluator = MTBenchEvaluator(
-        model_name=model_name,
-        judge_model_name=judge_model_name,
-        output_dir=str(eval_cache),
-        merge_system_user_message=True,  # TODO: expose this to the user
-    )
-
-    server = None
-    model_serve_url = None
-    try:
-        logger.debug("Starting model server for mt-bench answer generation")
-        server, model_serve_url, effective_gpus = launch_server(
-            ctx=ctx,
-            model=str(model),
-            model_name=model_name,
-            gpus=explicit_gpus,
-            max_workers="auto",
-            enable_serving_output=enable_serving_output,
-            backend=backends.VLLM,
-        )
-        logger.debug("Generating mt-bench answers")
-        evaluator.gen_answers(
-            model_serve_url, max_workers="auto", serving_gpus=effective_gpus
-        )
-    finally:
-        if server is not None:
-            server.shutdown()
-
-    try:
-        logger.debug("Starting model server for mt-bench answer judgment")
-        server, model_serve_url, effective_gpus = launch_server(
-            ctx=ctx,
-            model=str(mtbench_judge),
-            model_name=judge_model_name,
-            gpus=explicit_gpus,
-            max_workers="auto",
-            backend=backends.VLLM,
-            enable_serving_output=enable_serving_output,
-        )
-        logger.debug("Judging mt-bench answers")
-        mt_bench_results: tuple = evaluator.judge_answers(
-            model_serve_url, max_workers="auto", serving_gpus=effective_gpus
-        )
-        ckpt_score: float = mt_bench_results[0]
-    finally:
-        if server is not None:
-            server.shutdown()
-
-    return ckpt_score
-
-
-def _evaluate_dir_of_checkpoints(
-    eval_func: typing.Callable[..., float],
-    phase_model: EvalPhaseModel,
-    journal: TrainingJournal,
-) -> EvalResult:
-    """Run eval_func on all model checkpoints in a directory."""
-    # TODO: parallelize MMLU over available GPUs
-
-    # doing this to avoid removing checkpoints from same list that we're iterating over.
-    checkpoints_todo = list(
-        set(phase_model.checkpoints) - set(phase_model.finished_checkpoints)
-    )
-
-    if len(checkpoints_todo) == 0:
-        raise RuntimeError(
-            "No checkpoints were evaluated, 'checkpoints_todo' was empty in journal."
-        )
-
-    for checkpoint in checkpoints_todo:
-        logger.debug(str(checkpoint))
-        checkpoint_score = eval_func(model=checkpoint)
-
-        phase_model.results.append(
-            EvalResult(
-                score=checkpoint_score,
-                checkpoint=checkpoint,
-                ended_at_utc=TrainingJournal.now_utc(),
-            )
-        )
-
-        phase_model.finished_checkpoints.append(checkpoint)
-        journal.commit()
-
-        click.secho(
-            f"CHECKPOINT EVALUATION: {str(checkpoint)} SCORED {checkpoint_score}",
-            fg="red",
-            bg="cyan",
-        )
-
-    return TrainingJournal.best_checkpoint(phase_model=phase_model)
-
-
-def _run_phased_training(
-    ctx,
-    train_args: TrainingArgs,
-    torch_args: TorchrunArgs,
-    base_dir: pathlib.Path,
-    phase1_data: pathlib.Path,
-    phase1_num_epochs: int | None,
-    phase1_samples_per_save: int | None,
-    phase1_checkpoints_dir: pathlib.Path,
-    phased_phase1_effective_batch_size: int | None,
-    phase2_data: pathlib.Path,
-    phase2_num_epochs: int | None,
-    phase2_samples_per_save: int | None,
-    phase2_checkpoints_dir: pathlib.Path,
-    phased_phase2_effective_batch_size: int | None,
-    phase2_eval_cache: pathlib.Path,
-    mtbench_judge: pathlib.Path,
-    enable_serving_output: bool,
-    journal: TrainingJournal,
-) -> None:
-    if journal.current_phase == TrainingPhases.DONE:
-        click.secho(
-            "The selected Training Journal suggests that training has finished, with 'current_phase=done' in the journalfile.",
-            fg="cyan",
-        )
-        return
-
-    # make mypy happy
-    phase_model: TrainPhaseModel | EvalPhaseModel | None = None
-
-    if journal.current_phase == TrainingPhases.TRAIN1:
-        click.secho("Training Phase 1/2...", fg="cyan")
-
-        phase_model = journal.journal.train_1
-        if phase_model is None:
-            phase_model = TrainPhaseModel(checkpoints=phase1_checkpoints_dir)
-            journal.journal.train_1 = phase_model
-        journal.commit()
-
-        _training_phase(
-            train_args=train_args.model_copy(deep=True),
-            torch_args=torch_args,
-            data_path=phase1_data,
-            checkpoint_dir=phase1_checkpoints_dir,
-            num_epochs=phase1_num_epochs,
-            samples_per_save=phase1_samples_per_save,
-            effective_batch_size=phased_phase1_effective_batch_size,
-            # model override not necessary because we expect model to come from ctx.params.model_path.
-        )
-
-        phase_model.ended_at_utc = TrainingJournal.now_utc()
-
-        journal.current_phase = TrainingPhases.TRAIN2
-        journal.commit()
-
-        logger.debug("Finished training #1\n%s", journal.print_model_rich())
-    else:
-        click.secho("SKIPPING: Training Phase 1/2; already in Journal", fg="cyan")
-
-    # if journal.current_phase == TrainingPhases.EVAL1:
-    #     click.secho("MMLU evaluation for Phase 1...", fg="cyan")
-
-    # NOTE: requires hf_format sub-directory. Training sets this up.
-    # phase1_checkpoints_dir = phase1_checkpoints_dir / "hf_format"
-
-    # phase_model = journal.journal.eval_1
-    # if phase_model is None:
-    #     # if it's not None, it already exists and may have 'results', so we shouldn't overwrite it.
-    #     phase_model = EvalPhaseModel(
-    #         checkpoints=list(phase1_checkpoints_dir.iterdir())
-    #     )
-    #     journal.journal.eval_1 = phase_model
-    # journal.commit()
-
-    # best_checkpoint = _evaluate_dir_of_checkpoints(
-    #     eval_func=_mmlu, phase_model=phase_model, journal=journal
-    # )
-
-    # phase_model.best_checkpoint = best_checkpoint
-    # phase_model.ended_at_utc = TrainingJournal.now_utc()
-
-    #     journal.current_phase = TrainingPhases.TRAIN2
-    #     journal.commit()
-    #     logger.debug("Finished eval #1\n%s", journal.print_model_rich())
-    # else:
-    #     click.secho(
-    #         "SKIPPING: MMLU evaluation for Phase 1; already in Journal", fg="cyan"
-    #     )
-
-    if journal.current_phase == TrainingPhases.TRAIN2:
-        click.secho("Training Phase 2/2...", fg="cyan")
-
-        phase_model = journal.journal.train_2
-        if phase_model is None:
-            phase_model = TrainPhaseModel(checkpoints=phase2_checkpoints_dir)
-            journal.journal.train_2 = phase_model
-        journal.commit()
-
-        # if journal.journal.eval_1 is None:
-        #     raise RuntimeError(
-        #         "Training journal field 'eval_1' cannot be None for phase 'train_2'"
-        #     )
-
-        # NOTE:
-        # this is a recent change, implemented to ignore MMLU. We just look at the checkpoints
-        # from the phase 1 training and take the most recent one.
-        phase1_checkpoints_dir_hf = phase1_checkpoints_dir / "hf_format"
-        if not phase1_checkpoints_dir_hf.exists():
-            raise FileNotFoundError(
-                f"{phase1_checkpoints_dir_hf} doesn't exist. This likely means that no checkpoints were saved from phase 1."
-            )
-
-        phase1_checkpoints = sorted(
-            list(phase1_checkpoints_dir_hf.iterdir()),
-            reverse=True,
-            # XXX(osilkin): This line takes the checkpoint name "samples_NNN" and tells sorted
-            #               to use the last NNN string as an integer
-            key=lambda x: int(str(x).rsplit("_", maxsplit=1)[-1]),
-        )
-
-        if len(phase1_checkpoints) == 0:
-            raise FileNotFoundError(
-                f"{phase1_checkpoints_dir_hf} Has no checkpoints. This likely means that no checkpoints were saved from phase 1."
-            )
-
-        next_checkpoint = phase1_checkpoints[0]
-
-        _training_phase(
-            train_args=train_args.model_copy(deep=True),
-            torch_args=torch_args,
-            data_path=phase2_data,
-            checkpoint_dir=phase2_checkpoints_dir,
-            model_override=next_checkpoint,  # type: ignore
-            num_epochs=phase2_num_epochs,
-            samples_per_save=phase2_samples_per_save,
-            effective_batch_size=phased_phase2_effective_batch_size,
-        )
-
-        phase_model.ended_at_utc = TrainingJournal.now_utc()
-
-        journal.current_phase = TrainingPhases.EVAL2
-        journal.commit()
-        logger.debug("Finished training #2\n%s", journal.print_model_rich())
-    else:
-        click.secho("SKIPPING: Training Phase 2/2; already in Journal", fg="cyan")
-
-    if journal.current_phase == TrainingPhases.EVAL2:
-        click.secho("MT-Bench evaluation for Phase 2...", fg="cyan")
-
-        phase2_checkpoints_dir = phase2_checkpoints_dir / "hf_format"
-        phase2_eval_cache = base_dir / "phase2" / "eval_cache"
-        phase_model = journal.journal.eval_2
-        if phase_model is None:
-            # if it's not None, it already exists and may have 'results', so we shouldn't overwrite it.
-            phase_model = EvalPhaseModel(
-                checkpoints=list(phase2_checkpoints_dir.iterdir())
-            )
-            journal.journal.eval_2 = phase_model
-        journal.commit()
-
-        best_checkpoint = _evaluate_dir_of_checkpoints(
-            phase_model=phase_model,
-            journal=journal,
-            eval_func=functools.partial(
-                _mtbench,
-                ctx=ctx,
-                eval_cache=phase2_eval_cache,
-                mtbench_judge=mtbench_judge,
-                enable_serving_output=enable_serving_output,
-            ),
-        )
-
-        phase_model.best_checkpoint = best_checkpoint
-        phase_model.ended_at_utc = TrainingJournal.now_utc()
-
-        journal.current_phase = TrainingPhases.DONE
-        journal.journal.final_output = best_checkpoint
-        journal.journal.ended_at_utc = TrainingJournal.now_utc()
-        journal.commit()
-        logger.debug("Finished eval #2\n%s", journal.print_model_rich())
-
-    else:
-        click.secho(
-            "SKIPPING: MT-Bench evaluation for Phase 2; already in Journal", fg="cyan"
-        )
-
-    output_checkpoint: EvalResult | None = journal.journal.final_output
-    if not output_checkpoint:
-        raise RuntimeError(
-            "At the end of training, but no 'final_output' checkpoint in TrainingJournal"
-        )
-
-    click.secho(
-        f"Training finished! Best final checkpoint: {output_checkpoint.checkpoint} with score: {output_checkpoint.score}\nJournal: {str(journal.journalfile)}",
-        fg="green",
-    )

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -424,7 +424,7 @@ class TestLabTrain:
         assert linux_train_mock.call_args[1]["num_epochs"] == 10
         assert linux_train_mock.call_args[1]["train_device"] is not None
         assert not linux_train_mock.call_args[1]["four_bit_quant"]
-        assert len(linux_train_mock.call_args[1]) == 7
+        assert len(linux_train_mock.call_args[1]) == 6
         is_macos_with_m_chip_mock.assert_called_once()
         assert not os.path.isfile(LINUX_GGUF_FILE)
 
@@ -496,7 +496,7 @@ class TestLabTrain:
             assert linux_train_mock.call_args[1]["num_epochs"] == 10
             assert linux_train_mock.call_args[1]["train_device"] is not None
             assert not linux_train_mock.call_args[1]["four_bit_quant"]
-            assert len(linux_train_mock.call_args[1]) == 7
+            assert len(linux_train_mock.call_args[1]) == 6
             is_macos_with_m_chip_mock.assert_called_once()
             assert not os.path.isfile(LINUX_GGUF_FILE)
 
@@ -534,7 +534,7 @@ class TestLabTrain:
             assert linux_train_mock.call_args[1]["num_epochs"] == 10
             assert linux_train_mock.call_args[1]["train_device"] is not None
             assert not linux_train_mock.call_args[1]["four_bit_quant"]
-            assert len(linux_train_mock.call_args[1]) == 7
+            assert len(linux_train_mock.call_args[1]) == 6
             assert not os.path.isfile(LINUX_GGUF_FILE)
 
     @patch("instructlab.utils.is_macos_with_m_chip", return_value=False)


### PR DESCRIPTION
`ilab model train` has many modes of operation. These various modes will eventually need to be different endpoints accessible to users via a REST API. Additionally, in order to implement process handling in `ilab` having the actual underlying functionality of each train loop in its own module which takes primarily primitive types will allow us to kick off and manage processes seamlessly once that work begins.  `multiprocessing` in python can only pickle certain objects, so I did my best here to remove click focused variables from the train loops and opt for raising exceptions back to `train.py` file. 

resolves #2400 
**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
