### PR TITLE
fix the oci warning

### DIFF
--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -617,6 +617,8 @@ def is_oci_repo(repo_url: str) -> bool:
     """
     Checks if a provided repository follows the OCI registry URL syntax
     """
+    if not repo_url.startswith("docker://"):
+        return False
     oci_url_regex = r"^docker://([a-zA-Z0-9\-_.]+(:[0-9]+)?)(/[a-zA-Z0-9\-_.]+)+(@[a-zA-Z0-9]+|:[a-zA-Z0-9\-_.]+)?$"
     if not re.match(oci_url_regex, repo_url):
         logger.warning(f"Invalid OCI repository URL: {repo_url}")


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

The default repositories are not `OCI`, so it will hit the warning every time because it will check it first every time. So follow the `is_huggingface_repo` way to just return `bool`.
```
$ ilab model download
WARNING 2024-11-09 14:30:53,322 instructlab.utils:636: Invalid OCI repository URL: instructlab/merlinite-7b-lab-GGUF


       if is_oci_repo(repository):
            downloader = OCIDownloader(
                ctx=ctx, repository=repository, release=release, download_dest=model_dir
            )
        elif is_huggingface_repo(repository):


def is_huggingface_repo(repo_name: str) -> bool:
    # allow alphanumerics, underscores, hyphens and periods in huggingface repo names
    # repo name should be of the format <owner>/<model>
    pattern = r"^[\w.-]+\/[\w.-]+$"
    return re.match(pattern, repo_name) is not None
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
