### PR TITLE
optimize the list_datasets

### DIFF
--- a/src/instructlab/cli/data/list.py
+++ b/src/instructlab/cli/data/list.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+from collections import defaultdict
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Tuple
 import logging
+import os
+import re
 
 # Third Party
 import click
@@ -15,6 +18,35 @@ from instructlab.data.list_data import list_data  # type: ignore
 from instructlab.utils import print_table
 
 logger = logging.getLogger(__name__)
+
+# A constant for the timestamp regex pattern
+TIMESTAMP_REGEX = r"\d{4}-\d{2}-\d{2}T\d{2}_\d{2}_\d{2}"
+
+
+def extract_model_and_timestamp(
+    filename: str,
+) -> Tuple[Optional[str], bool, Optional[str]]:
+    """
+    Extracts the model name and complete timestamp from a filename.
+    """
+    # Extract model name and full timestamp
+    pattern_model = rf"^(test|messages|train)_(?P<model_name>[\w\-\.]+)_(?P<timestamp>{TIMESTAMP_REGEX})"
+    match_model = re.search(pattern_model, filename)
+
+    if match_model:
+        model_name = match_model.group("model_name")
+        timestamp = match_model.group("timestamp").replace("_", ":").replace("T", " ")
+        return (f"{model_name} {timestamp}", False, timestamp)
+
+    # Extract the timestamp
+    pattern_time = rf"(skills_train_msgs|node_datasets|knowledge_train_msgs)_(?P<timestamp>{TIMESTAMP_REGEX})"
+    match_time = re.search(pattern_time, filename)
+
+    if match_time:
+        timestamp = match_time.group("timestamp").replace("_", ":").replace("T", " ")
+        return (f"General {timestamp}", True, timestamp)
+
+    return (None, False, None)
 
 
 @click.command(name="list")
@@ -29,7 +61,7 @@ logger = logging.getLogger(__name__)
 def list_datasets(dataset_dirs):
     """lists datasets"""
 
-    data: List[List[Path]] = []
+    data: List[List[str]] = []
 
     dirs = [Path(dir) for dir in dataset_dirs]
 
@@ -40,4 +72,38 @@ def list_datasets(dataset_dirs):
         raise click.exceptions.Exit(1)
 
     headers = ["Dataset", "Created At", "File size"]
-    print_table(headers, data)
+    # Check if data is empty and print an empty table if so
+    if not data:
+        print_table(headers, data)
+        return
+
+    grouped_data = defaultdict(list)
+    timestamp_to_model = {}
+    general_files = []
+
+    # Process model name files e.g. start with test_, train_, messages_
+    for item in data:
+        filename = item[0]
+        group_key, is_general, timestamp = extract_model_and_timestamp(filename)
+
+        if group_key:
+            if is_general:
+                general_files.append((item, timestamp))
+            else:
+                grouped_data[group_key].append(item)
+                timestamp_to_model[timestamp] = group_key
+
+    # Process General files e.g. start with skills_train_msgs_, node_datasets_
+    for item, timestamp in general_files:
+        # Attempt to find a model group for the general file's timestamp
+        # If no corresponding model file with the same timestamp exists in `timestamp_to_model`,
+        # use the default group "General {timestamp}"
+        model_group = timestamp_to_model.get(timestamp, f"General {timestamp}")
+        grouped_data[model_group].append(item)
+
+    for idx, (group_key, items) in enumerate(
+        sorted(grouped_data.items(), key=lambda x: x[0].split(" ", 1)[1], reverse=True)
+    ):
+        click.echo(f"{os.linesep if idx > 0 else ''}{group_key}")
+        items.sort(key=lambda x: x[0])
+        print_table(headers, items)

