### PR TITLE
fix: allow OCI model folders

### DIFF
--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -238,10 +238,13 @@ class OCIDownloader(Downloader):
 
         blob_dir = f"{oci_dir}/blobs/sha256/"
         for name, dest in file_map.items():
-            dest_model_path = os.path.join(self.download_dest, model_name, dest)
+            dest_model_path = Path(self.download_dest) / model_name / str(dest)
             # unlink any existing version of the file
-            if os.path.exists(dest_model_path):
-                os.unlink(dest_model_path)
+            if dest_model_path.exists():
+                dest_model_path.unlink()
+
+            if not dest_model_path.parent.exists():
+                dest_model_path.parent.mkdir(parents=True)
 
             # create symlink to files in cache to avoid redownloading if model has been downloaded before
             os.symlink(


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

This fix allows to download OCI artifacts which contains files in a given folder structure.


<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
