### PR TITLE
feat: `evaluate` can now format output as JSON

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -381,7 +381,7 @@ class _evaluate(BaseModel):
     )
     format: Optional[str] = Field(
         default="text",
-        description="Format of evaluation results. Defaults to 'text' which prints to stdout, also allows for 'json' to dump to a JSON file.",
+        description="Format of evaluation results. Defaults to 'text' which prints to stdout with additional logging, also allows for 'json' to print to stdout without additional logging",
         examples=["text", "json"],
         pattern="text|json",
     )

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -379,6 +379,12 @@ class _evaluate(BaseModel):
     gpus: Optional[int] = Field(
         default=None, description="Number of GPUs to use for running evaluation."
     )
+    format: Optional[str] = Field(
+        default="text",
+        description="Format of evaluation results. Defaults to 'text' which prints to stdout, also allows for 'json' to dump to a JSON file.",
+        examples=["text", "json"],
+        pattern="text|json",
+    )
     mmlu: _mmlu = Field(
         default_factory=_mmlu,
         description="MMLU benchmarking settings",

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -80,6 +80,13 @@ evaluate:
     # Path to where base taxonomy is stored.
     # Default: /data/instructlab/taxonomy
     taxonomy_path: /data/instructlab/taxonomy
+  # Format of evaluation results. Defaults to 'text' which prints to stdout, also
+  # allows for 'json' to dump to a JSON file.
+  # Default: text
+  # Examples:
+  #   - text
+  #   - json
+  results: text
 # General configuration section.
 general:
   # Debug level for logging.

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -40,6 +40,13 @@ evaluate:
   # evaluation runs.
   # Default: None
   branch:
+  # Format of evaluation results. Defaults to 'text' which prints to stdout, also
+  # allows for 'json' to dump to a JSON file.
+  # Default: text
+  # Examples:
+  #   - text
+  #   - json
+  format: text
   # Number of GPUs to use for running evaluation.
   # Default: None
   gpus:
@@ -80,13 +87,6 @@ evaluate:
     # Path to where base taxonomy is stored.
     # Default: /data/instructlab/taxonomy
     taxonomy_path: /data/instructlab/taxonomy
-  # Format of evaluation results. Defaults to 'text' which prints to stdout, also
-  # allows for 'json' to dump to a JSON file.
-  # Default: text
-  # Examples:
-  #   - text
-  #   - json
-  results: text
 # General configuration section.
 general:
   # Debug level for logging.


### PR DESCRIPTION
previously, results from evaluation had to be parsed from stdout
with this change users can dump eval results directly to a JSON file

**Issue resolved by this Pull Request:**
Resolves #2469 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
