### PR TITLE
Various fixes to CUDA container

### DIFF
--- a/.github/workflows/image-cuda.yml
+++ b/.github/workflows/image-cuda.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build and push gobot image
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
         with:
-          context: .
+          context: containers/cuda
           platforms: linux/amd64
           build-args: |
             GIT_TAG=main

--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -186,7 +186,7 @@ RUN source ${VIRTUAL_ENV}/bin/activate \
     && if [ "${INSTRUCTLAB_VERSION}" != "" ] ; then \
         INSTRUCTLAB_PKG="${INSTRUCTLAB_PKG}==${INSTRUCTLAB_VERSION}" ; \
     fi \
-    && pip install 'torch>=2.3.0,<2.4.0' 'psutil>=6.0.0' \
+    && pip install torch==2.4.1 psutil==6.1.0 \
     && pip install flash_attn --no-build-isolation \
     && pip install --no-deps llama_cpp_python[server]==0.2.79 -C cmake.args="-DLLAMA_CUDA=on" -C cmake.args="-DLLAMA_NATIVE=off" \
     && pip install "${INSTRUCTLAB_PKG}" -C cmake.args="-DLLAMA_CUDA=on" -C cmake.args="-DLLAMA_NATIVE=off" \

--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -129,6 +129,7 @@ RUN dnf install -y --nodocs \
         cuda-minimal-build-${CUDA_DASHED_VERSION} \
         cuda-toolkit-${CUDA_DASHED_VERSION} \
         libcudnn${CUDNN_MAJOR_VERSION} \
+        libcudnn9-cuda-12 \
         libnccl \
         libcutensor2 \
     && dnf clean all \
@@ -161,7 +162,7 @@ ENV CPLUS_INCLUDE_PATH="${CUDA_HOME}/include:${CPLUS_INCLUDE_PATH}"
 ENV CMAKE_INCLUDE_PATH="${CUDA_HOME}/include:${CMAKE_INCLUDE_PATH}"
 
 # Install Intel oneAPI repository for Intel oneMKL
-COPY containers/cuda/intel-oneapi.repo /etc/yum.repos.d/oneapi.repo
+COPY intel-oneapi.repo /etc/yum.repos.d/oneapi.repo
 RUN dnf config-manager --set-enabled intel-oneapi
 
 RUN dnf -y install --nodocs \
@@ -179,12 +180,15 @@ ENV C_INCLUDE_PATH="${INTEL_MKL_HOME}/include:${C_INCLUDE_PATH}"
 ENV CPLUS_INCLUDE_PATH="${INTEL_MKL_HOME}/include:${CPLUS_INCLUDE_PATH}"
 ENV CMAKE_INCLUDE_PATH="${INTEL_MKL_HOME}/include:${CMAKE_INCLUDE_PATH}"
 
+ENV MAKEFLAGS="-j$(nproc)"
+
 RUN source ${VIRTUAL_ENV}/bin/activate \
     && if [ "${INSTRUCTLAB_VERSION}" != "" ] ; then \
         INSTRUCTLAB_PKG="${INSTRUCTLAB_PKG}==${INSTRUCTLAB_VERSION}" ; \
     fi \
-    && pip install torch psutil \
+    && pip install 'torch>=2.3.0,<2.4.0' 'psutil>=6.0.0' \
     && pip install flash_attn --no-build-isolation \
+    && pip install --no-deps llama_cpp_python[server]==0.2.79 -C cmake.args="-DLLAMA_CUDA=on" -C cmake.args="-DLLAMA_NATIVE=off" \
     && pip install "${INSTRUCTLAB_PKG}" -C cmake.args="-DLLAMA_CUDA=on" -C cmake.args="-DLLAMA_NATIVE=off" \
     && pip install vllm@git+https://github.com/opendatahub-io/vllm@v0.6.2
 


### PR DESCRIPTION
This PR introduces several fixes to the CUDA container image.

1. `make cuda` did not work with the latest releases:
- The Intel repo file was not copied from the right location, yielding the error:
```
Error: building at STEP "COPY containers/cuda/intel-oneapi.repo /etc/yum.repos.d/oneapi.repo": checking on sources under "/home/ec2-user/dev/instructlab/containers/cuda": copier: stat: "/containers/cuda/intel-oneapi.repo": no such file or directory
```
The fix modifies this line for `COPY intel-oneapi.repo /etc/yum.repos.d/oneapi.repo`
- Recent vllm update at version 0.6+ needs `libcudnn.so.9`. Without it you get a build error:
```
ImportError: libcudnn.so.9: cannot open shared object file: No such file or directory
```
The fix installs `libcudnn9-cuda-12` that features the missing library.
Note: this error was [already there](https://github.com/instructlab/instructlab/actions/runs/11519203297/job/32067656595) when the PR for vllm version bump was merged, but it was merged anyway.

2. Llama.cpp was not built with GPU acceleration. Putting the flag `cmake.args="-DLLAMA_CUDA=on"` when installing instructLab is not enough, the flag is not inherited in the dependencies builds.
The fix properly installs llama.cpp beforehand so that it's properly compiled.

3. Other fixes:
- Additional Make flag to enable compilation on the maximum CPU available on the build machine.
- Constrain torch version to the one required by InstructLab to avoid installation of whatever latest version, which could afterwards be replaced by the really needed version.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
