### PR TITLE
CI: update OCI model download test to pull from instructlab quay org

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -164,7 +164,7 @@ test_oci_model_download_with_vllm_backend(){
     shopt -s globstar
 
     # Run the ilab model download command with REGISTRY_AUTH_FILE
-    REGISTRY_AUTH_FILE=$HOME/auth.json ilab model download --repository docker://quay.io/ai-lab/models/granite-7b-lab --release latest --model-dir models/instructlab
+    REGISTRY_AUTH_FILE=$HOME/auth.json ilab model download --repository docker://quay.io/instructlab/granite-7b-lab --release latest --model-dir models/instructlab
 
     patterns=(
         "models/instructlab/granite-7b-lab/config.json"


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

Updates the OCI model download functional test to pull from https://quay.io/repository/instructlab/granite-7b-lab

fixes: #2197  

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