--- a/tests/test_lab_data_list.py
+++ b/tests/test_lab_data_list.py
@@ -1,0 +1,108 @@
+# Standard
+import pathlib
+import re
+import textwrap
+import time
+
+# Third Party
+from click.testing import CliRunner
+
+# First Party
+from instructlab import lab
+from instructlab.cli.data.list import extract_model_and_timestamp
+
+
+def extract_data_entries(table_output: str) -> str:
+    lines = table_output.splitlines()
+    data_entries = []
+    for line in lines:
+        if (
+            line.startswith("|")
+            and not line.startswith("| Dataset")
+            and not line.startswith("+")
+        ):
+            clean_line = re.sub(r"\s+", " ", line.strip())
+            data_entries.append(clean_line)
+    return "\n".join(data_entries)
+
+
+def test_data_list_command(cli_runner: CliRunner, tmp_path: pathlib.Path):
+    test_dir = tmp_path / "list_datasets_test_dir"
+    test_dir.mkdir()
+
+    files_to_create = [
+        "test_modelA_2024-10-27T08_34_48.jsonl",
+        "train_modelA_2024-10-27T08_34_48.jsonl",
+        "messages_modelB_2024-10-26T21_32_32.jsonl",
+        "skills_train_msgs_2024-10-27T08_34_48.jsonl",
+    ]
+
+    file_info = []
+    for filename in files_to_create:
+        file_path = test_dir / filename
+        file_path.write_text("test content")
+        stat = file_path.stat()
+        created_at = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(stat.st_ctime))
+        formatted_size = f"{12.00:.2f} B"
+        file_info.append((filename, created_at, formatted_size))
+
+    node_datasets_dir = test_dir / "node_datasets_2024-10-27T08_34_48"
+    node_datasets_dir.mkdir()
+    node_file = node_datasets_dir / "compositional_skills_valid.jsonl"
+    node_file.write_text("test content")
+    node_stat = node_file.stat()
+    node_created_at = time.strftime(
+        "%Y-%m-%d %H:%M:%S", time.localtime(node_stat.st_ctime)
+    )
+    node_formatted_size = f"{12.00:.2f} B"
+
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "data",
+            "list",
+            "--dataset-dirs",
+            str(test_dir),
+        ],
+    )
+
+    expected_output = textwrap.dedent(f"""
+        modelA 2024-10-27 08:34:48
+        +--------------------------------------------------------------------+---------------------+-----------+
+        | Dataset                                                            | Created At          | File size |
+        +--------------------------------------------------------------------+---------------------+-----------+
+        | node_datasets_2024-10-27T08_34_48/compositional_skills_valid.jsonl | {node_created_at} | {node_formatted_size} |
+        | skills_train_msgs_2024-10-27T08_34_48.jsonl                        | {file_info[3][1]} | {file_info[3][2]} |
+        | test_modelA_2024-10-27T08_34_48.jsonl                              | {file_info[0][1]} | {file_info[0][2]} |
+        | train_modelA_2024-10-27T08_34_48.jsonl                             | {file_info[1][1]} | {file_info[1][2]} |
+        +--------------------------------------------------------------------+---------------------+-----------+
+
+        modelB 2024-10-26 21:32:32
+        +-------------------------------------------+---------------------+-----------+
+        | Dataset                                   | Created At          | File size |
+        +-------------------------------------------+---------------------+-----------+
+        | messages_modelB_2024-10-26T21_32_32.jsonl | {file_info[2][1]} | {file_info[2][2]} |
+        +-------------------------------------------+---------------------+-----------+
+    """).strip()
+
+    assert result.exit_code == 0
+    assert extract_data_entries(result.output) == extract_data_entries(expected_output)
+
+
+def test_extract_model_and_timestamp_model_file():
+    filename = "train_modelA_2024-10-27T08_34_48.jsonl"
+    group_key, is_general, timestamp = extract_model_and_timestamp(filename)
+
+    assert group_key == "modelA 2024-10-27 08:34:48"
+    assert is_general is False
+    assert timestamp == "2024-10-27 08:34:48"
+
+
+def test_extract_model_and_timestamp_general_file():
+    filename = "skills_train_msgs_2024-10-27T08_34_48.jsonl"
+    group_key, is_general, timestamp = extract_model_and_timestamp(filename)
+
+    assert group_key == "General 2024-10-27 08:34:48"
+    assert is_general is True
+    assert timestamp == "2024-10-27 08:34:48"


### PR DESCRIPTION
- use the model name and timestamp to distinguish the different  runs

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

