### PR TITLE
add json option for show

### DIFF
--- a/src/instructlab/config/show.py
+++ b/src/instructlab/config/show.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
+
 # Standard
+from typing import Any, Dict
+import json
 import sys
 
 # Third Party
@@ -14,15 +17,53 @@ yaml = ruamel.yaml.YAML()
 yaml.indent(mapping=2, sequence=4, offset=2)
 
 
+def get_nested_value(data_dict: Dict[str, Any], path: str) -> Any:
+    """Retrieve nested value using dot-separated path."""
+    keys = path.split(".")
+    for key in keys:
+        data_dict = data_dict[key]
+    return data_dict
+
+
 @click.command()
 @click.pass_context
+@click.option(
+    "--json",
+    "-j",
+    "json_format",
+    is_flag=True,
+    help="Output in JSON format instead of YAML.",
+)
+@click.option(
+    "--key",
+    "-k",
+    "key_path",
+    default=None,
+    help="Show only a specific section of the configuration. Can be used in conjunction with -j. e.g. -k chat or -k chat.context",
+)
 @clickext.display_params
-def show(ctx: click.Context) -> None:
-    """Displays the current config as YAML"""
-    # TODO: make this use pretty colors like jq/yq
+def show(ctx: click.Context, json_format: bool, key_path: str) -> None:
+    """Displays the current config as YAML or JSON, with an option to extract a specific key."""
+
     try:
         commented_map = configuration.config_to_commented_map(ctx.obj.config)
-    except YAMLError as e:
-        click.secho(f"Error loading config as YAML: {e}", fg="red")
+        result = (
+            commented_map if not key_path else get_nested_value(commented_map, key_path)
+        )
+
+        if json_format:
+            json_output = json.dumps(result, indent=4)
+            click.echo(json_output)
+        else:
+            if isinstance(result, (dict, list)):
+                yaml.dump(result, sys.stdout)
+            else:
+                click.echo(result)
+
+    except KeyError:
+        click.secho(f"Key not found: '{key_path}'", fg="red")
         ctx.exit(2)
-    yaml.dump(commented_map, sys.stdout)
+
+    except YAMLError as e:
+        click.secho(f"Error loading config: {e}.", fg="red")
+        ctx.exit(2)

--- a/tests/test_lab_config.py
+++ b/tests/test_lab_config.py
@@ -1,15 +1,69 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+import json
 import logging
 import pathlib
 
 # Third Party
 from click.testing import CliRunner
+from ruamel.yaml import YAML
+import ruamel.yaml
 import yaml
 
 # First Party
 from instructlab import configuration, lab
+
+test_source_config_data = """
+# Chat configuration section.
+chat:
+  # Predefined setting or environment that influences the behavior and responses of
+  # the chat assistant. Each context is associated with a specific prompt that
+  # guides the assistant on how to respond to user inputs. Available contexts:
+  # default, cli_helper.
+  # Default: default
+  context: default
+  # Sets temperature to 0 if enabled, leading to more deterministic responses.
+  # Default: False
+  greedy_mode: false
+  # Directory where chat logs are stored.
+  # Default: /data/instructlab/chatlogs
+  logs_dir: /data/instructlab/chatlogs
+  # The maximum number of tokens that can be generated in the chat completion. Be
+  # aware that larger values use more memory.
+  # Default: None
+  max_tokens:
+  # Model to be used for chatting with.
+  # Default: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
+  model: /cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
+  # Filepath of a dialog session file.
+  # Default: None
+  session:
+  # Enable vim keybindings for chat.
+  # Default: False
+  vi_mode: false
+  # Renders vertical overflow if enabled, displays ellipses otherwise.
+  # Default: True
+  visible_overflow: true
+# General configuration section.
+general:
+  # Debug level for logging.
+  # Default: 0
+  debug_level: 0
+  # Log format. https://docs.python.org/3/library/logging.html#logrecord-attributes
+  # Default: %(levelname)s %(asctime)s %(name)s:%(lineno)d: %(message)s
+  log_format: '%(levelname)s %(asctime)s %(name)s:%(lineno)d: %(message)s'
+  # Log level for logging.
+  # Default: INFO
+  log_level: INFO
+"""
+
+
+def remove_comment_indentation(yaml_output: str) -> str:
+    return "\n".join(
+        line.lstrip() if line.lstrip().startswith("#") else line
+        for line in yaml_output.splitlines()
+    )
 
 
 def test_ilab_config_show(cli_runner: CliRunner) -> None:
@@ -20,6 +74,84 @@ def test_ilab_config_show(cli_runner: CliRunner) -> None:
     assert parsed
 
     assert configuration.Config(**parsed)
+
+
+def test_ilab_config_show_json_output(
+    cli_runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    test_config_path = tmp_path / "test_config.yaml"
+    test_config_path.write_text(test_source_config_data)
+
+    logging.disable(logging.CRITICAL)
+    result_json = cli_runner.invoke(
+        lab.ilab, ["--config", str(test_config_path), "config", "show", "--json"]
+    )
+    logging.disable(logging.NOTSET)
+
+    assert result_json.exit_code == 0
+    parsed_json = json.loads(result_json.stdout)
+    assert "chat" in parsed_json
+    assert "general" in parsed_json
+
+
+def test_ilab_config_show_key_general(
+    cli_runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    # Expected output as a JSON string for --key general
+    test_config_path = tmp_path / "test_config.yaml"
+    test_config_path.write_text(test_source_config_data)
+
+    cfg = configuration.get_default_config()
+    expected_general_output = cfg.general.model_dump()
+
+    logging.disable(logging.CRITICAL)
+    # Test --key output for general
+    result_key_general = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config",
+            str(test_config_path),
+            "config",
+            "show",
+            "--key",
+            "general",
+            "--json",
+        ],
+    )
+    logging.disable(logging.NOTSET)
+
+    assert result_key_general.exit_code == 0
+    parsed_output = json.loads(result_key_general.stdout)
+    assert parsed_output == expected_general_output
+
+
+def test_ilab_config_show_key_general_yaml(
+    cli_runner: CliRunner, tmp_path: pathlib.Path
+) -> None:
+    test_config_path = tmp_path / "test_config.yaml"
+    test_config_path.write_text(test_source_config_data)
+
+    cfg = configuration.read_config(str(test_config_path))
+    general_config_commented_map = configuration.config_to_commented_map(cfg.general)
+
+    yaml_stream = ruamel.yaml.compat.StringIO()
+    yaml_instance = YAML()
+    yaml_instance.indent(mapping=2, sequence=4, offset=0)
+    yaml_instance.dump(general_config_commented_map, yaml_stream)
+    expected_yaml_output = yaml_stream.getvalue()
+
+    # Test --key output for general in YAML
+    logging.disable(logging.CRITICAL)
+    result_key_general_yaml = cli_runner.invoke(
+        lab.ilab,
+        ["--config", str(test_config_path), "config", "show", "--key", "general"],
+    )
+    logging.disable(logging.NOTSET)
+
+    assert result_key_general_yaml.exit_code == 0
+    actual_output = remove_comment_indentation(result_key_general_yaml.stdout.strip())
+    expected_yaml_output = remove_comment_indentation(expected_yaml_output.strip())
+    assert actual_output == expected_yaml_output
 
 
 def test_ilab_config_init_with_env_var_config(


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

Improve the `show` command. [origin one 2264](https://github.com/instructlab/instructlab/pull/2264)
- Background
So far, `ilab config show` only simply print the `config.yaml`, and config become more and more according to the repo become stronger.
The issue is hard to read/search the config what we want. e.g. there are paths, model, data, train ..etc.

Improvement actions:
- add `json` output without comments
```
$ ilab config show -j
{
    "chat": {
        "context": "default",
        "greedy_mode": false,
        "logs_dir": "/Users/xx/.local/share/instructlab/chatlogs",
        "max_tokens": null,
        "model": "/Users/xx/.cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf",
        "session": null,
        "vi_mode": false,
        "visible_overflow": true
    },
    "evaluate": {
        "base_branch": null,
        "base_model": "instructlab/granite-7b-lab",
        "branch": null,
        "gpus": null,
        "mmlu": {
            "batch_size": "auto",
            "few_shots": 5
        },
        "mmlu_branch": {
```

- add key search e.g. -k chat.model, easy to check the config, or combine `-k` with `-j` to list section
```

ilab config show -k chat -j
{
    "context": "default",
    "greedy_mode": false,
    "logs_dir": "/root/.local/share/instructlab/chatlogs",
    "max_tokens": null,
    "model": "/root/.cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf",
    "session": null,
    "vi_mode": false,
    "visible_overflow": true
}
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
