### PR TITLE
config: change default training backend to FSDP

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -448,7 +448,7 @@ class _train(BaseModel):
         default=False, description="Allow CPU offload for FSDP optimizer."
     )
     distributed_backend: DistributedBackend = Field(
-        default=DistributedBackend.DEEPSPEED,
+        default=DistributedBackend.FSDP,
         description="Pick a distributed training backend framework for GPU accelerated full fine-tuning.",
         validate_default=True,  # ensures that the 'use_enum_values' flag takes effect on the default value
     )

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -281,8 +281,8 @@ train:
   disable_flash_attn: false
   # Pick a distributed training backend framework for GPU accelerated full fine-
   # tuning.
-  # Default: deepspeed
-  distributed_backend: deepspeed
+  # Default: fsdp
+  distributed_backend: fsdp
   # The number of samples in a batch that the model should see before its parameters
   # are updated.
   # Default: 64


### PR DESCRIPTION
the project is beginnng to move away from DeepSpeed towards FSDP as our preferred training backend
this commit changes the default _train config class to use FSDP instead of DeepSpeed

**Issue resolved by this Pull Request:**
Resolves #2521

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
