### PR TITLE
Fix add command to use var with sync-library

### DIFF
--- a/scripts/infra/cloud-instance.sh
+++ b/scripts/infra/cloud-instance.sh
@@ -373,7 +373,7 @@ sync_library() {
         branch=${branch##refs/heads/}
         if [ "$TEMP_COMMIT" = true ] && [ -n "$(git status --porcelain=v1 2>/dev/null)" ]; then
             trap 'git reset HEAD~' EXIT
-            git add repo_dir
+            git add "${repo_dir}"
             git commit -m 'Sync commit'
         fi
         GIT_SSH_COMMAND="ssh -o 'StrictHostKeyChecking no' -i $(instance_key)" git push ssh://"$user_name"@"$PUBLIC_DNS":"$user_home"/"$LIBRARY".git "$branch":main -f


### PR DESCRIPTION
This change fixes sync-library -c to use the correct repo dir for each library.  Was missing the variable reference.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
