### PR TITLE
add -k option for show

### DIFF
--- a/src/instructlab/config/show.py
+++ b/src/instructlab/config/show.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+
 # Standard
+from typing import Any, Dict
 import sys
 
 # Third Party
@@ -14,15 +16,42 @@ yaml = ruamel.yaml.YAML()
 yaml.indent(mapping=2, sequence=4, offset=2)
 
 
+def get_nested_value(data_dict: Dict[str, Any], path: str) -> Any:
+    """Retrieve nested value using dot-separated path."""
+    keys = path.split(".")
+    for key in keys:
+        data_dict = data_dict[key]
+    return data_dict
+
+
 @click.command()
 @click.pass_context
+@click.option(
+    "--key",
+    "-k",
+    "key_path",
+    default=None,
+    help="Show only a specific section of the configuration, e.g., -k chat or -k chat.context",
+)
 @clickext.display_params
-def show(ctx: click.Context) -> None:
-    """Displays the current config as YAML"""
-    # TODO: make this use pretty colors like jq/yq
+def show(ctx: click.Context, key_path: str) -> None:
+    """Displays the current config as YAML with an option to extract a specific key."""
+
     try:
         commented_map = configuration.config_to_commented_map(ctx.obj.config)
-    except YAMLError as e:
-        click.secho(f"Error loading config as YAML: {e}", fg="red")
+        result = (
+            commented_map if not key_path else get_nested_value(commented_map, key_path)
+        )
+
+        if isinstance(result, (dict, list)):
+            yaml.dump(result, sys.stdout)
+        else:
+            click.echo(result)
+
+    except KeyError:
+        click.secho(f"Key not found: '{key_path}'", fg="red")
         ctx.exit(2)
-    yaml.dump(commented_map, sys.stdout)
+
+    except YAMLError as e:
+        click.secho(f"Error loading config: {e}.", fg="red")
+        ctx.exit(2)


### PR DESCRIPTION
- add the key option and use key to search the config

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

Improve the `show` command. [origin one 2264](https://github.com/instructlab/instructlab/pull/2264)
- Background
So far, `ilab config show` only simply print the `config.yaml`, and config become more and more according to the repo become stronger.
The issue is hard to read/search the config what we want. e.g. there are paths, model, data, train ..etc.

- add key search e.g. -k chat.model, easy to check the config
```
$ ilab config show -k version
1.0.0

$ ilab config show -k chat.model
/Users/xx/.cache/instructlab/models/merlinite-7b-lab-Q4_K_M.gguf
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
