### PR TITLE
feat: add support for granite architecture models (granite-3.0)

### DIFF
--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -64,16 +64,17 @@ RTX
 RX
 Radeon
 SDG
+SFT
 SHA
 Safetensor
 Safetensors
 Salawu
-SFT
 Shaders
 Shivchander
 Srivastava
 Sudalairaj
 TBD
+TOML
 Taj
 Tesla
 UI
@@ -95,8 +96,8 @@ backends
 backport
 backported
 bashrc
-chatlogs
 chatbot
+chatlogs
 cli
 codebase
 compositional
@@ -126,6 +127,7 @@ hipBLAS
 ibmcloud
 ilab
 impactful
+inferencing
 init
 instructlab
 ip
@@ -178,4 +180,3 @@ wikisql
 xcode
 xlarge
 yaml
-TOML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Features
 
 * `ilab` now supports system profiles. These profiles apply entire configuration files tailored to specific hardware configurations. We support a set of auto-detected profiles for CPU enabled Linux machines, M-Series Apple Silicon Chips, and Nvidia GPUs, and Intel Gaudi 3. When you run `ilab config init`, one of these profiles should be selected for you. If there is not a direct match, a menu will be displayed allowing you to choose one.
+* Add support for inferencing with IBM granite architecture models.
 
 ## v0.20
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ instructlab-eval>=0.4.0
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.4.0
 instructlab-sdg>=0.5.0
-instructlab-training>=0.5.0
+instructlab-training>=0.6.0
 llama_cpp_python[server]==0.2.79
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 numpy>=1.26.4,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ httpx>=0.25.0
 instructlab-eval>=0.4.0
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.4.0
-instructlab-sdg>=0.5.0
-instructlab-training>=0.5.0
+instructlab-sdg==0.5.0a2
+instructlab-training==0.6.0a1
 llama_cpp_python[server]==0.2.79
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 numpy>=1.26.4,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ httpx>=0.25.0
 instructlab-eval>=0.4.0
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.4.0
-instructlab-sdg==0.5.0a2
-instructlab-training==0.6.0a1
+instructlab-sdg>=0.5.0
+instructlab-training>=0.5.0
 llama_cpp_python[server]==0.2.79
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 numpy>=1.26.4,<2.0.0

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,2 +1,2 @@
 # Extra dependencies for NVIDIA CUDA
-instructlab-training[cuda]>=0.5.0
+instructlab-training[cuda]>=0.6.0

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -1,2 +1,2 @@
 # Extra dependencies for AMD ROCm
-instructlab-training[rocm]>=0.5.0
+instructlab-training[rocm]>=0.6.0

