### PR TITLE
docs: update release guidance to include lib dep cap

### DIFF
--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -51,9 +51,10 @@ The following are the steps for how Y-stream and Z-stream releases gets cut.
 
 1. Determine a commit on the main branch that will serve as the basis for the next release - most of the time this should be the latest commit.
 1. Create a new release branch in the format `release-vX.Y` off of the determined commit (will match `main` if the latest commit is chosen).
-1. Validate the release branch with an [E2E test](ci.md).
+1. Open a PR to the new release branch capping the InstructLab Libraries (SDG, Training, Eval) to the desired Y-Streams
+    - [Run a large E2E CI job](ci.md) against this PR to ensure full E2E coverage of the release candidate
+    - Example: <https://github.com/instructlab/instructlab/pull/2564>
 1. Create a new release on GitHub targeting the release branch and using the latest Y-Stream tag as the previous release (e.g. `0.15.1` precedes `0.16.0`).
-1. Move the `stable` tag to the new release (note this tag is set to be deprecated on September 1st, 2024 - users should use PyPi to install the latest "stable" release)
 1. Announce release via the following:
     - The `#announce` channel on Slack
     - The `announce` mailing list
@@ -64,7 +65,6 @@ The following are the steps for how Y-stream and Z-stream releases gets cut.
 1. Backport all relevant commits from `main` to the `release-vX.Y` branch - this can be done automatically with Mergify or manually if preferred. A backport using Mergify is done by adding a comment to the PR with the change merged to `main` with the contents `@Mergifyio backport <release-vX.Y>`.
 1. Validate the release branch with an [E2E test](ci.md).
 1. Create a new release on GitHub targeting the release branch and using the previous Z-Stream tag as the previous release (e.g. `0.15.0` precedes `0.15.1`).
-1. Move the `stable` tag to the new release (note this tag is set to be deprecated on September 1st, 2024 - users should use PyPi to install the latest "stable" release)
 1. If changes warrant an announcement, announce via the following:
     - The `#announce` channel on Slack
     - The `announce` mailing list


### PR DESCRIPTION
Also remove mention of the deprecated "stable" tag

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
