### PR TITLE
fix: ilab config init improperly sets generate model

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -193,8 +193,6 @@ def init(
     # we should not override all paths with the serve model if special ENV vars exist
     if param_source != click.core.ParameterSource.ENVIRONMENT:
         cfg.chat.model = model_path
-        cfg.generate.model = model_path
-        cfg.generate.teacher.model_path = model_path
         cfg.serve.model_path = model_path
         cfg.evaluate.model = model_path
         cfg.generate.taxonomy_base = taxonomy_base

--- a/tests/test_lab_config.py
+++ b/tests/test_lab_config.py
@@ -66,6 +66,7 @@ def test_ilab_config_init_with_model_path(cli_runner: CliRunner) -> None:
     with config_path.open(encoding="utf-8") as f:
         parsed = yaml.safe_load(f)
     assert parsed
-    assert configuration.Config(**parsed).generate.model == "path/to/model"
-    assert configuration.Config(**parsed).generate.teacher.model_path == "path/to/model"
+    # the generate config should NOT use the same model as the chat/serve model
+    assert configuration.Config(**parsed).generate.model != "path/to/model"
+    assert configuration.Config(**parsed).generate.teacher.model_path != "path/to/model"
     assert configuration.Config(**parsed).serve.model_path == "path/to/model"


### PR DESCRIPTION
even though the defaults in the config file are mistral, ilab config init overrides these with merlinite due to some old logic that assumes merlinite is the model you want to use for everything

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
