### PR TITLE
feat: Switch data generate and model download default behaviors

### DIFF
--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Run e2e test
         run: |
           . venv/bin/activate
-          ./scripts/e2e-custom.sh -msq
+          ./scripts/e2e-custom.sh -mSsq
 
   stop-small-ec2-runner:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,7 @@ jobs:
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
         with:
           path: ~/.cache/huggingface
-          # config contains DEFAULT_MODEL
+          # config contains DEFAULT_CHAT_MODEL
           key: huggingface-${{ hashFiles('src/instructlab/configuration.py') }}
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Intel Gaudi software has been updated to 1.17.1 with Python 3.11 and
   Torch 2.3.1 support.
 * `--legacy` has been removed and replaced with `--pipeline=simple` in `ilab model train`
+* `ilab data generate` now defaults to `--pipeline full` and uses the  `TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral-7b-instruct-v0.2.Q4_K_M.gguf` model as the teacher. This provides increased performance and better generated data.
 
 ### Features
 

--- a/scripts/e2e-custom.sh
+++ b/scripts/e2e-custom.sh
@@ -24,7 +24,7 @@ SIMPLE_TRAIN=0
 FULL_TRAIN=0
 ACCELERATED_TRAIN=0
 HF_TOKEN=${HF_TOKEN:-}
-SDG_PIPELINE="simple"
+SDG_PIPELINE="full"
 SKIP_TRAIN=${SKIP_TRAIN:-0}
 EVAL=0
 MIXTRAL_GGUF_MODEL="mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf"
@@ -266,9 +266,9 @@ test_generate() {
         GENERATE_ARGS+=("--model" "${CACHE_HOME}/instructlab/models/${MERLINITE_GGUF_MODEL}")
     fi
 
-    # default arg for '--pipeline' is "simple"
-    if [ "$SDG_PIPELINE" = "full" ]; then
-        GENERATE_ARGS+=("--pipeline" "full")
+    # default arg for '--pipeline' is "full"
+    if [ "$SDG_PIPELINE" = "simple" ]; then
+        GENERATE_ARGS+=("--pipeline" "simple")
     fi
 
     # Disable batching with llama-cpp. See https://github.com/instructlab/instructlab/issues/1892
@@ -534,7 +534,7 @@ usage() {
     echo "  -a  Use the 'full' training library rather than legacy training"
     echo "  -s  Run the simple training using the SFTTainer rather than the custom training loop"
     echo "  -f  Run the fullsize training instead of --4-bit-quant"
-    echo "  -F  Use the 'full' SDG pipeline instead of the default 'simple' pipeline"
+    echo "  -S  Use the 'simple' SDG pipeline instead of the default 'full' pipeline"
     echo "  -h  Show this help text"
     echo "  -m  Run minimal configuration with lower number of instructions and training epochs (run quicker when you have no GPU)"
     echo "  -M  Use the mixtral model (4-bit quantized) instead of merlinite model (4-bit quantized)."
@@ -544,15 +544,15 @@ usage() {
 
 # Process command line arguments
 task "Configuring ..."
-while getopts "eFhqasfmMPv" opt; do
+while getopts "eShqasfmMPv" opt; do
     case $opt in
         e)
             EVAL=1
             step "Run model evaluation."
             ;;
-        F)
-            SDG_PIPELINE="full"
-            step "Using full SDG pipeline."
+        S)
+            SDG_PIPELINE="simple"
+            step "Using simple SDG pipeline."
             ;;
         h)
             usage

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -331,7 +331,7 @@ EOF
     sed -i.bak -e 's/sdg_scale_factor.*/sdg_scale_factor: 1/g' "${ILAB_CONFIG_FILE}"
 
     # This should be finished in a minute or so but time it out incase it goes wrong
-    if ! timeout 20m ilab data generate --taxonomy-path test_taxonomy/compositional_skills/qna.yaml; then
+    if ! timeout 20m ilab data generate --pipeline simple --model "${ILAB_CACHE_DIR}/models/merlinite-7b-lab-Q4_K_M.gguf"  --taxonomy-path test_taxonomy/compositional_skills/qna.yaml; then
         echo "Error: ilab data generate command took more than 20 minutes and was cancelled"
         exit 1
     fi

