### PR TITLE
deps: update vllm tag to v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.20
+
+### Breaking Changes
+
+* vLLM has been upgraded to [v0.6.2](https://github.com/opendatahub-io/vllm/releases/tag/v0.6.2) and will need to be reinstalled if you are upgrading `ilab` from an older version
+
 ## v0.19
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
       source venv/bin/activate
       pip cache remove llama_cpp_python
       CMAKE_ARGS="-DLLAMA_CUDA=on -DLLAMA_NATIVE=off" pip install 'instructlab[cuda]'
-      pip install vllm@git+https://github.com/opendatahub-io/vllm@2024.08.01
+      pip install vllm@git+https://github.com/opendatahub-io/vllm@v0.6.2
    ```
 
 4. From your `venv` environment, verify `ilab` is installed correctly, by running the `ilab` command.
@@ -455,7 +455,7 @@ After running `ilab config init` your directories will look like the following o
    If it is not, please run:
 
    ```shell
-   pip install vllm@git+https://github.com/opendatahub-io/vllm@2024.08.01
+   pip install vllm@git+https://github.com/opendatahub-io/vllm@v0.6.2
    ```
 
    ```shell

--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -186,7 +186,7 @@ RUN source ${VIRTUAL_ENV}/bin/activate \
     && pip install torch psutil \
     && pip install flash_attn --no-build-isolation \
     && pip install "${INSTRUCTLAB_PKG}" -C cmake.args="-DLLAMA_CUDA=on" -C cmake.args="-DLLAMA_NATIVE=off" \
-    && pip install vllm@git+https://github.com/opendatahub-io/vllm@2024.08.01
+    && pip install vllm@git+https://github.com/opendatahub-io/vllm@v0.6.2
 
 ENV TORCH_HOME="${VIRTUAL_ENV}/lib64/${PYTHON}/site-packages/torch"
 ENV PYTORCH_HOME="${VIRTUAL_ENV}/lib64/${PYTHON}/site-packages/torch"

--- a/requirements-vllm-cuda.txt
+++ b/requirements-vllm-cuda.txt
@@ -2,4 +2,4 @@
 # Dependencies for installing vLLM on CUDA
 
 # vLLM only supports Linux platform (including WSL)
-vllm @git+https://github.com/opendatahub-io/vllm@2024.08.01 ; sys_platform == 'linux' and platform_machine == 'x86_64'
+vllm @git+https://github.com/opendatahub-io/vllm@v0.6.2 ; sys_platform == 'linux' and platform_machine == 'x86_64'

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,8 +27,8 @@ sentencepiece>=0.2.0
 # "old" version required for vLLM on CUDA to build
 tokenizers>=0.11.1
 toml>=0.10.2
-# Habana Labs 1.17.1 has PyTorch 2.3.1a0+gitxxx pre-release
-torch>=2.3.0,<2.4.0
+# Default version. Can be overridden in extra requirements
+torch>=2.3.0,<2.5.0
 tqdm>=4.66.2
 # 'optimum' for Intel Gaudi needs transformers <4.44.0,>=4.43.0
 transformers>=4.41.2


### PR DESCRIPTION
**NOTE:** This PR is also relaxing the `torch` requirement to allow for the new vllm version to be installed, as it requires `2.4.0` - a proper upgrade will be done in https://github.com/instructlab/instructlab/pull/2445 

Partially addresses #2511

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
