### PR TITLE
add instructlab-training[hpu] to requirements/hpu.txt

### DIFF
--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -13,3 +13,6 @@ habana_gpu_migration>=1.18.0
 #habana-pyhlml
 #habana_quantization_toolkit
 #habana-torch-dataloader
+
+# Extra dependencies for Intel Gaudi cards
+instructlab-training[hpu]>=0.6.0


### PR DESCRIPTION
in order for instructlab to be installed for hpus, require that we also
install the dependencies in the hpu set of requirements for
instructlab-training

Signed-off-by: James Kunstle <jkunstle@redhat.com>
