### PR TITLE
dolomite fixes

### DIFF
--- a/src/instructlab/cli/model/train.py
+++ b/src/instructlab/cli/model/train.py
@@ -245,6 +245,7 @@ def clickpath_setup(is_dir: bool) -> click.Path:
     cls=clickext.ConfigOption,
     config_sections=ADDITIONAL_ARGUMENTS,
     type=click.BOOL,
+    required=True,  # default from config
 )
 @click.option(
     "--gpus",

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -54,6 +54,9 @@ yaml = YAML()
 yaml.indent(mapping=2, sequence=4, offset=2)
 
 
+logger = logging.getLogger(__name__)
+
+
 class ConfigException(Exception):
     """An exception that a configuration file has an error."""
 
@@ -1142,8 +1145,20 @@ def ensure_storage_directories_exist() -> bool:
 
     fresh_install = recreate_system_profiles()
 
-    # create expert_args file for users to see/edit
-    if not os.path.isfile(DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_FILE):
+    # open file in read mode to load current contents
+
+    train_options_dict: dict[str, Any] = {}
+    try:
+        with open(
+            DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_FILE, "r", encoding="utf-8"
+        ) as infile:
+            train_options_dict = yaml.load(infile) or {}
+    except FileNotFoundError:
+        logger.debug("Additional Arguments internal file not found, creating now")
+
+    # check if there are new keys in defaults
+    if len(DEFAULTS.ADDITIONAL_ARGS_DEFAULTS.keys()) > len(train_options_dict.keys()):
+        # open file in write mode and update contents if there are new keys
         with open(
             DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_FILE, "w", encoding="utf-8"
         ) as outfile:


### PR DESCRIPTION
    when additional_args defaults change, overwrite file

    currently new args like use_dolomite don't propogate into the additional args file since on most systems
    it already exists. Check if the file contents match the defaults. If they do not, overwrite


    make use_dolomite mandatory

    if a user deletes use_dolomite from cfg, we shouldn't run training successfully

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
