### PR TITLE
expose max_num_tokens for SDG

### DIFF
--- a/scripts/test-data/profile-l4-x1.yaml
+++ b/scripts/test-data/profile-l4-x1.yaml
@@ -55,6 +55,8 @@ generate:
   model: ~/.cache/instructlab/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf
   # Number of CPU cores to use for generation
   num_cpus: 10
+  # Maximum number of tokens to generate
+  max_num_tokens: 512
   # Directory where generated datasets are stored
   output_dir: ~/.local/share/instructlab/datasets
   # Directory where pipeline config files are stored

--- a/src/instructlab/cli/data/generate.py
+++ b/src/instructlab/cli/data/generate.py
@@ -148,6 +148,11 @@ logger = logging.getLogger(__name__)
     cls=clickext.ConfigOption,
     config_sections="teacher.vllm",
 )
+@click.option(
+    "--max-num-tokens",
+    type=click.IntRange(min=512),
+    cls=clickext.ConfigOption,
+)
 @click.pass_context
 @clickext.display_params
 def generate(
@@ -174,6 +179,7 @@ def generate(
     enable_serving_output,
     batch_size,
     gpus,
+    max_num_tokens,
 ):
     """Generates synthetic data to enhance your example data"""
 
@@ -250,6 +256,7 @@ def generate(
             batch_size,
             gpus,
             checkpoint_dir,
+            max_num_tokens,
         )
     except Exception as exc:
         click.secho(f"failed to generate data with exception: {exc}", fg="red")

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -244,6 +244,10 @@ class _generate(BaseModel):
         default=DEFAULTS.SDG_PIPELINE,
         description="Data generation pipeline to use. Available: 'simple', 'full', or a valid path to a directory of pipeline workflow YAML files. Note that 'full' requires a larger teacher model, Mixtral-8x7b.",
     )
+    max_num_tokens: Optional[int] = Field(
+        default=DEFAULTS.SDG_MAX_NUM_TOKENS,
+        description="The maximum amount of tokens for the model to generate during knowledge generation. A lower number yields less data but a faster SDG run. It is reccomended to use this on consumer hardware",
+    )
     model: StrictStr = Field(
         default_factory=lambda: DEFAULTS.DEFAULT_TEACHER_MODEL,
         description="Teacher model that will be used to synthetically generate training data.",

--- a/src/instructlab/data/generate_data.py
+++ b/src/instructlab/data/generate_data.py
@@ -31,6 +31,7 @@ def gen_data(
     batch_size,
     gpus,
     checkpoint_dir,
+    max_num_tokens,
 ):
     """Generates synthetic data to enhance your example data"""
     # Third Party
@@ -100,6 +101,7 @@ def gen_data(
             pipeline=pipeline,
             batch_size=batch_size,
             checkpoint_dir=checkpoint_dir,
+            max_num_tokens=max_num_tokens,
         )
     except GenerateException as exc:
         raise ValueError(

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -74,6 +74,7 @@ class _InstructlabDefaults:
     MULTIPROCESSING_START_METHOD = "spawn"
     SDG_PIPELINE = "full"
     SDG_SCALE_FACTOR = 30
+    SDG_MAX_NUM_TOKENS = 4096
 
     # When otherwise unknown, ilab uses this as the default family
     MODEL_FAMILY = "granite"

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -96,6 +96,11 @@ generate:
   # Maximum number of words per chunk.
   # Default: 1000
   chunk_word_count: 1000
+  # The maximum amount of tokens for the model to generate during knowledge
+  # generation. A lower number yields less data but a faster SDG run. It is
+  # reccomended to use this on consumer hardware
+  # Default: 4096
+  max_num_tokens: 4096
   # Teacher model that will be used to synthetically generate training data.
   # Default: /cache/instructlab/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf
   model: /cache/instructlab/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf


### PR DESCRIPTION
SDG now supports max_num_tokens, allowing for `gen_knowledge` to be run quicker and generate less data This should be exposed to users in the CLI. On a laptop many people care about speed and quick results rather than large datasets

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