--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -38,7 +38,7 @@ from instructlab.utils import convert_bytes_to_proper_mag
 @click.option(
     "--model-path",
     type=click.Path(),
-    default=lambda: DEFAULTS.DEFAULT_MODEL,
+    default=lambda: DEFAULTS.DEFAULT_CHAT_MODEL,
     show_default="The instructlab data files location per the user's system.",
     help="Path to the model used during generation.",
 )

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -117,7 +117,7 @@ class _chat(BaseModel):
     # model configuration
     model_config = ConfigDict(extra="ignore")
     model: str = Field(
-        default_factory=lambda: DEFAULTS.DEFAULT_MODEL,
+        default_factory=lambda: DEFAULTS.DEFAULT_CHAT_MODEL,
         description="Model to be used for chatting with.",
     )
     # additional fields with defaults
@@ -206,7 +206,7 @@ class _serve(BaseModel):
         description="llama-cpp serving settings.",
     )
     model_path: StrictStr = Field(
-        default_factory=lambda: DEFAULTS.DEFAULT_MODEL,
+        default_factory=lambda: DEFAULTS.DEFAULT_CHAT_MODEL,
         description="Directory where model to be served is stored.",
     )
     # additional fields with defaults
@@ -245,7 +245,7 @@ class _generate(BaseModel):
         description="Data generation pipeline to use. Available: 'simple', 'full', or a valid path to a directory of pipeline workflow YAML files. Note that 'full' requires a larger teacher model, Mixtral-8x7b.",
     )
     model: StrictStr = Field(
-        default_factory=lambda: DEFAULTS.DEFAULT_MODEL,
+        default_factory=lambda: DEFAULTS.DEFAULT_TEACHER_MODEL,
         description="Teacher model that will be used to synthetically generate training data.",
     )
     taxonomy_path: StrictStr = Field(
@@ -257,7 +257,10 @@ class _generate(BaseModel):
         description="Branch of taxonomy used to calculate diff against.",
     )
     # additional fields with defaults
