### PR TITLE
adding api_key command line argument for llama_ccp

### DIFF
--- a/src/instructlab/cli/model/serve.py
+++ b/src/instructlab/cli/model/serve.py
@@ -56,6 +56,11 @@ def warn_for_unsupported_backend_param(ctx):
     config_sections="llama_cpp",
 )
 @click.option(
+    "--api-key",
+    type=str,
+    cls=clickext.ConfigOption,
+)
+@click.option(
     "--model-family",
     type=str,
     help="Model family is used to specify which chat template to serve with",
@@ -91,6 +96,7 @@ def serve(
     gpu_layers: int,
     num_threads: int | None,
     max_ctx_size: int,
+    api_key: str | None,
     model_family,
     log_file: pathlib.Path | None,
     backend: str | None,
@@ -107,6 +113,7 @@ def serve(
         gpu_layers,
         num_threads,
         max_ctx_size,
+        api_key,
         model_family,
         log_file,
         backend,

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -51,6 +51,7 @@ class Server(BackendServer):
         port: int,
         gpu_layers: int,
         max_ctx_size: int,
+        api_key: str,
         num_threads: Optional[int],
         log_file: Optional[pathlib.Path] = None,
     ):
@@ -65,6 +66,7 @@ class Server(BackendServer):
         )
         self.gpu_layers = gpu_layers
         self.max_ctx_size = max_ctx_size
+        self.api_key = api_key
         self.num_threads = num_threads
         self.queue: Optional[multiprocessing.Queue] = None
         self.process: multiprocessing.Process | None = None
@@ -77,6 +79,7 @@ class Server(BackendServer):
                 chat_template=self.chat_template,
                 gpu_layers=self.gpu_layers,
                 max_ctx_size=self.max_ctx_size,
+                api_key=self.api_key,
                 model_family=self.model_family,
                 threads=self.num_threads,
                 host=self.host,
@@ -104,6 +107,7 @@ class Server(BackendServer):
                 "chat_template": self.chat_template,
                 "gpu_layers": self.gpu_layers,
                 "max_ctx_size": self.max_ctx_size,
+                "api_key": self.api_key,
                 "model_family": self.model_family,
                 "port": port,
                 "host": self.host,
@@ -177,6 +181,7 @@ def server(
     chat_template: str,
     gpu_layers: int,
     max_ctx_size: int,
+    api_key: str,
     model_family: str,
     threads=None,
     host: str = "localhost",
@@ -192,6 +197,7 @@ def server(
         port=port,
         model=model_path.as_posix(),
         n_ctx=max_ctx_size,
+        api_key=api_key,
         n_gpu_layers=gpu_layers,
         verbose=verbose,
     )


### PR DESCRIPTION
this allows you to use instructlab command line arguments just like this

```
ilab model serve --api-key seantoken
```

specifically this is just for llama.ccp and just does a pass through to their native --api-key to force authentication.  This allows people to use instructlab with some level of security and showcase demos with an api key rather than leaving it wide open.  I have tested this with a G6 AWS service running instructlab and got it working

Here is an example:

```
➜  ~ curl -X 'POST' \
  'http://98.80.168.118:8000/v1/completions' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer seantoken' \
  -H 'Content-Type: application/json' \
  -d '{
  "prompt": "\n\n### Instructions:\nWhat is the capital of France?\n\n### Response:\n",
  "stop": [
    "\n",
    "###"
  ]
}'

{"id":"cmpl-26ac8114-947f-4e4a-969f-c2329c384f65","object":"text_completion","created":1731016999,"model":"/home/ec2-user/.cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf","choices":[{"text":"Paris. The capital of France is Paris, which is known for its rich","index":0,"logprobs":null,"finish_reason":"length"}],"usage":{"prompt_tokens":21,"completion_tokens":16,"total_tokens":37}}%
```

now the token works, but if I pass a bad token I will get Invalid API key

```
➜  ~ curl -X 'POST' \
  'http://98.80.168.118:8000/v1/completions' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer seasdfantoken' \
  -H 'Content-Type: application/json' \
  -d '{
  "prompt": "\n\n### Instructions:\nWhat is the capital of France?\n\n### Response:\n",
  "stop": [
    "\n",
    "###"
  ]
}'

{"detail":"Invalid API key"}%
```

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
