### PR TITLE
Add phased training unit test

### DIFF
--- a/src/instructlab/model/accelerated_train.py
+++ b/src/instructlab/model/accelerated_train.py
@@ -73,7 +73,8 @@ def accelerated_train(
         # pull the trainrandom.randinting and torch args from the flags
         # the flags are populated from the config as a base.
         logger.debug(
-            "Rendered training arguments:\n%s", pprint.pformat(train_args.model_dump())
+            "Rendered training arguments:\n%s",
+            pprint.pformat(train_args),
         )
 
         if not (phased_phase1_data and phased_phase2_data):

--- a/src/instructlab/model/phased_training.py
+++ b/src/instructlab/model/phased_training.py
@@ -25,7 +25,7 @@ class TrainingPhases(enum.Enum):
 
 
 AutoDatetimeField = pydantic.Field(
-    default_factory=lambda: datetime.datetime.now(datetime.UTC)
+    default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
 )
 
 
@@ -181,7 +181,7 @@ class TrainingJournal:
     @staticmethod
     def now_utc() -> datetime.datetime:
         """Static helper method for current time in UTC"""
-        return datetime.datetime.now(datetime.UTC)
+        return datetime.datetime.now(datetime.timezone.utc)
 
     @staticmethod
     def best_checkpoint(phase_model: EvalPhaseModel) -> EvalResult:


### PR DESCRIPTION
This test exercises several of the paths for phased training to make sure the basic journaling is working as expected.  It first fails on the first phase, then fakes its way past phase 1, then asserts it starts on phase 2.

Also changes datetime.UTC to datatime.timezone.utc since .UTC wasn't added until 3.11


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
