### PR TITLE
fix: mergify shouldn't require lint when script shell files are changed

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -45,7 +45,6 @@ pull_request_rules:
         - -files~=^scripts/test-data/
         - -files=.github/workflows/e2e-nvidia-a10g-x1.yml
 
-
     # small e2e workflow
     - or:
       - and:
@@ -97,7 +96,6 @@ pull_request_rules:
           - files~=^requirements.*\.txt$
           - files=tox.ini
           - files=.pylintrc
-          - files~=^scripts/[^/]+\.sh$
           - files=.github/workflows/lint.yml
       - and:
         - -files~=\.py$
@@ -105,7 +103,6 @@ pull_request_rules:
         - -files~=^requirements.*\.txt$
         - -files=tox.ini
         - -files=.pylintrc
-        - -files~=^scripts/[^/]+\.sh$
         - -files=.github/workflows/lint.yml
 
     - or:

--- a/.github/workflows/e2e-nvidia-a10g-x1.yml
+++ b/.github/workflows/e2e-nvidia-a10g-x1.yml
@@ -127,7 +127,7 @@ jobs:
           # https://github.com/instructlab/instructlab/issues/1821
           # install with Torch and build dependencies installed
           python3.11 -m pip install packaging wheel setuptools-scm
-          python3.11 -m pip install .[cuda]
+          python3.11 -m pip install .[cuda] -r requirements-vllm-cuda.txt
 
       - name: Check disk
         run: |


### PR DESCRIPTION
Also adds missing vllm requirements file for Medium E2E job

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [x] E2E Workflow tests have been added, if necessary.
