### PR TITLE
Handle case where training can't be run

### DIFF
--- a/src/instructlab/cli/model/train.py
+++ b/src/instructlab/cli/model/train.py
@@ -493,6 +493,11 @@ def train(
         except Exception as exc:
             click.secho(f"{exc}", fg="red")
             raise click.exceptions.Exit(1)
+    else:
+        click.secho(
+            f"Unable to train with device={device} and pipeline={pipeline}", fg="red"
+        )
+        raise click.exceptions.Exit(1)
 
 
 # chooses which type of training to run depending on the device provided

--- a/tests/test_lab_train.py
+++ b/tests/test_lab_train.py
@@ -671,3 +671,26 @@ class TestLabTrain:
             in result.output
         )
         assert result.exit_code == 1
+
+    def test_invalid_train_request(
+        self,
+        cli_runner: CliRunner,
+    ):
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "train",
+                "--pipeline",
+                "accelerated",
+                "--strategy",
+                "lab-multiphase",
+                "--device",
+                "cpu",
+            ],
+        )
+        assert (
+            "Unable to train with device=cpu and pipeline=accelerated" in result.output
+        )
+        assert result.exit_code == 1


### PR DESCRIPTION
Example output:

Unable to train with device=cpu and pipeline=accelerated

Resolves #2546

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
