### PR TITLE
add --host and --port for serve

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -219,7 +219,7 @@ test_bind_port(){
     }
 
     # configure a different port
-    exec sed -i.bak 's/:8000/:9999/g' %s
+    exec sed -i.bak 's/8000/9999/g' %s
 
     # check that ilab model serve is working on the new port
     # catch ERROR strings in the output

--- a/src/instructlab/cli/model/serve.py
+++ b/src/instructlab/cli/model/serve.py
@@ -83,6 +83,20 @@ def warn_for_unsupported_backend_param(ctx):
     cls=clickext.ConfigOption,
     config_sections="vllm",
 )
+@click.option(
+    "-h",
+    "--host",
+    type=str,
+    cls=clickext.ConfigOption,
+    config_sections="server",
+)
+@click.option(
+    "-p",
+    "--port",
+    type=int,
+    cls=clickext.ConfigOption,
+    config_sections="server",
+)
 @click.pass_context
 @clickext.display_params
 def serve(
@@ -96,6 +110,8 @@ def serve(
     backend: str | None,
     chat_template: str | None,
     gpus: int | None,
+    host: str,
+    port: int,
 ) -> None:
     """Starts a local server"""
 
@@ -112,6 +128,8 @@ def serve(
         backend,
         chat_template,
         gpus,
+        host,
+        port,
     )
 
 

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -27,6 +27,7 @@ from pydantic import (
     ConfigDict,
     Field,
     PositiveInt,
+    StrictInt,
     StrictStr,
     ValidationError,
     field_validator,
@@ -205,6 +206,13 @@ class _serve_llama_cpp(BaseModel):
     )
 
 
+class _serve_server(BaseModel):
+    """Class describing configuration of server serving backend."""
+
+    host: StrictStr = Field(default="127.0.0.1", description="Host to serve on.")
+    port: StrictInt = Field(default=8000, description="Port to serve on.")
+
+
 class _serve(BaseModel):
     """Class describing configuration of the 'serve' sub-command."""
 
@@ -225,8 +233,9 @@ class _serve(BaseModel):
         description="Directory where model to be served is stored.",
     )
     # additional fields with defaults
