### PR TITLE
add the missing newline

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -114,11 +114,11 @@ def init(
     )
     if overwrite_profile:
         click.echo(
-            f"Generating config file and profiles:\n    {DEFAULTS.CONFIG_FILE}\n    {DEFAULTS.TRAIN_PROFILE_DIR}\n"
+            f"\nGenerating config file and profiles:\n    {DEFAULTS.CONFIG_FILE}\n    {DEFAULTS.TRAIN_PROFILE_DIR}\n"
         )
         recreate_train_profiles(overwrite=True)
     else:
-        click.echo(f"Generating config file:\n    {DEFAULTS.CONFIG_FILE}\n")
+        click.echo(f"\nGenerating config file:\n    {DEFAULTS.CONFIG_FILE}\n")
     if train_profile is not None:
         cfg.train = read_train_profile(train_profile)
     elif interactive:
@@ -222,7 +222,7 @@ def hw_auto_detect() -> tuple[str | None, int | None, _train, bool]:
     edited_cfg = False
     # try nvidia
     if torch.cuda.is_available() and torch.version.hip is None:
-        click.echo("\nDetecting Hardware...")
+        click.echo("Detecting hardware...")
         gpus = torch.cuda.device_count()
         for i in range(gpus):
             properties = torch.cuda.get_device_properties(i)
@@ -362,10 +362,10 @@ def get_params(
         cfg = read_config(config)
     clone_taxonomy_repo = True
     if interactive:
-        guide_text = "  This guide will help you to setup your environment."
+        guide_text = "  This guide will help you to setup your environment"
         separator = get_separator(guide_text)
         click.echo(
-            f"\n{separator}\n         Welcome to InstructLab CLI.\n{guide_text}\n{separator}\n"
+            f"\n{separator}\n         Welcome to the InstructLab CLI\n{guide_text}\n{separator}\n"
         )
         click.echo(
             "Please provide the following values to initiate the "


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

Thank you for merge [PR 2443 ](https://github.com/instructlab/instructlab/pull/2443), recheck it, add the missing newline,  they are from the different prompts. And remove the unnecessary line.

```
from:

Please provide the following values to initiate the environment [press Enter for defaults]: 
Path to taxonomy repo [/root/.local/share/instructlab/taxonomy]:  
Path to your model [/root/.cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf]:  
Generating config file and profiles:
    /root/.config/instructlab/config.yaml
    /root/.local/share/instructlab/internal/train_configuration/profiles

to:

Please provide the following values to initiate the environment [press Enter for defaults]: 
Path to taxonomy repo [/root/.local/share/instructlab/taxonomy]:  
Path to your model [/root/.cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf]:  
# <<<<<<<<<<< newline
Generating config file and profiles:
    /root/.config/instructlab/config.yaml
    /root/.local/share/instructlab/internal/train_configuration/profiles


=====================>
from:
Generating config file:
    /home/user/.config/instructlab/config.yaml
# one line    <<<<<<<<<<< 
# two lines  <<<<<<<<<<< 
Detecting Hardware...
We chose Nvidia 1x L40s as your designated training profile. This is for systems with xx GB of vRAM.
This profile is the best approximation for your system based off of the amount of vRAM. We modified it to match the number of GPUs you have.
Is this profile correct? [Y/n]: y

to:
from:
Generating config file:
    /home/user/.config/instructlab/config.yaml
# one line  <<<<<<<<<<< 
Detecting Hardware...
We chose Nvidia 1x L40s as your designated training profile. This is for systems with xx GB of vRAM.
This profile is the best approximation for your system based off of the amount of vRAM. We modified it to match the number of GPUs you have.
Is this profile correct? [Y/n]: y
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
