### PR TITLE
feat: Add temperature setting to `ilab model chat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 * train-profiles have been deprecated and replaced with system-profiles. These profiles follow the format of the config file and apply to all commands. They live in `~/.local/share/instructlab/internal/system_profiles`
 * The default model has been changed from Merlinite to Granite - see <https://github.com/instructlab/instructlab/issues/2238> for more details
+* Removed the `--greedy-mode` flag from `ilab model chat`. Please update any scripts or workflows relying on `--greedy-mode` to ensure compatibility.
 
 ### Features
 
 * `ilab` now supports system profiles. These profiles apply entire configuration files tailored to specific hardware configurations. We support a set of auto-detected profiles for CPU enabled Linux machines, M-Series Apple Silicon Chips, and Nvidia GPUs, and Intel Gaudi 3. When you run `ilab config init`, one of these profiles should be selected for you. If there is not a direct match, a menu will be displayed allowing you to choose one.
 * Add support for inferencing with IBM granite architecture models.
+
+* `ilab model chat` now includes a temperature setting feature, allowing users to adjust the response generation behavior. A default temperature of 1.0 has been added to the configuration file, which can be customized for each chat session using the `--temperature` or `-t` flag. Lower values produce
+more deterministic and focused responses, while higher values increase variability.
 
 ## v0.20
 

--- a/README.md
+++ b/README.md
@@ -542,10 +542,10 @@ ilab config show
    >>>                                                                                                                                                                                                                               [S][default]
    ```
 
-- You can also adjust the temperature settings of the model with the `--greedy-mode` flag.
+- You can also adjust the temperature settings of the model with the `--temperature` or `-t` flag. The default is 1.0.
 
    ```shell
-   ilab model chat --model ~/.cache/instructlab/models/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf --greedy-mode
+   ilab model chat --model ~/.cache/instructlab/models/mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf --temperature 0.5
    ```
 
 ## 🚀 Upgrade InstructLab to latest version

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Welcome to InstructLab's documentation!
    demo-slides.md
    README.md
    release-strategy.md
+   instructlab_models.md
 
 
 Indices and tables

--- a/scripts/test-data/profile-l4-x1.yaml
+++ b/scripts/test-data/profile-l4-x1.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/scripts/test-data/profile-l40s-x4.yaml
+++ b/scripts/test-data/profile-l40s-x4.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/scripts/test-data/profile-t4-x1.yaml
+++ b/scripts/test-data/profile-t4-x1.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -141,13 +141,13 @@ class _chat(BaseModel):
         default_factory=lambda: DEFAULTS.CHATLOGS_DIR,
         description="Directory where chat logs are stored.",
     )
-    greedy_mode: bool = Field(
-        default=False,
-        description="Sets temperature to 0 if enabled, leading to more deterministic responses.",
-    )
     max_tokens: typing.Optional[int] = Field(
         default=None,
         description="The maximum number of tokens that can be generated in the chat completion. Be aware that larger values use more memory.",
+    )
+    temperature: float = Field(
+        default=1.0,
+        description="Controls the randomness of the model's responses. Lower values make the output more deterministic, while higher values produce more random results.",
     )
 
 

--- a/src/instructlab/profiles/apple/m1/m1_max.yaml
+++ b/src/instructlab/profiles/apple/m1/m1_max.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/apple/m1/m1_ultra.yaml
+++ b/src/instructlab/profiles/apple/m1/m1_ultra.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/apple/m2/m2.yaml
+++ b/src/instructlab/profiles/apple/m2/m2.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/apple/m2/m2_max.yaml
+++ b/src/instructlab/profiles/apple/m2/m2_max.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/apple/m2/m2_pro.yaml
+++ b/src/instructlab/profiles/apple/m2/m2_pro.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/apple/m2/m2_ultra.yaml
+++ b/src/instructlab/profiles/apple/m2/m2_ultra.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/apple/m3/m3.yaml
+++ b/src/instructlab/profiles/apple/m3/m3.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/apple/m3/m3_max.yaml
+++ b/src/instructlab/profiles/apple/m3/m3_max.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/apple/m3/m3_pro.yaml
+++ b/src/instructlab/profiles/apple/m3/m3_pro.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/intel/cpu.yaml
+++ b/src/instructlab/profiles/intel/cpu.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/intel/gaudi/gaudi_3.yaml
+++ b/src/instructlab/profiles/intel/gaudi/gaudi_3.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/nvidia/a100/a100_x2.yaml
+++ b/src/instructlab/profiles/nvidia/a100/a100_x2.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/nvidia/a100/a100_x4.yaml
+++ b/src/instructlab/profiles/nvidia/a100/a100_x4.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/nvidia/a100/a100_x8.yaml
+++ b/src/instructlab/profiles/nvidia/a100/a100_x8.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/nvidia/h100/h100_x2.yaml
+++ b/src/instructlab/profiles/nvidia/h100/h100_x2.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/nvidia/h100/h100_x4.yaml
+++ b/src/instructlab/profiles/nvidia/h100/h100_x4.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/nvidia/h100/h100_x8.yaml
+++ b/src/instructlab/profiles/nvidia/h100/h100_x8.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/nvidia/l4/l4_x8.yaml
+++ b/src/instructlab/profiles/nvidia/l4/l4_x8.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/nvidia/l40s/l40s_x4.yaml
+++ b/src/instructlab/profiles/nvidia/l40s/l40s_x4.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/src/instructlab/profiles/nvidia/l40s/l40s_x8.yaml
+++ b/src/instructlab/profiles/nvidia/l40s/l40s_x8.yaml
@@ -1,7 +1,5 @@
 chat:
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses
-  greedy_mode: false
   # Directory where chat logs are stored
   logs_dir: ~/.local/share/instructlab/chatlogs
   # The maximum number of tokens that can be generated in the chat completion

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,7 +45,7 @@ class TestConfig:
         assert cfg.chat.context == "default"
         assert cfg.chat.session is None
         assert cfg.chat.logs_dir == f"{data_dir}/chatlogs"
-        assert not cfg.chat.greedy_mode
+        assert cfg.chat.temperature is not None
 
         assert cfg.evaluate is not None
 

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -6,9 +6,6 @@ chat:
   # default, cli_helper.
   # Default: default
   context: default
-  # Sets temperature to 0 if enabled, leading to more deterministic responses.
-  # Default: False
-  greedy_mode: false
   # Directory where chat logs are stored.
   # Default: /data/instructlab/chatlogs
   logs_dir: /data/instructlab/chatlogs
@@ -22,6 +19,9 @@ chat:
   # Filepath of a dialog session file.
   # Default: None
   session:
+  # Controls the randomness of the model's responses.
+  # Default: 1.0
+  temperature: 1.0
   # Enable vim keybindings for chat.
   # Default: False
   vi_mode: false


### PR DESCRIPTION
Introduced a default temperature setting in the config, with a default of 1.0. Also includes a `--temperature` and `-t` flag to allow users to set a custom temperature for each chat session. This enables users to adjust the temperature value, leading to their preferred level of deterministic and accurate responses.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
