### PR TITLE
feat: add hf_transfer for fast model download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 * `ilab` now supports system profiles. These profiles apply entire configuration files tailored to specific hardware configurations. We support a set of auto-detected profiles for CPU enabled Linux machines, M-Series Apple Silicon Chips, and Nvidia GPUs, and Intel Gaudi 3. When you run `ilab config init`, one of these profiles should be selected for you. If there is not a direct match, a menu will be displayed allowing you to choose one.
 
+* `ilab model download` uses the `hf_transfer` library for faster model downloads reducing the average download time by 60%. This only applies to models that are hosted on Hugging Face Hub. This can be disabled by setting the environment variable `HF_HUB_ENABLE_HF_TRANSFER` to `0`.
+
 ## v0.20
 
 ### Breaking Changes

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ trl>=0.9.4
 wandb>=0.16.4
 xdg-base-dirs>=6.0.1
 psutil>=6.0.0
+huggingface_hub[hf_transfer]>=0.1.8

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -50,6 +50,10 @@ from .defaults import (
 yaml = YAML()
 yaml.indent(mapping=2, sequence=4, offset=2)
 
+# Enable fast-download using external dependency "hf_transfer"
+# Used by the "ilab model download" command
+os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+
 
 class ConfigException(Exception):
     """An exception that a configuration file has an error."""


### PR DESCRIPTION
Using the `hf_transfer` library can drastically speed up downloading a model.
On my machine, downloading the default `granite-7b-lab-Q4_K_M.gguf`, consistently resulted in the following:

- Without hf_transfer: 98.29s
- With hf_transfer: 37.79s

Using `hf_transfer` can be disabled by setting
`HF_HUB_ENABLE_HF_TRANSFER=0`.

This only applies to models that are hosted on Hugging Face Hub.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
