### PR TITLE
fix: switch vram approximation

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -282,10 +282,16 @@ def match_profile_based_on_vram(vram) -> tuple[int | None, str | None, _train]:
             ):
                 click.secho("Unable to retrieve train profiles", fg="red")
                 raise click.exceptions.Exit(1)
+            # we want to match based off if our vRAM is >= the Profile vRAM. However,
+            # you do not want to overdo this and match a profile that has hundreds of GB less than your system
+            # only match if the profile has 30GB less than our system.
             if (
                 chosen_vram is None
                 or chosen_vram > gpu_count_configs["vram_and_config"]["vram"]
-            ) and vram < gpu_count_configs["vram_and_config"]["vram"]:
+            ) and (
+                vram >= gpu_count_configs["vram_and_config"]["vram"]
+                and vram - gpu_count_configs["vram_and_config"]["vram"] <= 30
+            ):
                 # set our return values
                 gpus = gpu_count_configs["gpu_count"]
                 chosen_profile_name = f"Nvidia {gpus}x {group_gpu_name}"

--- a/tests/test_lab_init.py
+++ b/tests/test_lab_init.py
@@ -25,7 +25,7 @@ class TestLabInit:
         assert result.exit_code == 0, result.stdout
         convert_bytes_to_proper_mag_mock.assert_called_once()
         assert (
-            "We chose Nvidia 2x A100 as your designated training profile. This is for systems with 160 GB of vRAM"
+            "We chose Nvidia 1x L40s as your designated training profile. This is for systems with 80 GB of vRAM"
             in result.stdout
         )
 


### PR DESCRIPTION
vram approximation should be >= not <. Using less than can lead to situations where we overmatch to a profile that can cause OOM situations. Making sure our profile is "overfit" for the vRAM makes more sense. However, there has to be a threshold here so we don't overfit in the other direction
