### PR TITLE
Setting proper amount of RAM for L40s and creating config for single A100

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1373,7 +1373,7 @@ def get_profile_mappings() -> dict[str, tuple[dict[str, object], ...]]:
 
     profile_mappings = {
         "L40s": (
-            {"gpu_count": 1, "vram_and_config": {"vram": 80, "config": SINGLE_L40}},
+            {"gpu_count": 1, "vram_and_config": {"vram": 48, "config": SINGLE_L40}},
             {
                 "gpu_count": 4,
                 "vram_and_config": {
@@ -1400,6 +1400,10 @@ def get_profile_mappings() -> dict[str, tuple[dict[str, object], ...]]:
             },
         ),
         "A100": (
+            {
+                "gpu_count": 1,
+                "vram_and_config": {"vram": 80, "config": SINGLE_A100_H100},
+            },
             {
                 "gpu_count": 2,
                 "vram_and_config": {


### PR DESCRIPTION

The amount of vRAM for single L40s is now set according to datasheet[1].

The profile for single A100 card has been added.

[1] https://resources.nvidia.com/en-us-l40s/l40s-datasheet-28413

Should partly address issues like #2451 

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Functional tests have been added, if necessary.
- [x] E2E Workflow tests have been added, if necessary.
