### PR TITLE
fix: adjust training defaults for laptop

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -409,14 +409,14 @@ class _train(BaseModel):
         description="Maximum sequence length to be included in the training set. Samples exceeding this length will be dropped.",
     )
     max_batch_len: int = Field(
-        default=10000,
+        default=5000,
         description="Maximum tokens per gpu for each batch that will be handled in a single step. If running into out-of-memory errors, this value can be lowered but not below the `max_seq_len`.",
     )
     num_epochs: int = Field(
         default=10, description="Number of epochs to run training for."
     )
     effective_batch_size: int = Field(
-        default=3840,
+        default=64,
         description="The number of samples in a batch that the model should see before its parameters are updated.",
     )
     save_samples: int = Field(
@@ -438,7 +438,7 @@ class _train(BaseModel):
         validate_default=True,  # ensures that the 'use_enum_values' flag takes effect on the default value
     )
     lora_rank: int | None = Field(
-        default=4,
+        default=0,
         description="Rank of low rank matrices to be used during training.",
     )
     lora_quantize_dtype: str | None = Field(

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -274,8 +274,8 @@ train:
   distributed_backend: deepspeed
   # The number of samples in a batch that the model should see before its parameters
   # are updated.
-  # Default: 3840
-  effective_batch_size: 3840
+  # Default: 64
+  effective_batch_size: 64
   # Allow CPU offload for FSDP optimizer.
   # Default: False
   fsdp_cpu_offload_optimizer: false
@@ -290,13 +290,13 @@ train:
   #   - nf4
   lora_quantize_dtype: nf4
   # Rank of low rank matrices to be used during training.
-  # Default: 4
-  lora_rank: 4
+  # Default: 0
+  lora_rank: 0
   # Maximum tokens per gpu for each batch that will be handled in a single step. If
   # running into out-of-memory errors, this value can be lowered but not below the
   # `max_seq_len`.
-  # Default: 10000
-  max_batch_len: 10000
+  # Default: 5000
+  max_batch_len: 5000
   # Maximum sequence length to be included in the training set. Samples exceeding
   # this length will be dropped.
   # Default: 4096


### PR DESCRIPTION
effective batch size should be 64 for knowledge on a laptop which is what we focus on primarily

max batch len is too high for most laptops to work with. 5000 is a realistic max batch len for 64 GB of RAM following full SDG

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
