### PR TITLE
enhance taxonomy dir check

### DIFF
--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -406,7 +406,7 @@ def validate_taxonomy(
     taxonomy: str | Path,
     taxonomy_base: str,
     yaml_rules: str | Path | None = None,
-) -> None:
+) -> bool:
     yamllint_config = None  # If no custom rules file, use default config
     if yaml_rules is not None:  # user attempted to pass custom rules file
         yaml_rules_path = Path(yaml_rules)
@@ -432,12 +432,14 @@ def validate_taxonomy(
         else:
             # Gather the new or changed YAMLs using git diff, including untracked files
             taxonomy_files = get_taxonomy_diff(taxonomy, taxonomy_base)
+        if not taxonomy_files:
+            logger.debug(f"Taxonomy directory {taxonomy} contains no qna.yaml files.")
+            return False
         total_errors = 0
         total_warnings = 0
-        if taxonomy_files:
-            logger.debug("Found new taxonomy files:")
-            for e in taxonomy_files:
-                logger.debug("* %s", e)
+        logger.debug("Found new taxonomy files:")
+        for e in taxonomy_files:
+            logger.debug("* %s", e)
         for f in taxonomy_files:
             file_path = os.path.join(taxonomy, f)
             warnings, errors = validate_taxonomy_file(file_path, yamllint_config)
@@ -454,6 +456,7 @@ def validate_taxonomy(
                     f"{total_errors} total errors found across {len(taxonomy_files)} taxonomy files!"
                 )
             )
+    return True
 
 
 def get_ssl_cert_config(tls_client_cert, tls_client_key, tls_client_passwd):

--- a/tests/test_lab_diff.py
+++ b/tests/test_lab_diff.py
@@ -170,6 +170,8 @@ class TestLabDiff:
 
     def test_diff_invalid_base(self, cli_runner: CliRunner):
         taxonomy_base = "invalid"
+        untracked_file = "compositional_skills/new/qna.yaml"
+        self.taxonomy.create_untracked(untracked_file)
         result = cli_runner.invoke(
             lab.ilab,
             [
@@ -405,7 +407,10 @@ class TestLabDiff:
                 self.taxonomy.root,
             ],
         )
-        assert f"Taxonomy in {self.taxonomy.root} is valid :)" in result.output
+        assert (
+            f"No new or changed qna.yaml files compared to the base branch {TAXONOMY_BASE}."
+            in result.output
+        )
         assert result.exit_code == 0
 
     def test_diff_invalid_yaml_filename_quiet(


### PR DESCRIPTION
enhance the empty check and handle git exception for quiet

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

Even the dir is empty still valid, and will handle the git error for `quiet`
```
$ ls -a /Users/xx/.local/share/instructlab/test-taxonomy
.    ..   .git  # only .git

$ ilab taxonomy diff
Taxonomy in /Users/xx/.local/share/instructlab/test-taxonomy is valid :)  # still valid


 ls -a /Users/xx/.local/share/instructlab/test-taxonomy 
.  ..     # really empty

$ ilab taxonomy diff --quiet       # cannot handle git error
Traceback (most recent call last):
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/bin/ilab", line 8, in <module>
    sys.exit(ilab())
             ^^^^^^
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/lib/python3.11/site-packages/instructlab/clickext.py", line 319, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/lib/python3.11/site-packages/instructlab/taxonomy/diff.py", line 84, in diff
    validate_taxonomy(taxonomy_path, taxonomy_base, yaml_rules)
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/lib/python3.11/site-packages/instructlab/utils.py", line 434, in validate_taxonomy
    taxonomy_files = get_taxonomy_diff(taxonomy, taxonomy_base)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/lib/python3.11/site-packages/instructlab/utils.py", line 202, in get_taxonomy_diff
    repo = git.Repo(repo_path)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/xx/src/github_projects/ilab-envs/instructlab-2024-10-18-18-07/instructlab/venv/lib/python3.11/site-packages/git/repo/base.py", line 289, in __init__
    raise InvalidGitRepositoryError(epath)
git.exc.InvalidGitRepositoryError: /Users/xx/.local/share/instructlab/test-taxonomy

```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