-    teacher: _serve = Field(default_factory=_serve, description="Teacher configuration")
+    teacher: _serve = Field(
+        default_factory=lambda: _serve(model_path=DEFAULTS.DEFAULT_TEACHER_MODEL),
+        description="Teacher configuration",
+    )
     num_cpus: PositiveInt = Field(
         default=DEFAULTS.NUM_CPUS,
         description="Number of CPU cores to use for generation.",

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -55,6 +55,7 @@ class _InstructlabDefaults:
     # TODO: Consolidate --model and --model-path into one --model-path flag since we always need a path now
     MODEL_NAME_OLD = "merlinite-7b-lab-Q4_K_M"
     MERLINITE_GGUF_REPO = "instructlab/merlinite-7b-lab-GGUF"
+    MISTRAL_GGUF_REPO = "TheBloke/Mistral-7B-Instruct-v0.2-GGUF"
     GGUF_MODEL_NAME = "merlinite-7b-lab-Q4_K_M.gguf"
     MISTRAL_GGUF_MODEL_NAME = "mistral-7b-instruct-v0.2.Q4_K_M.gguf"
     MODEL_REPO = "instructlab/granite-7b-lab"

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -56,6 +56,7 @@ class _InstructlabDefaults:
     MODEL_NAME_OLD = "merlinite-7b-lab-Q4_K_M"
     MERLINITE_GGUF_REPO = "instructlab/merlinite-7b-lab-GGUF"
     GGUF_MODEL_NAME = "merlinite-7b-lab-Q4_K_M.gguf"
+    MISTRAL_GGUF_MODEL_NAME = "mistral-7b-instruct-v0.2.Q4_K_M.gguf"
     MODEL_REPO = "instructlab/granite-7b-lab"
     JUDGE_MODEL_MT = "prometheus-eval/prometheus-8x7b-v2.0"
     TAXONOMY_REPO = "https://github.com/instructlab/taxonomy.git"
@@ -67,7 +68,7 @@ class _InstructlabDefaults:
     CONNECTION_TIMEOUT = httpx.Timeout(timeout=30.0)
     # use spawn start method, fork is not thread-safe
     MULTIPROCESSING_START_METHOD = "spawn"
-    SDG_PIPELINE = "simple"
+    SDG_PIPELINE = "full"
     SDG_SCALE_FACTOR = 30
 
     # When otherwise unknown, ilab uses this as the default family
@@ -120,8 +121,12 @@ class _InstructlabDefaults:
         return path.join(self._cache_home, STORAGE_DIR_NAMES.MODELS)
 
     @property
-    def DEFAULT_MODEL(self) -> str:
+    def DEFAULT_CHAT_MODEL(self) -> str:
         return path.join(self.MODELS_DIR, self.GGUF_MODEL_NAME)
+
+    @property
+    def DEFAULT_TEACHER_MODEL(self) -> str:
+        return path.join(self.MODELS_DIR, self.MISTRAL_GGUF_MODEL_NAME)
 
     @property
     def DEFAULT_JUDGE_MODEL(self) -> str:

--- a/src/instructlab/model/linux_test.py
+++ b/src/instructlab/model/linux_test.py
@@ -87,7 +87,7 @@ def linux_test(
     # linux_test
     logger.debug("test_file=%s", test_file)
     if not models:
-        models = [DEFAULTS.DEFAULT_MODEL]
+        models = [DEFAULTS.DEFAULT_CHAT_MODEL]
     if not create_params:
         create_params = {}
 

--- a/src/instructlab/model/test.py
+++ b/src/instructlab/model/test.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "-m",
     "--model",
-    default=lambda: DEFAULTS.DEFAULT_MODEL,
+    default=lambda: DEFAULTS.DEFAULT_CHAT_MODEL,
     show_default=True,
     help="Base model name to test on Linux",
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,8 @@ class TestConfig:
         internal_dirname = "internal"
         cache_dir = os.path.join(xdg_cache_home(), package_name)
         data_dir = os.path.join(xdg_data_home(), package_name)
-        default_model = f"{cache_dir}/models/merlinite-7b-lab-Q4_K_M.gguf"
+        default_chat_model = f"{cache_dir}/models/merlinite-7b-lab-Q4_K_M.gguf"
+        default_sdg_model = f"{cache_dir}/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf"
 
         assert cfg.general is not None
         assert cfg.version is not None
@@ -39,7 +40,7 @@ class TestConfig:
         assert cfg.general.debug_level == 0
 
         assert cfg.chat is not None
-        assert cfg.chat.model == default_model
+        assert cfg.chat.model == default_chat_model
         assert not cfg.chat.vi_mode
         assert cfg.chat.visible_overflow
         assert cfg.chat.context == "default"
@@ -53,7 +54,7 @@ class TestConfig:
         assert cfg.general.log_level == "INFO"
 
         assert cfg.generate is not None
-        assert cfg.generate.teacher.model_path == default_model
+        assert cfg.generate.teacher.model_path == default_sdg_model
         assert cfg.generate.teacher.llama_cpp is not None
         assert cfg.generate.teacher.llama_cpp.gpu_layers == -1
         assert cfg.generate.teacher.llama_cpp.max_ctx_size == 4096
@@ -63,8 +64,8 @@ class TestConfig:
         assert cfg.generate.teacher.host_port == "127.0.0.1:8000"
         assert cfg.generate.teacher.backend is None
         assert cfg.generate.teacher.chat_template is None
-        assert cfg.generate.pipeline == "simple"
-        assert cfg.generate.model == default_model
+        assert cfg.generate.pipeline == "full"
+        assert cfg.generate.model == default_sdg_model
         assert cfg.generate.taxonomy_path == f"{data_dir}/taxonomy"
         assert cfg.generate.taxonomy_base == "origin/main"
         assert cfg.generate.num_cpus == 10
@@ -76,7 +77,7 @@ class TestConfig:
         )
 
         assert cfg.serve is not None
-        assert cfg.serve.model_path == default_model
+        assert cfg.serve.model_path == default_chat_model
         assert cfg.serve.llama_cpp is not None
         assert cfg.serve.llama_cpp.gpu_layers == -1
         assert cfg.serve.llama_cpp.max_ctx_size == 4096
@@ -90,19 +91,19 @@ class TestConfig:
     def _assert_model_defaults(self, cfg):
         package_name = "instructlab"
         cache_dir = os.path.join(xdg_cache_home(), package_name)
-        default_model = f"{cache_dir}/models/merlinite-7b-lab-Q4_K_M.gguf"
+        default_chat_model = f"{cache_dir}/models/merlinite-7b-lab-Q4_K_M.gguf"
 
         assert cfg.chat is not None
-        assert cfg.chat.model == default_model
+        assert cfg.chat.model == default_chat_model
 
         assert cfg.evaluate is not None
         assert cfg.evaluate.base_model == "instructlab/granite-7b-lab"
 
         assert cfg.generate is not None
-        assert cfg.generate.model == DEFAULTS.DEFAULT_MODEL
+        assert cfg.generate.model == DEFAULTS.DEFAULT_TEACHER_MODEL
 
         assert cfg.serve is not None
-        assert cfg.serve.model_path == DEFAULTS.DEFAULT_MODEL
+        assert cfg.serve.model_path == DEFAULTS.DEFAULT_CHAT_MODEL
 
         assert cfg.train is not None
         assert cfg.train.model_path == "instructlab/granite-7b-lab"

--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -24,10 +24,13 @@ class TestLabDownload:
                 "--config=DEFAULT",
                 "model",
                 "download",
+                "--hf-token=foo",
             ],
         )
