### PR TITLE
enhance read_config

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -907,6 +907,10 @@ def read_config(
     try:
         with open(config_file, "r", encoding="utf-8") as yamlfile:
             content = yaml.load(yamlfile)
+            if not isinstance(content, dict):
+                raise ConfigException(
+                    f"Expected a dictionary but got {type(content).__name__} in file {config_file}."
+                )
             _expand_paths(content)
             return Config(**content)
     except ValidationError as exc:
@@ -922,6 +926,10 @@ def read_config(
                 + "\n"
             )
         raise ConfigException(msg) from exc
+    except TypeError as exc:
+        raise ConfigException(
+            f"Failed to load config from {config_file}: {exc}"
+        ) from exc
 
 
 def _expand_paths(content: dict | list):


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

it will get the `TypeError` if something wrong with the config file.
```
$ ilab config show
Traceback (most recent call last):
  File "/Users/instructlab/venv/bin/ilab", line 8, in <module>
    sys.exit(ilab())
             ^^^^^^
  File "/Users//instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users//instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1685, in invoke
    super().invoke(ctx)
  File "/Users/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/instructlab/venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users//instructlab/venv/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users//instructlab/src/instructlab/lab.py", line 50, in ilab
    cfg.init(ctx, config_file, debug_level)
  File "/Users/instructlab/src/instructlab/configuration.py", line 1285, in init
    config_obj = read_config(config_file)
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users//instructlab/src/instructlab/configuration.py", line 951, in read_config
    return Config(**content)
           ^^^^^^^^^^^^^^^^^
TypeError: instructlab.configuration.Config() argument after ** must be a mapping, not NoneType
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
