### PR TITLE
reformat the download output

### DIFF
--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -75,6 +75,6 @@ class TestLabDownload:
         )
         assert result.exit_code == 1
         assert (
-            "Invalid repository supplied: Please specify tag/version 'latest' via --release"
+            "\nInvalid repository supplied:\n    Please specify tag/version 'latest' via --release"
             in result.output
         )


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

reformat the `download` output
e.g.
```
$ ilab model download
Downloading model from Hugging Face:
    Model: instructlab/merlinite-7b-lab-GGUF@main
    Destination: /Users/user/.cache/instructlab/models

Downloading model failed with the following Hugging Face Hub error:
    (ProtocolError('Connection aborted.', ConnectionResetError(54, 'Connection reset by peer')), '(Request ID: eb0fd877-eae3-4799-b6a2-47422213a96f)')

Downloading model failed with the following error: 1

---------------
$ ilab model download --repository=TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF --filename=mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf
Downloading model from Hugging Face:
    Model: TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF@main
    Destination: /Users/user/.cache/instructlab/models

TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF requires a HF Token to be set.
Please use '--hf-token' or 'export HF_TOKEN' to download all necessary models

---------------
$ ilab model download --repository=TheBlokeMixtral-8x7B-Instruct-v0.1-GGUF --filename=mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf
repository TheBlokeMixtral-8x7B-Instruct-v0.1-GGUF matches neither Hugging Face nor OCI registry format.
Please supply a valid repository.

---------------
$ ilab model download --repository docker://xx.xx.io/xx/mixtral-8x7b-instruct-v0-1 --release 1.1
Downloading model from OCI registry:
    Model: docker://xx.xx.xx/xx/mixtral-8x7b-instruct-v0-1@1.1
    Destination: /Users/user/.cache/instructlab/models

skopeo is not installed.
Please install recommended version: 1.9.0

Downloading model failed with the following error: 1

---------------
$ ilab model download --repository docker://xx.xx.xx/xx/mixtral-8x7b-instruct-v0-1 --release 1.1
Downloading model from OCI registry:
    Model: docker://xx.xx.xx/xx/mixtral-8x7b-instruct-v0-1@1.1
    Destination: /Users/user/.cache/instructlab/models

Downloading model failed with the following error:
    skopeo version 1.8.1 is lower than 1.9.0. 
    Please upgrade it.
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
