### PR TITLE
use default indent constant for download and init

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -26,6 +26,7 @@ from instructlab.configuration import (
     recreate_system_profiles,
     write_config,
 )
+from instructlab.defaults import DEFAULT_INDENT
 from instructlab.utils import convert_bytes_to_proper_mag
 
 logger = logging.getLogger(__name__)
@@ -116,11 +117,13 @@ def init(
     )
     if overwrite_profile:
         click.echo(
-            f"\nGenerating config file and profiles:\n    {DEFAULTS.CONFIG_FILE}\n    {DEFAULTS.SYSTEM_PROFILE_DIR}\n"
+            f"\nGenerating config file and profiles:\n{DEFAULT_INDENT}{DEFAULTS.CONFIG_FILE}\n{DEFAULT_INDENT}{DEFAULTS.SYSTEM_PROFILE_DIR}\n"
         )
         recreate_system_profiles(overwrite=True)
     else:
-        click.echo(f"\nGenerating config file:\n    {DEFAULTS.CONFIG_FILE}\n")
+        click.echo(
+            f"\nGenerating config file:\n{DEFAULT_INDENT}{DEFAULTS.CONFIG_FILE}\n"
+        )
     if profile is not None:
         cfg = read_config(profile)
     elif interactive:
@@ -140,7 +143,7 @@ def init(
     ready_text = "  You're ready to start using `ilab`. Enjoy!"
     separator = get_separator(ready_text)
     click.secho(
-        f"\n{separator}\n    Initialization completed successfully!\n{ready_text}\n{separator}",
+        f"\n{separator}\n{DEFAULT_INDENT}Initialization completed successfully!\n{ready_text}\n{separator}",
         fg="green",
     )
 
@@ -338,13 +341,15 @@ def hw_auto_detect() -> Config | None:
 
 def check_if_configs_exist(fresh_install) -> bool:
     if exists(DEFAULTS.CONFIG_FILE):
-        click.echo(f"Existing config file was found in:\n    {DEFAULTS.CONFIG_FILE}")
+        click.echo(
+            f"Existing config file was found in:\n{DEFAULT_INDENT}{DEFAULTS.CONFIG_FILE}"
+        )
         overwrite = click.confirm("Do you still want to continue?")
         if not overwrite:
             raise click.exceptions.Exit(0)
     if exists(DEFAULTS.SYSTEM_PROFILE_DIR) and not fresh_install:
         return click.confirm(
-            f"Existing system profiles were found in {DEFAULTS.SYSTEM_PROFILE_DIR}\nDo you want to restore these profiles to the default values?"
+            f"\nExisting system profiles were found in:\n{DEFAULT_INDENT}{DEFAULTS.SYSTEM_PROFILE_DIR}\nDo you want to restore these profiles to the default values?"
         )
     # default behavior should be do NOT overwrite files that could have just been created
     return False

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -18,6 +18,9 @@ MODEL_FAMILY_MAPPINGS = {
     "granite": "merlinite",
 }
 
+# Indentation constant
+DEFAULT_INDENT = "    "
+
 # Default log format
 LOG_FORMAT = "%(levelname)s %(asctime)s %(name)s:%(lineno)d: %(message)s"
 

--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -18,9 +18,8 @@ import click
 # First Party
 from instructlab import clickext
 from instructlab.configuration import DEFAULTS
+from instructlab.defaults import DEFAULT_INDENT
 from instructlab.utils import is_huggingface_repo, is_oci_repo, load_json
-
-DEFAULT_INDENT = "    "
 
 logger = logging.getLogger(__name__)
 
@@ -336,7 +335,7 @@ def download(ctx, repositories, releases, filenames, model_dir, hf_token):
         except (ValueError, Exception) as exc:
             if isinstance(exc, ValueError) and "HF_TOKEN" in str(exc):
                 click.secho(
-                    f"\n{downloader.repository} requires a HF Token to be set.\nPlease use '--hf-token' or 'export HF_TOKEN' to download all necessary models",
+                    f"\n{downloader.repository} requires a HF Token to be set.\nPlease use '--hf-token' or 'export HF_TOKEN' to download all necessary models.",
                     fg="yellow",
                 )
             else:


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

- Move the `DEFAULT_INDENT` to `defaults`, and use it in `init` and `download`
- And the existing profiles should use indent(merged in [2443](https://github.com/instructlab/instructlab/pull/2443)), and separate it.
```
 ilab config init
Existing config file was found in:
    /Users/xx/.config/instructlab/config.yaml
Do you still want to continue? [y/N]: y
Existing system profiles were found in /Users/xx/.local/share/instructlab/internal/system_profiles
Do you want to restore these profiles to the default values? [y/N]: n

$ ilab config init
Existing config file was found in:
    /Users/xx/.config/instructlab/config.yaml
Do you still want to continue? [y/N]: y

Existing system profiles were found in:
    /Users/xx/.local/share/instructlab/internal/system_profiles
Do you want to restore these profiles to the default values? [y/N]: n
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