-        assert result.exit_code == 0, "command finished with an unexpected exit code"
-        mock_hf_hub_download.assert_called_once()
+        assert (
+            result.exit_code == 0
+        ), f"command finished with an unexpected exit code. {result.stdout}"
+        assert mock_hf_hub_download.call_count == 2
 
     @patch(
         "instructlab.model.download.hf_hub_download",

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -96,8 +96,8 @@ generate:
   # Default: 1000
   chunk_word_count: 1000
   # Teacher model that will be used to synthetically generate training data.
-  # Default: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
-  model: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
+  # Default: /cache/instructlab/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf
+  model: /cache/instructlab/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf
   # Number of CPU cores to use for generation.
   # Default: 10
   num_cpus: 10
@@ -111,8 +111,8 @@ generate:
   # Data generation pipeline to use. Available: 'simple', 'full', or a valid path to
   # a directory of pipeline workflow YAML files. Note that 'full' requires a larger
   # teacher model, Mixtral-8x7b.
-  # Default: simple
-  pipeline: simple
+  # Default: full
+  pipeline: full
   # The total number of instructions to be generated.
   # Default: 30
   sdg_scale_factor: 30
@@ -161,7 +161,7 @@ generate:
       max_ctx_size: 4096
     # Directory where model to be served is stored.
     # Default: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
-    model_path: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
+    model_path: /cache/instructlab/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf
     # vLLM serving settings.
     vllm:
       # Number of GPUs to use.


### PR DESCRIPTION
The simple pipeline is not maintained actively. The full pipeline runs on laptops using the mistral-7b-instruct GGUF. This pipeline takes longer but yields very good results as compared to simple.
    
 Switch the default model to mistral-7b-instruct-v0.2.Q4_K_M.gguf and the default SDG pipeline to full. Full does not work with merlinite due to prompt template incompatibility
    
I can provide sample outputs when using merlinite vs mistral, merlinite yields no results (0 generated samples), mistral yields ~150 from a small QNA + Wikipedia page.

Related to this change,   ilab model download by default downloads merlinite.
    
This should still happen for purposes of chatting with the model on your laptop.
    
However, --repository and --filename should be able to take multiple values and download each repo and its associated file.
    
The two defaults here will be the merlinite repo + filename, and the mistral repo + filename

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
