### PR TITLE
fix: support specifying release per repo for download

### DIFF
--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -253,6 +253,7 @@ class OCIDownloader(Downloader):
 @click.command()
 @click.option(
     "--repository",
+    "-rp",
     "repositories",
     multiple=True,
     default=[
@@ -264,7 +265,13 @@ class OCIDownloader(Downloader):
 )
 @click.option(
     "--release",
-    default="main",  # TODO: add to config.yaml
+    "-rl",
+    "releases",
+    multiple=True,
+    default=[
+        "main",
+        "main",
+    ],  # TODO: add to config.yaml
     show_default=True,
     help="The revision of the model to download - e.g. a branch, tag, or commit hash for Hugging Face repositories and tag or commit hash for OCI repositories.",
 )
@@ -290,12 +297,14 @@ class OCIDownloader(Downloader):
 )
 @click.pass_context
 @clickext.display_params
-def download(ctx, repositories, release, filenames, model_dir, hf_token):
+def download(ctx, repositories, releases, filenames, model_dir, hf_token):
     """Downloads model from a specified repository"""
     downloader = None
 
     # strict = false ensures that if you just give --repository <some_safetensor> we won't error because len(filenames) is greater due to the defaults
-    for repository, filename in zip(repositories, filenames, strict=False):
+    for repository, filename, release in zip(
+        repositories, filenames, releases, strict=False
+    ):
         if is_oci_repo(repository):
             downloader = OCIDownloader(
                 ctx=ctx, repository=repository, release=release, download_dest=model_dir


### PR DESCRIPTION
allows specifying release to be downloaded per repo

addresses #2490 partially

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
