### PR TITLE
Ensure Deletion of Existing Profiles

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1153,6 +1153,19 @@ def read_and_create_system_profiles(profiles_dir: str, overwrite: bool) -> bool:
     read_and_create_system_profiles walks the given dir, reads the templated files and writes them into
     the DEFAULTS.SYSTEM_PROFILE_DIR preserving their arch, processor name, and yaml file name
     """
+    # if we are overwriting, remove the existing dir. We should do this because
+    # the directory being provided, if using $ILAB_SYSTEM_PROFILE_DIR, could have a different structure.
+    # if the directory structure differs, some leftover profiles could be left behind for selection
+    if overwrite:
+        # Standard
+        import shutil
+
+        for item in os.listdir(DEFAULTS.SYSTEM_PROFILE_DIR):
+            item_path = os.path.join(DEFAULTS.SYSTEM_PROFILE_DIR, item)
+            # Check if the item is a directory
+            if os.path.isdir(item_path):
+                # Remove the directory and its contents
+                shutil.rmtree(item_path)
     fresh_install = False
     for dirpath, _dirnames, filenames in os.walk(profiles_dir):
         for filename in filenames:


### PR DESCRIPTION
when the user confirms they want to override their existing profiles. we should remove the entire directory. the directory being provided, if using $ILAB_SYSTEM_PROFILE_DIR, could have a different structure. If the directory structure differs, some leftover profiles could be left behind for selection

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
