### PR TITLE
Don't fail fast when one of the unit/func test envs fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
     needs: ["test-workflow-ready"]
     runs-on: "${{ matrix.platform }}"
     strategy:
+      fail-fast: false
       matrix:
         python:
           - "3.10"


### PR DESCRIPTION
Previously if 3.10 ubuntu failed (for example), 3.11 and macos wouldn't report results.  This should allow for all of them to finish.  It shouldn't waste much resource if they are all going to fail the same way anyway but now let you know if the failure is version dependent.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