User the model name and the timestamp to show it.
```

====> Currently:

generate one time:
$ ilab data list
+--------------------------------------------------------------------+---------------------+-----------+
| Dataset                                                            | Created At          | File size |
+--------------------------------------------------------------------+---------------------+-----------+
| test_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-26T22_22_42.jsonl     | 2024-10-26 22:22:42 | 1.55 KB   |
| messages_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-26T22_22_42.jsonl | 2024-10-26 23:08:52 | 78.61 KB  |
| train_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-26T22_22_42.jsonl    | 2024-10-26 23:08:52 | 64.85 KB  |
| test_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-26T21_32_32.jsonl     | 2024-10-26 21:32:32 | 1.55 KB   |
| skills_train_msgs_2024-10-26T22_22_42.jsonl                        | 2024-10-26 23:09:02 | 25.40 KB  |
| node_datasets_2024-10-26T22_22_42/compositional_skills_valid.jsonl | 2024-10-26 23:08:52 | 139.00 KB |
+--------------------------------------------------------------------+---------------------+-----------+

generate more times, difficult to view
$ ilab data list
+--------------------------------------------------------------------+---------------------+-----------+
| Dataset                                                            | Created At          | File size |
+--------------------------------------------------------------------+---------------------+-----------+
| test_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-27T08_34_48.jsonl     | 2024-10-27 08:34:48 | 1.55 KB   |
| messages_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-27T06_01_40.jsonl | 2024-10-27 06:47:58 | 78.61 KB  |
| train_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-27T06_01_40.jsonl    | 2024-10-27 06:47:58 | 64.85 KB  |
| train_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-27T08_34_48.jsonl    | 2024-10-27 09:21:05 | 64.85 KB  |
| messages_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-27T08_34_48.jsonl | 2024-10-27 09:21:05 | 78.61 KB  |
| test_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-27T06_01_40.jsonl     | 2024-10-27 06:01:40 | 1.55 KB   |
| test_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-26T22_22_42.jsonl     | 2024-10-26 22:22:42 | 1.55 KB   |
| messages_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-26T22_22_42.jsonl | 2024-10-26 23:08:52 | 78.61 KB  |
| train_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-26T22_22_42.jsonl    | 2024-10-26 23:08:52 | 64.85 KB  |
| skills_train_msgs_2024-10-27T06_01_40.jsonl                        | 2024-10-27 06:47:59 | 25.40 KB  |
| skills_train_msgs_2024-10-27T08_34_48.jsonl                        | 2024-10-27 09:21:06 | 25.40 KB  |
| skills_train_msgs_2024-10-26T22_22_42.jsonl                        | 2024-10-26 23:09:02 | 25.40 KB  |
| node_datasets_2024-10-27T06_01_40/compositional_skills_valid.jsonl | 2024-10-27 06:47:58 | 139.00 KB |
| node_datasets_2024-10-26T22_22_42/compositional_skills_valid.jsonl | 2024-10-26 23:08:52 | 139.00 KB |
| node_datasets_2024-10-27T08_34_48/compositional_skills_valid.jsonl | 2024-10-27 09:21:05 | 139.00 KB |
+--------------------------------------------------------------------+---------------------+-----------+

====> New output:
$ ilab data list
mistral-7b-instruct-v0.2.Q4_K_M 2024-10-27 08:34:48
+--------------------------------------------------------------------+---------------------+-----------+
| Dataset                                                            | Created At          | File size |
+--------------------------------------------------------------------+---------------------+-----------+
| test_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-27T08_34_48.jsonl     | 2024-10-27 08:34:48 | 1.55 KB   |
| train_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-27T08_34_48.jsonl    | 2024-10-27 09:21:05 | 64.85 KB  |
| messages_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-27T08_34_48.jsonl | 2024-10-27 09:21:05 | 78.61 KB  |
| skills_train_msgs_2024-10-27T08_34_48.jsonl                        | 2024-10-27 09:21:06 | 25.40 KB  |
| node_datasets_2024-10-27T08_34_48/compositional_skills_valid.jsonl | 2024-10-27 09:21:05 | 139.00 KB |
+--------------------------------------------------------------------+---------------------+-----------+

mistral-7b-instruct-v0.2.Q4_K_M 2024-10-27 06:01:40
+--------------------------------------------------------------------+---------------------+-----------+
| Dataset                                                            | Created At          | File size |
+--------------------------------------------------------------------+---------------------+-----------+
| messages_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-27T06_01_40.jsonl | 2024-10-27 06:47:58 | 78.61 KB  |
| train_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-27T06_01_40.jsonl    | 2024-10-27 06:47:58 | 64.85 KB  |
| test_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-27T06_01_40.jsonl     | 2024-10-27 06:01:40 | 1.55 KB   |
| skills_train_msgs_2024-10-27T06_01_40.jsonl                        | 2024-10-27 06:47:59 | 25.40 KB  |
| node_datasets_2024-10-27T06_01_40/compositional_skills_valid.jsonl | 2024-10-27 06:47:58 | 139.00 KB |
+--------------------------------------------------------------------+---------------------+-----------+

mistral-7b-instruct-v0.2.Q4_K_M 2024-10-26 22:22:42
+--------------------------------------------------------------------+---------------------+-----------+
| Dataset                                                            | Created At          | File size |
+--------------------------------------------------------------------+---------------------+-----------+
| test_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-26T22_22_42.jsonl     | 2024-10-26 22:22:42 | 1.55 KB   |
| messages_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-26T22_22_42.jsonl | 2024-10-26 23:08:52 | 78.61 KB  |
| train_mistral-7b-instruct-v0.2.Q4_K_M_2024-10-26T22_22_42.jsonl    | 2024-10-26 23:08:52 | 64.85 KB  |
| skills_train_msgs_2024-10-26T22_22_42.jsonl                        | 2024-10-26 23:09:02 | 25.40 KB  |
| node_datasets_2024-10-26T22_22_42/compositional_skills_valid.jsonl | 2024-10-26 23:08:52 | 139.00 KB |
+--------------------------------------------------------------------+---------------------+-----------+
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
