### PR TITLE
Full Train Memory Optimizations

### DIFF
--- a/src/instructlab/cli/model/train.py
+++ b/src/instructlab/cli/model/train.py
@@ -364,6 +364,11 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     is_flag=True,
     help="Clear phased cache (journal, checkpoints, metadata). Helpful paired with '--skip-user-confirm'",
 )
+@click.option(
+    "--optimize-memory",
+    is_flag=True,
+    help="Optimize Memory Usage on CPU and MacOS. This uses the torch_dtype='auto' instead of float32",
+)
 @click.pass_context
 @clickext.display_params
 def train(
@@ -397,6 +402,7 @@ def train(
     training_journal: pathlib.Path | None,
     force_clear_phased_cache: bool,
     distributed_backend,
+    optimize_memory,
     **kwargs,
 ):
     """
@@ -469,7 +475,9 @@ def train(
         # if on CPU or MPS, execute full train, which is based
         # off of the structure of the training repo, just with different optimizers, model sizes, and special data gradient accumulation to get it
         # to fit on most consumer laptops
-        full_train.train(train_args=train_args, device=device)
+        full_train.train(
+            train_args=train_args, device=device, optimize_memory=optimize_memory
+        )
     elif pipeline == "simple":
         # First Party
         from instructlab.model import simple_train


### PR DESCRIPTION
Currently, full train only runs on hardware with 64GB of Memory.

With some optimizations, this can be cut down to a 16GB requirement, massively increasing the amount of users able to run this workflow.

`AutoModel` and `AutoConfig` both have a torch_dtype and low_cpu_mem_usage fields. setting the dtype to `auto` and `low_cpu_mem_usage` to True on all architectures yields improved results.

The _only_ caveat here is that Intel CPUs preform siginficantly worse when using the `torch_dtype=auto` setting. We should stick with fp32 on intel CPUs

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
