### PR TITLE
robust check for oci repo

### DIFF
--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -631,10 +631,11 @@ def is_oci_repo(repo_url: str) -> bool:
     """
     Checks if a provided repository follows the OCI registry URL syntax
     """
-
-    # TODO: flesh this out and make it a more robust check
-    oci_url_prefix = "docker://"
-    return repo_url.startswith(oci_url_prefix)
+    oci_url_regex = r"^docker://([a-zA-Z0-9\-_.]+(:[0-9]+)?)(/[a-zA-Z0-9\-_.]+)+(@[a-zA-Z0-9]+|:[a-zA-Z0-9\-_.]+)?$"
+    if not re.match(oci_url_regex, repo_url):
+        logger.warning(f"Invalid OCI repository URL: {repo_url}")
+        return False
+    return True
 
 
 def is_huggingface_repo(repo_name: str) -> bool:


### PR DESCRIPTION
- add a regular expression to match oci repo

```
docker://<registry>/<repository>:<tag>

    command = [
            "skopeo",
            "copy",
            f"{self.repository}:{self.release}",
            f"oci:{oci_dir}",
            "--remove-signatures",
        ]
```
since the `skopeo` use `repository` and `release` , repository should be for url part, and there is check for release, so try to a valid oci url.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