--- a/src/instructlab/cli/model/train.py
+++ b/src/instructlab/cli/model/train.py
@@ -241,6 +241,12 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     type=bool,
 )
 @click.option(
+    "--use-dolomite",
+    cls=clickext.ConfigOption,
+    config_sections=ADDITIONAL_ARGUMENTS,
+    type=bool,
+)
+@click.option(
     "--gpus",
     "nproc_per_node",
     cls=clickext.ConfigOption,

--- a/src/instructlab/cli/model/train.py
+++ b/src/instructlab/cli/model/train.py
@@ -244,7 +244,7 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     "--use-dolomite",
     cls=clickext.ConfigOption,
     config_sections=ADDITIONAL_ARGUMENTS,
-    type=bool,
+    type=click.BOOL,
 )
 @click.option(
     "--gpus",

--- a/src/instructlab/common.py
+++ b/src/instructlab/common.py
@@ -1,3 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
-SYS_PROMPT = "I am, Red Hat® Instruct Model based on Granite 7B, an AI language model developed by Red Hat and IBM Research, based on the Granite-7b-base language model. My primary function is to be a chat assistant."
+DEFAULT_SYS_PROMPT = "I am an advanced AI language model designed to assist you with a wide range of tasks and provide helpful, clear, and accurate responses. My primary role is to serve as a chat assistant, engaging in natural, conversational dialogue, answering questions, generating ideas, and offering support across various topics."
+CLI_HELPER_SYS_PROMPT = "You are an expert for command line interface and know all common commands. Answer the command to execute as it without any explanation."
+
+
+class SupportedModelArchitectures:
+    LLAMA = "llama"
+    GRANITE = "granite"
+
+
+# These system prompts are specific to granite models developed by Red Hat and IBM Research
+SYSTEM_PROMPTS = {
+    SupportedModelArchitectures.LLAMA: "I am, Red Hat® Instruct Model based on Granite 7B, an AI language model developed by Red Hat and IBM Research, based on the Granite-7b-base language model. My primary function is to be a chat assistant.",
+    SupportedModelArchitectures.GRANITE: "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.0-8b-base model. My primary role is to serve as a chat assistant.",
+}

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -36,6 +36,9 @@ from ruamel.yaml import YAML, CommentedMap
 from typing_extensions import deprecated as Deprecated
 import click
 
+# First Party
+from instructlab.utils import get_model_arch, use_legacy_pretraining_format
+
 # Local
 from . import log
 from .defaults import (
@@ -1356,6 +1359,10 @@ def map_train_to_library(ctx, params):
     if params["pipeline"] == "full":
         train_args.disable_flash_attn = True
 
+    student_model_arch = get_model_arch(params["model_path"])
+    train_args.use_legacy_sp_tokens = use_legacy_pretraining_format(
+        params["model_path"], student_model_arch
+    )
     return train_args, torch_args
 
 

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1310,9 +1310,6 @@ def init(
 def map_train_to_library(ctx, params):
     # first do a lazy unwrap into the respective options
     train_args = TrainingArgs(**params)
-    print("~~~~~~~~~##########")
-    print(train_args)
-    os._exit(0)
     torch_args = TorchrunArgs(**params)
 
     ds_args = DeepSpeedOptions(

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1310,6 +1310,9 @@ def init(
 def map_train_to_library(ctx, params):
     # first do a lazy unwrap into the respective options
     train_args = TrainingArgs(**params)
+    print("~~~~~~~~~##########")
+    print(train_args)
+    os._exit(0)
     torch_args = TorchrunArgs(**params)
 
     ds_args = DeepSpeedOptions(

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1360,7 +1360,7 @@ def map_train_to_library(ctx, params):
         train_args.disable_flash_attn = True
 
     student_model_arch = get_model_arch(params["model_path"])
-    train_args.use_legacy_sp_tokens = use_legacy_pretraining_format(
+    train_args.use_legacy_tmpl = use_legacy_pretraining_format(
         params["model_path"], student_model_arch
     )
     return train_args, torch_args

--- a/src/instructlab/data/generate_data.py
+++ b/src/instructlab/data/generate_data.py
@@ -32,6 +32,8 @@ def gen_data(
     gpus,
     checkpoint_dir,
     max_num_tokens,
+    system_prompt,
+    use_legacy_pretraining_format,
 ):
     """Generates synthetic data to enhance your example data"""
     # Third Party
@@ -102,6 +104,8 @@ def gen_data(
             batch_size=batch_size,
             checkpoint_dir=checkpoint_dir,
             max_num_tokens=max_num_tokens,
+            system_prompt=system_prompt,
+            use_legacy_pretraining_format=use_legacy_pretraining_format,
         )
     except GenerateException as exc:
         raise ValueError(

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -91,6 +91,7 @@ class _InstructlabDefaults:
         "lora_alpha": 32,
         "lora_dropout": 0.1,
         "lora_target_modules": ["q_proj", "k_proj", "v_proj", "o_proj"],
+        "use_dolomite": False,
     }
 
     def __init__(self):

--- a/src/instructlab/model/backends/common.py
+++ b/src/instructlab/model/backends/common.py
@@ -61,6 +61,7 @@ class Closeable(typing.Protocol):
 class ServerException(Exception):
     """An exception raised when serving the API."""
 
+
 def get_in_memory_model_template(
     model_family: str, model_arch: str
 ) -> Tuple[str, str, str]:
@@ -76,7 +77,7 @@ def get_in_memory_model_template(
         bos_token (str): Beginning of sentence token
         eos_token (str): End of sentence token
     """
-
+    template = eos_token = bos_token = ""
 
     logger.debug(
         "Searching in-memory model templates for model family %s and arch %s",
@@ -101,6 +102,9 @@ def get_in_memory_model_template(
                 template = template_dict["template"]
                 bos_token = template_dict["special_tokens"].bos.token
                 eos_token = template_dict["special_tokens"].eos.token
+
+    logger.debug("no match found for supplied model family and architecture")
+    return template, eos_token, bos_token
 
 
 def format_template(template: str, bos_token: str, eos_token: str) -> str:
@@ -163,7 +167,7 @@ def get_model_template(
         if template == "":
             raise ValueError(
                 "Unable to find an appropriate chat template for supplied model"
-            )
+            ) from e
 
     # if present, replace token placeholders with actual tokens in the chat template
     template = format_template(
@@ -171,6 +175,7 @@ def get_model_template(
     )
 
     return template, eos_token, bos_token
+
 
 def is_temp_server_running():
     """Check if the temp server is running."""

--- a/src/instructlab/model/backends/common.py
+++ b/src/instructlab/model/backends/common.py
@@ -12,7 +12,7 @@ from instructlab.training.chat_templates import (
     ibm_generic_tmpl as granite,  # type: ignore[import-untyped]
 )
 from instructlab.training.chat_templates import (
-    ibm_legacy_tmpl as granite_legacy,  # type: ignore
+    ibm_legacy_tmpl as granite_llama,  # type: ignore
 )
 from instructlab.training.chat_templates import mistral_tmpl as mistral  # type: ignore
 
@@ -41,8 +41,8 @@ templates = [
     {
         "family": "granite",
         "arch": SupportedModelArchitectures.LLAMA,
-        "template": granite_legacy.CHAT_TEMPLATE,
-        "special_tokens": granite_legacy.SPECIAL_TOKENS,
+        "template": granite_llama.CHAT_TEMPLATE,
+        "special_tokens": granite_llama.SPECIAL_TOKENS,
     },
     {
         "family": "mixtral",

--- a/src/instructlab/model/backends/common.py
+++ b/src/instructlab/model/backends/common.py
@@ -102,7 +102,8 @@ def get_in_memory_model_template(
                 bos_token = template_dict["special_tokens"].bos.token
                 eos_token = template_dict["special_tokens"].eos.token
 
-    logger.info("no match found for supplied model family and architecture")
+    if template == "":
+        logger.info("no match found for supplied model family and architecture")
     return template, eos_token, bos_token
 
 

--- a/src/instructlab/model/backends/common.py
+++ b/src/instructlab/model/backends/common.py
@@ -1,14 +1,29 @@
 # Standard
 from typing import Tuple
 import contextlib
+import json
 import logging
 import multiprocessing
 import pathlib
 import socket
 import typing
 
-# Local
-from ...configuration import get_model_family
+# Third Party
+from instructlab.training.chat_templates import (
+    ibm_generic_tmpl as granite,  # type: ignore[import-untyped]
+)
+from instructlab.training.chat_templates import (
+    ibm_legacy_tmpl as granite_legacy,  # type: ignore
+)
+from instructlab.training.chat_templates import mistral_tmpl as mistral  # type: ignore
+
+# First Party
+from instructlab.common import SupportedModelArchitectures
+from instructlab.configuration import get_model_family
+from instructlab.utils import get_model_arch
+
+# mypy: disable_error_code="import-untyped"
+
 
 logger = logging.getLogger(__name__)
 
@@ -19,12 +34,22 @@ LLAMA_CPP = "llama-cpp"
 VLLM = "vllm"
 templates = [
     {
-        "model": "granite",
-        "template": "{% for message in messages %}\n{% if message['role'] == 'user' %}\n{{ '<|user|>\n' + message['content'] }}\n{% elif message['role'] == 'system' %}\n{{ '<|system|>\n' + message['content'] }}\n{% elif message['role'] == 'assistant' %}\n{{ '<|assistant|>\n' + message['content'] + eos_token }}\n{% endif %}\n{% if loop.last and add_generation_prompt %}\n{{ '<|assistant|>' }}\n{% endif %}\n{% endfor %}",
+        "family": "granite",
+        "arch": SupportedModelArchitectures.GRANITE,
+        "template": granite.CHAT_TEMPLATE,
+        "special_tokens": granite.SPECIAL_TOKENS,
     },
     {
-        "model": "mixtral",
-        "template": "{{ bos_token }}\n{% for message in messages %}\n{% if message['role'] == 'user' %}\n{{ '[INST] ' + message['content'] + ' [/INST]' }}\n{% elif message['role'] == 'assistant' %}\n{{ message['content'] + eos_token}}\n{% endif %}\n{% endfor %}",
+        "family": "granite",
+        "arch": SupportedModelArchitectures.LLAMA,
+        "template": granite_legacy.CHAT_TEMPLATE,
+        "special_tokens": granite_legacy.SPECIAL_TOKENS,
+    },
+    {
+        "family": "mixtral",
+        "arch": "mixtral",
+        "template": mistral.CHAT_TEMPLATE,
+        "special_tokens": mistral.SPECIAL_TOKENS,
     },
 ]
 
@@ -36,27 +61,116 @@ class Closeable(typing.Protocol):
 class ServerException(Exception):
     """An exception raised when serving the API."""
 
+def get_in_memory_model_template(
+    model_family: str, model_arch: str
+) -> Tuple[str, str, str]:
+    """
+    Retrieve an in-memory chat template based on the model family and architecture
+
+    args
+        model_family (str): family that the model belongs to
+        model_arch (str): architecture of the model
+
+    returns
+        template (str): resolved chat template
+        bos_token (str): Beginning of sentence token
+        eos_token (str): End of sentence token
+    """
+
+
+    logger.debug(
+        "Searching in-memory model templates for model family %s and arch %s",
+        model_family,
+        model_arch,
+    )
+
+    # Try to match both model and arch
+    for template_dict in templates:
+        if (
+            template_dict.get("family") == model_family
+            and template_dict.get("arch") == model_arch
+        ):
+            template = template_dict["template"]
+            bos_token = template_dict["special_tokens"].bos.token
+            eos_token = template_dict["special_tokens"].eos.token
+
+    # If no match, try matching on model only
+    if template == "":
+        for template_dict in templates:
+            if template_dict.get("family") == model_family:
+                template = template_dict["template"]
+                bos_token = template_dict["special_tokens"].bos.token
+                eos_token = template_dict["special_tokens"].eos.token
+
+
+def format_template(template: str, bos_token: str, eos_token: str) -> str:
+    prefix = ""
+    if eos_token:
+        prefix = '{{% set eos_token = "{}" %}}\n'.format(eos_token)
+    if bos_token:
+        prefix = '{}{{% set bos_token = "{}" %}}\n'.format(prefix, bos_token)
+
+    return prefix + template
+
 
 def get_model_template(
     model_family: str, model_path: pathlib.Path
 ) -> Tuple[str, str, str]:
-    eos_token = "<|endoftext|>"
-    bos_token = ""
-    template = ""
+    """
+    Read the chat template from the model's tokenizer config if available. If not,
+    fallback to in-memory templates
+
+    args
+        model_path (str): Path to the model, used to read the tokenizer config if available
+        model_family (str): model family used to map in-memory template if needed
+    returns
+        template (str): resolved chat template
+        bos_token (str): Beginning of sentence token
+        eos_token (str): End of sentence token
+    """
+
     resolved_family = get_model_family(model_family, model_path)
-    logger.debug(
-        "Searching hard coded model templates for model family %s's template",
-        resolved_family,
+    model_arch = get_model_arch(model_path)
+
+    template = eos_token = bos_token = ""
+    try:
+        with open(
+            pathlib.Path(model_path) / "tokenizer_config.json",
+            "r",
+            encoding="utf-8",
+        ) as f:
+            tcfg = json.load(f)
+        template = tcfg["chat_template"]
+        bos_token = tcfg["bos_token"]
+        eos_token = tcfg["eos_token"]
+
+        # Handle edge case: some 7b models (llama architecture) may contain a sub-optimal chat template in their
+        # tokenizer configs. Check if the template accounts for generation prompt addition
+        # If this is not the case we must patch the chat template to make sure the model does not lose performance.
+        if model_arch == SupportedModelArchitectures.LLAMA:
+            if "add_generation_prompt" not in template:
+                template, eos_token, bos_token = get_in_memory_model_template(
+                    resolved_family, model_arch
+                )
+
+    except (FileNotFoundError, NotADirectoryError, PermissionError) as e:
+        logger.warning(
+            f"Unable to read tokenizer config for model: {model_path}: {e}. Falling back to in-memory chat template mapping"
+        )
+        template, eos_token, bos_token = get_in_memory_model_template(
+            resolved_family, model_arch
+        )
+        if template == "":
+            raise ValueError(
+                "Unable to find an appropriate chat template for supplied model"
+            )
+
+    # if present, replace token placeholders with actual tokens in the chat template
+    template = format_template(
+        template=template, bos_token=bos_token, eos_token=eos_token
     )
-    for template_dict in templates:
-        if template_dict["model"] == resolved_family:
-            template = template_dict["template"]
-            if template_dict["model"] == "mixtral":
-                eos_token = "</s>"
-                bos_token = "<s>"
 
     return template, eos_token, bos_token
-
 
 def is_temp_server_running():
     """Check if the temp server is running."""

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -197,6 +197,7 @@ class Server(BackendServer):
     def get_backend_type(self):
         return VLLM
 
+
 def get_argument(prefix: str, args: typing.List[str]):
     # Return last value in args for either --foo value or --foo=value
     # Returns True if flag --foo is provided with no value

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -197,19 +197,6 @@ class Server(BackendServer):
     def get_backend_type(self):
         return VLLM
 
-
-def format_template(model_family: str, model_path: pathlib.Path) -> str:
-    template, eos_token, bos_token = get_model_template(model_family, model_path)
-
-    prefix = ""
-    if eos_token:
-        prefix = '{{% set eos_token = "{}" %}}\n'.format(eos_token)
-    if bos_token:
-        prefix = '{}{{% set bos_token = "{}" %}}\n'.format(prefix, bos_token)
-
-    return prefix + template
-
-
 def get_argument(prefix: str, args: typing.List[str]):
     # Return last value in args for either --foo value or --foo=value
     # Returns True if flag --foo is provided with no value
@@ -396,10 +383,10 @@ def build_vllm_cmd(
 
     if not contains_argument("--chat-template", vllm_args):
         if chat_template == CHAT_TEMPLATE_AUTO:
-            # For auto templates, the build-in in-memory template
+            # For auto templates, the chat template
             # needs to be written to a temporary file so that vLLM
             # can read it
-            template = format_template(model_family, model_path)
+            template, _, _ = get_model_template(model_family, model_path)
             file = create_tmpfile(template)
             tmp_files.append(file)
             vllm_cmd.extend(["--chat-template", file.name])

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -580,8 +580,13 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
         self.info["messages"].append(message)
 
     def _handle_list_contexts(self, _):
+        # reconstruct contexts dict based on values passed at runtime
+        context_dict = dict.fromkeys(CONTEXTS, None)
+        context_dict["default"] = get_sysprompt(get_model_arch(pathlib.Path(self.model)))
+        context_dict["cli_helper"] = get_cli_helper_sysprompt()
+
         context_list = "\n\n".join(
-            [f"**{key}**:\n{value}" for key, value in CONTEXTS.items()]
+            [f"**{key}**:\n{value}" for key, value in context_dict.items()]
         )
         self._sys_print(Markdown(f"**Available contexts:**\n\n{context_list}"))
         raise KeyboardInterrupt

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -33,7 +33,7 @@ from instructlab.client_utils import HttpClientParams
 
 # Local
 from ..client_utils import http_client
-from ..utils import get_sysprompt
+from ..utils import get_cli_helper_sysprompt, get_model_arch, get_sysprompt
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +59,8 @@ Press Alt (or Meta) and Enter or Esc Enter to end multiline input.
 """
 
 CONTEXTS = {
-    "default": get_sysprompt(),
-    "cli_helper": "You are an expert for command line interface and know all common commands. Answer the command to execute as it without any explanation.",
+    "default": get_sysprompt,
+    "cli_helper": get_cli_helper_sysprompt,
 }
 
 PROMPT_HISTORY_FILEPATH = os.path.expanduser("~/.local/chat-cli.history")
@@ -464,7 +464,9 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
             )
             raise KeyboardInterrupt
         self.loaded["name"] = context
-        self.loaded["messages"] = [{"role": "system", "content": CONTEXTS[context]}]
+
+        sys_prompt = CONTEXTS.get(context, "default")(get_model_arch(self.model))
+        self.loaded["messages"] = [{"role": "system", "content": sys_prompt}]
         self._reset_session()
         self.greet(new=True)
         raise KeyboardInterrupt
@@ -582,7 +584,9 @@ class ConsoleChatBot:  # pylint: disable=too-many-instance-attributes
     def _handle_list_contexts(self, _):
         # reconstruct contexts dict based on values passed at runtime
         context_dict = dict.fromkeys(CONTEXTS, None)
-        context_dict["default"] = get_sysprompt(get_model_arch(pathlib.Path(self.model)))
+        context_dict["default"] = get_sysprompt(
+            get_model_arch(pathlib.Path(self.model))
+        )
         context_dict["cli_helper"] = get_cli_helper_sysprompt()
 
         context_list = "\n\n".join(
@@ -799,7 +803,8 @@ def chat_cli(
         logger.info(f"Context {context} not found in the config file. Using default.")
         context = "default"
     loaded["name"] = context
-    loaded["messages"] = [{"role": "system", "content": CONTEXTS[context]}]
+    sys_prompt = CONTEXTS.get(context, "default")(get_model_arch(model))
+    loaded["messages"] = [{"role": "system", "content": sys_prompt}]
 
     # Session from CLI
     if session is not None:

--- a/src/instructlab/model/linux_test.py
+++ b/src/instructlab/model/linux_test.py
@@ -30,7 +30,7 @@ def response(client, user: str, create_params: dict):
     resp = client.chat.completions.create(
         **create_params,
         messages=[
-            {"role": "system", "content": get_sysprompt()},
+            {"role": "system", "content": get_sysprompt("default")},
             {"role": "user", "content": user},
         ],
     )

--- a/src/instructlab/model/test.py
+++ b/src/instructlab/model/test.py
@@ -105,7 +105,10 @@ def test(
         with open(test_data_dir, "r", encoding="utf-8") as f:
             test_data = [json.loads(line) for line in f]
 
-        print("system prompt:", utils.get_sysprompt())
+        print(
+            "system prompt:",
+            utils.get_sysprompt(utils.get_model_arch(Path(model_dir))),
+        )
         for idx, example in enumerate(test_data):
             system = example["system"]
             user = example["user"]

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -85,7 +85,7 @@ class StoppingCriteriaSub(StoppingCriteria):
 
 def create_prompt(
     user: str,
-    system: str = CONTEXTS["default"],
+    system: str,
 ):
     return f"""\
     <|system|>
@@ -289,7 +289,8 @@ def linux_train(
     )
 
     def model_generate(user, **kwargs):
-        text = create_prompt(user=user)
+        system_prompt = CONTEXTS["default"]("default")
+        text = create_prompt(user=user, system=system_prompt)
 
         input_ids = tokenizer(text, return_tensors="pt").input_ids.to(model.device)
         outputs = model.generate(

--- a/src/instructlab/train/lora_mlx/make_data.py
+++ b/src/instructlab/train/lora_mlx/make_data.py
@@ -31,7 +31,7 @@ def make_data(data_dir: str, is_shiv: bool = False):
             data_new = []
             for obj in data:
                 obj_new = {
-                    "system": get_sysprompt(),
+                    "system": get_sysprompt("default"),
                     "user": obj["user"],
                     "assistant": obj["assistant"],
                 }
@@ -63,7 +63,7 @@ def make_data(data_dir: str, is_shiv: bool = False):
         data_new = []
         for obj in data:
             obj_new = {
-                "system": get_sysprompt(),
+                "system": get_sysprompt("default"),
                 "user": obj["inputs"],
                 "assistant": obj["targets"],
             }

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -1006,8 +1006,8 @@ def use_legacy_pretraining_format(model_path: Path, model_arch: str) -> bool:
         _, eos_token, bos_token = get_model_template_from_tokenizer(model_path)
         if eos_token is not None and bos_token is not None:
             if (
-                eos_token == granite_llama.SPECIAL_TOEKNS.eos.token
-                and bos_token == granite_llama.SPECIAL_TOEKNS.bos.token
+                eos_token == granite_llama.SPECIAL_TOKENS.eos.token
+                and bos_token == granite_llama.SPECIAL_TOKENS.bos.token
             ):
                 return True
     except Exception:

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -980,7 +980,7 @@ def get_model_template_from_tokenizer(model_path: pathlib.Path) -> Tuple[str, st
 
     try:
         tcfg = get_config_file_from_model(model_path, "tokenizer_config.json")
-        template = tcfg["template"]
+        template = tcfg["chat_template"]
         bos_token = tcfg["bos_token"]
         eos_token = tcfg["eos_token"]
     except (FileNotFoundError, NotADirectoryError, PermissionError) as e:

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -28,6 +28,9 @@ from instructlab.schema.taxonomy import (
     TaxonomyParser,
     TaxonomyReadingException,
 )
+from instructlab.training.chat_templates import (
+    ibm_legacy_tmpl as granite_llama,  # type: ignore
+)
 import click
 import git
 import gitdb
@@ -35,8 +38,10 @@ import yaml
 
 # Local
 from . import common
-from .common import CLI_HELPER_SYS_PROMPT, SYSTEM_PROMPTS
+from .common import CLI_HELPER_SYS_PROMPT, SYSTEM_PROMPTS, SupportedModelArchitectures
 from .defaults import DEFAULTS
+
+# mypy: disable_error_code="import-untyped"
 
 logger = logging.getLogger(__name__)
 
@@ -925,13 +930,89 @@ def get_model_arch(model_path: pathlib.Path) -> str:
 
     model_arch = "default"
     try:
+        model_cfg = get_config_file_from_model(model_path, "config.json")
+        model_arch = model_cfg["model_type"]
+    except Exception as e:
+        logger.debug(
+            f"Unable to get model architecture from config for model: {model_path}: {e}. Falling back to default value"
+        )
+
+    return model_arch
+
+
+def get_config_file_from_model(model_path: pathlib.Path, filename: str):
+    """
+    Reads a config file from a model's directory into memory
+
+    args
+        model_path (str): path to the model
+        filename (str): name of config file to be read
+    returns
+        json loaded config dict
+    """
+    try:
         with open(
-            pathlib.Path(model_path) / "config.json",
+            pathlib.Path(model_path) / filename,
             "r",
             encoding="utf-8",
         ) as f:
-            tcfg = json.load(f)
-        model_arch = tcfg["model_type"]
+            model_cfg = json.load(f)
+        return model_cfg
     except (FileNotFoundError, NotADirectoryError, PermissionError) as e:
-        logger.warning(f"Unable to read config for model: {model_path}: {e}.")
-    return model_arch
+        raise ValueError(
+            f"Unable to load file {filename} from {model_path}: {e}"
+        ) from e
+
+
+def get_model_template_from_tokenizer(model_path: pathlib.Path) -> Tuple[str, str, str]:
+    """
+    Attempts to read a model's tokenizer config file and extract the template and special
+    tokens from it
+
+    args
+        model_path (str): path to the model
+    returns
+        template (str): resolved chat template
+        bos_token (str): Beginning of sentence token
+        eos_token (str): End of sentence token
+    """
+    template = eos_token = bos_token = None
+
+    try:
+        tcfg = get_config_file_from_model(model_path, "tokenizer_config.json")
+        template = tcfg["template"]
+        bos_token = tcfg["bos_token"]
+        eos_token = tcfg["eos_token"]
+    except (FileNotFoundError, NotADirectoryError, PermissionError) as e:
+        raise e
+
+    return template, eos_token, bos_token
+
+
+def use_legacy_pretraining_format(model_path: Path, model_arch: str) -> bool:
+    """
+    Checks if the provided model is carrying a tokenizer config that specifies
+    legacy special tokens. If unable to find/load the tokenizer config, falls back
+    to check the architecture of the model. This function determines if SDG and training
+    need to be instructed to also work with legacy tokens and chat templates
+
+    args
+        model_path (str): path to the model
+        model_arch (str): architecture of model
+    returns
+        (bool): True if we should use legacy pretraining format and template, false if not
+    """
+    try:
+        _, eos_token, bos_token = get_model_template_from_tokenizer(model_path)
+        if eos_token is not None and bos_token is not None:
+            if (
+                eos_token == granite_llama.SPECIAL_TOEKNS.eos.token
+                and bos_token == granite_llama.SPECIAL_TOEKNS.bos.token
+            ):
+                return True
+    except Exception:
+        logger.debug(
+            "unable to load tokenizer config to determine pretraining format. Checking model architecture"
+        )
+        return model_arch.lower() == SupportedModelArchitectures.LLAMA
+    return False

--- a/tests/test_model_chat.py
+++ b/tests/test_model_chat.py
@@ -51,9 +51,7 @@ def test_list_contexts_output():
 
     expected_output = (
         "Available contexts:\n\n"
-        "default: I am, Red Hat® Instruct Model based on Granite 7B, an AI language model "
-        "developed by Red Hat and IBM Research, based on the Granite-7b-base language "
-        "model. My primary function is to be a chat assistant.\n\n"
+        "default: I am an AI language model. My primary role is to serve as a chat assistant.\n\n"
         "cli_helper: You are an expert for command line interface and know all common "
         "commands. Answer the command to execute as it without any explanation."
     )

--- a/tests/test_model_chat.py
+++ b/tests/test_model_chat.py
@@ -51,7 +51,7 @@ def test_list_contexts_output():
 
     expected_output = (
         "Available contexts:\n\n"
-        "default: I am an AI language model. My primary role is to serve as a chat assistant.\n\n"
+        "default: I am an advanced AI language model designed to assist you with a wide range of tasks and provide helpful, clear, and accurate responses. My primary role is to serve as a chat assistant, engaging in natural, conversational dialogue, answering questions, generating ideas, and offering support across various topics.\n\n"
         "cli_helper: You are an expert for command line interface and know all common "
         "commands. Answer the command to execute as it without any explanation."
     )


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

This PR does the following:

- replace hard coded chat templates with imports from `instructlab/training`, which maintains chat templates for all natively supported models
- For safetensor models that carry a `tokenizer_config.json` file, extract chat template and special tokens from there. Only fall-back to in-memory templates if unable to read from tokenizer config file 
- centralize system prompts in one place. Add a system prompt for granite-3.0 models. Add a default prompt for non-granite models. Use model architecture to pick the correct system prompt for a model
- supply the correct system prompt to SDG based on the student model configured in the config file. Also supply extra parameter `legacy_pretraining_format` to sdg to dictate whether SDG should use granite-3.0 special tokens or existing granite-7b special tokens in the pretraining messages format
- communicate usage of legacy special tokens to training via `use_legacy_tmpl` in the `TrainingArgs` API
- update context handling to accommodate supporting multiple system prompts that need to be chosen based on model architecture 
- add `--use-dolomite` as an flag and additional_arg in train config for users to fall back to dolomite architecture if required  (default to False)
- bump training version to `>=0.6.0` to consume granite-3.0 related changes 

NOTE:
detecting architecture for GGUF models is still a TODO, as a result right now all GGUF models get the default system prompt even if they are of granite or llama architecture. This will be fixed in a follow up PR
as for being able to serve and convert granite-3.0 GGUF models, that is currently blocked until we can upgrade llama-cpp to v0.3

**Issue resolved by this Pull Request:**
Resolves #2523 #2583 

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
