### PR TITLE
add custom handling for A100 System Profile

### DIFF
--- a/tests/test_lab_init.py
+++ b/tests/test_lab_init.py
@@ -17,7 +17,7 @@ from instructlab.configuration import DEFAULTS, read_config
 class TestLabInit:
     @patch(
         "instructlab.config.init.get_gpu_or_cpu",
-        return_value=("nvidia a100 x2", False, True),
+        return_value=("nvidia a100 x2", False, True, 0, 0),
     )
     def test_ilab_config_init_auto_detection_nvidia(
         self, convert_bytes_to_proper_mag_mock, cli_runner: CliRunner
@@ -32,7 +32,7 @@ class TestLabInit:
 
     @patch(
         "instructlab.config.init.get_gpu_or_cpu",
-        return_value=("apple m3 max", True, False),
+        return_value=("apple m3 max", True, False, 0, 0),
     )
     def test_ilab_config_init_auto_detection_mac(
         self, convert_bytes_to_proper_mag_mock, cli_runner: CliRunner
@@ -46,7 +46,8 @@ class TestLabInit:
         )
 
     @patch(
-        "instructlab.config.init.get_gpu_or_cpu", return_value=("amd cpu", True, True)
+        "instructlab.config.init.get_gpu_or_cpu",
+        return_value=("amd cpu", True, True, 0, 0),
     )
     def test_ilab_config_init_auto_detection_cpu(
         self, convert_bytes_to_proper_mag_mock, cli_runner: CliRunner
@@ -61,7 +62,7 @@ class TestLabInit:
 
     @patch(
         "instructlab.config.init.get_gpu_or_cpu",
-        return_value=("intel gaudi 3", False, True),
+        return_value=("intel gaudi 3", False, True, 0, 0),
     )
     def test_ilab_config_init_auto_detection_gaudi(
         self, convert_bytes_to_proper_mag_mock, cli_runner: CliRunner


### PR DESCRIPTION
The A100, unlike other cards, has two variants: 80GB and 40GB, we need to swap out a config entry if we are dealing with the A100 40GB

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
