### PR TITLE
chore: add python deprecation notice to help and init

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -70,6 +70,14 @@ def init(
             )
             if not overwrite:
                 return
+        click.secho(
+            """
+            NOTE: ilab no longer supports Python 3.9 or Python 3.12 as of version 0.18. If you are using either of these Python versions, there is no upgrade path from ilab 0.17 to newer ilab versions.
+            Please switch to Python 3.10 or 3.11 to use the latest ilab. ilab 0.17 will receive no bug fixes or additional features.
+            You can check which Python version you are using by running `python --version`
+            """,
+            fg="yellow",
+        )
         click.echo(
             "Welcome to InstructLab CLI. This guide will help you to setup your environment."
         )

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -93,7 +93,12 @@ aliases = {
 @click.pass_context
 # pylint: disable=redefined-outer-name
 def ilab(ctx, config_file):
-    """CLI for interacting with InstructLab.
+    """
+    NOTE: ilab no longer supports Python 3.9 or Python 3.12 as of version 0.18. If you are using either of these Python versions, there is no upgrade path from ilab 0.17 to newer ilab versions.
+    Please switch to Python 3.10 or 3.11 to use the latest ilab. ilab 0.17 will receive no bug fixes or additional features.
+    You can check which Python version you are using by running `python --version`
+
+    CLI for interacting with InstructLab.
 
     If this is your first time running ilab, it's best to start with `ilab init` to create the environment.
     """


### PR DESCRIPTION
we've seen a lot of confusion from folks using deprecated Python versions installing 0.17 - adding a message to recommend folks use a support Python version so they can use the latest ilab

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