-    host_port: StrictStr = Field(
-        default="127.0.0.1:8000", description="Host and port to serve on."
+    server: _serve_server = Field(
+        default=_serve_server(),
+        description="Server configuration including host and port.",
     )
     chat_template: Optional[str] = Field(
         default=None,
@@ -247,7 +256,7 @@ class _serve(BaseModel):
 
     def api_base(self):
         """Returns server API URL, based on the configured host and port"""
-        return get_api_base(self.host_port)
+        return get_api_base(self.server.host, self.server.port)
 
 
 class _generate(BaseModel):
@@ -1143,9 +1152,9 @@ def write_config_to_yaml(cfg: Config, file_path: str):
         yaml.dump(commented_map, yaml_file)
 
 
-def get_api_base(host_port: str) -> str:
-    """Returns server API URL, based on the provided host_port"""
-    return f"http://{host_port}/v1"
+def get_api_base(host: str, port: int) -> str:
+    """Returns server API URL, based on the provided host and port"""
+    return f"http://{host}:{port}/v1"
 
 
 def get_model_family(family, model_path):

--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -11,7 +11,7 @@ import click
 
 # Local
 from ...configuration import _serve as serve_config
-from ...utils import is_model_gguf, is_model_safetensors, split_hostport
+from ...utils import is_model_gguf, is_model_safetensors
 from .common import CHAT_TEMPLATE_AUTO, LLAMA_CPP, VLLM
 from .server import BackendServer
 
@@ -135,7 +135,8 @@ def select_backend(
         click.secho(f"Failed to determine backend: {e}", fg="red")
         raise click.exceptions.Exit(1)
 
-    host, port = split_hostport(cfg.host_port)
+    host = cfg.server.host
+    port = cfg.server.port
     chat_template = cfg.chat_template
     if not chat_template:
         chat_template = CHAT_TEMPLATE_AUTO

--- a/src/instructlab/model/backends/llama_cpp.py
+++ b/src/instructlab/model/backends/llama_cpp.py
@@ -128,7 +128,7 @@ class Server(BackendServer):
         try:
             self.port = free_tcp_ipv4_port(self.host)
             # start new server
-            self.api_base = str(get_api_base(f"{self.host}:{self.port}"))
+            self.api_base = str(get_api_base(self.host, self.port))
             logger.debug(f"Starting a temporary server at {self.api_base}...")
             self.process = self.create_server_process(self.port)
             self.process.start()

--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -115,8 +115,7 @@ class Server(BackendServer):
         port = free_tcp_ipv4_port(self.host)
         logger.debug(f"Using available port {port} for temporary model serving.")
 
-        host_port = f"{self.host}:{port}"
-        temp_api_base = get_api_base(host_port)
+        temp_api_base = get_api_base(self.host, port)
         vllm_server_process = self.create_server_process(port, background)
         logger.info("Starting a temporary vLLM server at %s", temp_api_base)
         count = 0
@@ -309,7 +308,7 @@ def run_vllm(
                 start_new_session=True,
             )
 
-        api_base = get_api_base(f"{host}:{port}")
+        api_base = get_api_base(host, port)
         logger.info("vLLM starting up on pid %s at %s", vllm_process.pid, api_base)
 
     except:

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -197,7 +197,8 @@ def chat(
     # First Party
     from instructlab.model.backends.common import is_temp_server_running
 
-    users_endpoint_url = cfg.get_api_base(ctx.obj.config.serve.host_port)
+    serve_server = ctx.obj.config.serve.server
+    users_endpoint_url = cfg.get_api_base(serve_server.host, serve_server.port)
 
     # we prefer the given endpoint when one is provided, else we check if the user
     # is actively serving something before falling back to serving our own model

--- a/src/instructlab/model/serve_backend.py
+++ b/src/instructlab/model/serve_backend.py
@@ -6,7 +6,7 @@ import pathlib
 import sys
 
 # First Party
-from instructlab import log, utils
+from instructlab import log
 from instructlab.model.backends import backends
 from instructlab.model.backends.common import ServerException
 from instructlab.model.backends.server import BackendServer
@@ -33,6 +33,8 @@ def serve_backend(
     backend: str | None,
     chat_template: str | None,
     gpus: int | None,
+    host: str,
+    port: int,
 ) -> None:
     """Core server functionality to be called from the CLI"""
     # Configure logging
@@ -42,8 +44,6 @@ def serve_backend(
 
     # First Party
     from instructlab.model.backends import llama_cpp, vllm
-
-    host, port = utils.split_hostport(ctx.obj.config.serve.host_port)
 
     try:
         backend = backends.get(model_path, backend)

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -4,7 +4,6 @@
 from functools import wraps
 from pathlib import Path
 from typing import List, Tuple, TypedDict
-from urllib.parse import urlparse
 import copy
 import glob
 import json
@@ -456,19 +455,6 @@ def validate_taxonomy(
                     f"{total_errors} total errors found across {len(taxonomy_files)} taxonomy files!"
                 )
             )
-
-
-def split_hostport(hostport: str) -> tuple[str, int]:
-    """Split server:port into server and port (IPv6 safe)"""
-    if "//" not in hostport:
-        # urlparse expects an URL-like input like '//host:port'
-        hostport = f"//{hostport}"
-    parsed = urlparse(hostport)
-    hostname = parsed.hostname
-    port = parsed.port
-    if not hostname or not port:
-        raise ValueError(f"Invalid host-port string: '{hostport}'")
-    return hostname, port
 
 
 def is_pretraining_dataset(ds: List[MessageSample]) -> bool:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,7 +60,8 @@ class TestConfig:
         assert cfg.generate.teacher.llama_cpp.llm_family == ""
         assert cfg.generate.teacher.vllm is not None
         assert cfg.generate.teacher.vllm.vllm_args == []
-        assert cfg.generate.teacher.host_port == "127.0.0.1:8000"
+        assert cfg.generate.teacher.server.host == "127.0.0.1"
+        assert cfg.generate.teacher.server.port == 8000
         assert cfg.generate.teacher.backend is None
         assert cfg.generate.teacher.chat_template is None
         assert cfg.generate.pipeline == "full"
@@ -83,7 +84,8 @@ class TestConfig:
         assert cfg.serve.llama_cpp.llm_family == ""
         assert cfg.serve.vllm is not None
         assert cfg.serve.vllm.vllm_args == []
-        assert cfg.serve.host_port == "127.0.0.1:8000"
+        assert cfg.serve.server.host == "127.0.0.1"
+        assert cfg.serve.server.port == 8000
         assert cfg.serve.backend is None
         assert cfg.serve.chat_template is None
 

--- a/tests/test_lab_serve.py
+++ b/tests/test_lab_serve.py
@@ -335,3 +335,53 @@ def test_warn_for_unsupported_backend_param(param, expected_call_count):
             mock_warning.assert_called_with(
                 f"Option '--{param.replace('_','-')}' not supported by the backend."
             )
+
+
+def test_serve_host(cli_runner: CliRunner):
+    args = common.vllm_setup_test(
+        cli_runner,
+        [
+            "--config=DEFAULT",
+            "model",
+            "serve",
+            "--model-path=foo",
+            "--host",
+            "2.4.6.8",
+        ],
+    )
+    assert "2.4.6.8" in args
+    assert "8000" in args
+
+
+def test_serve_port(cli_runner: CliRunner):
+    args = common.vllm_setup_test(
+        cli_runner,
+        [
+            "--config=DEFAULT",
+            "model",
+            "serve",
+            "--model-path=foo",
+            "--port",
+            "1234",
+        ],
+    )
+    assert "127.0.0.1" in args
+    assert "1234" in args
+
+
+def test_serve_host_port(cli_runner: CliRunner):
+    args = common.vllm_setup_test(
+        cli_runner,
+        [
+            "--config=DEFAULT",
+            "model",
+            "serve",
+            "--model-path=foo",
+            "--host",
+            "192.168.1.1",
+            "--port",
+            "1234",
+        ],
+    )
+    assert "192.168.1.1" in args
+    assert "1234" in args

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -187,34 +187,6 @@ class TestUtils:
             utils.ensure_legacy_dataset(dataset)
 
 
-@pytest.mark.parametrize(
-    "url,expected_host,expected_port",
-    [
-        ("127.0.0.1:8080", "127.0.0.1", 8080),
-        ("[::1]:8080", "::1", 8080),
-        ("host.test:9090", "host.test", 9090),
-        ("https://host.test:443/egg/spam", "host.test", 443),
-    ],
-)
-def test_split_hostport(url, expected_host, expected_port):
-    host, port = utils.split_hostport(url)
-    assert host == expected_host
-    assert port == expected_port
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        "127.0.0.1",
-        "",
-        "::1:8080",
-    ],
-)
-def test_split_hostport_err(url):
-    with pytest.raises(ValueError):
-        utils.split_hostport(url)
-
-
 def test_get_sysprompt():
     arch = "llama"
     assert (

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -152,9 +152,6 @@ generate:
     #   - tokenizer
     #   - A filesystem path expressing the location of a custom template
     chat_template:
-    # Host and port to serve on.
-    # Default: 127.0.0.1:8000
-    host_port: 127.0.0.1:8000
     # llama-cpp serving settings.
     llama_cpp:
       # Number of model layers to offload to GPU. -1 means all layers.
@@ -172,6 +169,15 @@ generate:
     # Directory where model to be served is stored.
     # Default: /cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
     model_path: /cache/instructlab/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf
+    # Server configuration including host and port.
+    # Default: host='127.0.0.1' port=8000
+    server:
+      # Host to serve on.
+      # Default: 127.0.0.1
+      host: 127.0.0.1
+      # Port to serve on.
+      # Default: 8000
+      port: 8000
     # vLLM serving settings.
     vllm:
       # Number of GPUs to use.
@@ -227,9 +233,6 @@ serve:
   #   - tokenizer
   #   - A filesystem path expressing the location of a custom template
   chat_template:
-  # Host and port to serve on.
-  # Default: 127.0.0.1:8000
-  host_port: 127.0.0.1:8000
   # llama-cpp serving settings.
   llama_cpp:
     # Number of model layers to offload to GPU. -1 means all layers.
@@ -247,6 +250,15 @@ serve:
   # Directory where model to be served is stored.
   # Default: /cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
   model_path: /cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
+  # Server configuration including host and port.
+  # Default: host='127.0.0.1' port=8000
+  server:
+    # Host to serve on.
+    # Default: 127.0.0.1
+    host: 127.0.0.1
+    # Port to serve on.
+    # Default: 8000
+    port: 8000
   # vLLM serving settings.
   vllm:
     # Number of GPUs to use.


### PR DESCRIPTION
add host_port arg to the serve_backend

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

```
$ ilab model serve --help
  -h, --host TEXT             Host to serve on. [default: 127.0.0.1; config:
                              'serve.server.host']
  -p, --port INTEGER          Port to serve on. [default: 8000; config:
                              'serve.server.port']
```

Seems some requests [2604](https://github.com/instructlab/instructlab/issues/2604) [1823](https://github.com/instructlab/instructlab/issues/1823)  for this arg, so update it. And sorry for the original one [1446](https://github.com/instructlab/instructlab/pull/1446) that missed the previous git env. please check this one, thanks.


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
