### PR TITLE
add a check for download

### DIFF
--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -16,8 +16,16 @@ class TestLabDownload:
     # of your module, so you should use `my_module.Y`` to patch.
     # When using `import X`, you should use `X.Y` to patch.
     # https://docs.python.org/3/library/unittest.mock.html#where-to-patch?
+    @patch("instructlab.model.download.get_model_size_in_gb", return_value=5.00)
+    @patch("instructlab.model.download.get_available_space_in_gb", return_value=10.00)
     @patch("instructlab.model.download.hf_hub_download")
-    def test_download(self, mock_hf_hub_download, cli_runner: CliRunner):
+    def test_download(
+        self,
+        mock_hf_hub_download,
+        mock_available_space,
+        mock_model_size,
+        cli_runner: CliRunner,
+    ):
         result = cli_runner.invoke(
             lab.ilab,
             [
@@ -31,12 +39,18 @@ class TestLabDownload:
             result.exit_code == 0
         ), f"command finished with an unexpected exit code. {result.stdout}"
         assert mock_hf_hub_download.call_count == 3
+        assert mock_available_space.return_value == 10.00
+        assert mock_model_size.return_value == 5.00
 
+    @patch("instructlab.model.download.get_model_size_in_gb", return_value=5.00)
+    @patch("instructlab.model.download.get_available_space_in_gb", return_value=10.00)
     @patch(
         "instructlab.model.download.hf_hub_download",
         MagicMock(side_effect=HfHubHTTPError("Could not reach hugging face server")),
     )
-    def test_download_error(self, cli_runner: CliRunner):
+    def test_download_error(
+        self, mock_available_space, mock_model_size, cli_runner: CliRunner
+    ):
         result = cli_runner.invoke(
             lab.ilab,
             [
@@ -47,9 +61,19 @@ class TestLabDownload:
         )
         assert result.exit_code == 1, "command finished with an unexpected exit code"
         assert "Could not reach hugging face server" in result.output
+        mock_available_space.assert_called_once()
+        mock_model_size.assert_called_once()
 
+    @patch("instructlab.model.download.get_oci_image_size_in_gb", return_value=5.00)
+    @patch("instructlab.model.download.get_available_space_in_gb", return_value=10.00)
     @patch("instructlab.model.download.OCIDownloader.download")
-    def test_oci_download(self, mock_oci_download, cli_runner: CliRunner):
+    def test_oci_download(
+        self,
+        mock_oci_download,
+        mock_available_space,
+        mock_model_size,
+        cli_runner: CliRunner,
+    ):
         result = cli_runner.invoke(
             lab.ilab,
             [
@@ -62,6 +86,8 @@ class TestLabDownload:
         )
         assert result.exit_code == 0
         mock_oci_download.assert_called_once()
+        assert mock_available_space.return_value == 10.00
+        assert mock_model_size.return_value == 5.00
 
     def test_oci_download_repository_error(self, cli_runner: CliRunner):
         result = cli_runner.invoke(
@@ -78,3 +104,27 @@ class TestLabDownload:
             "\nInvalid repository supplied:\n    Please specify tag/version 'latest' via --release"
             in result.output
         )
+
+    @patch("instructlab.model.download.get_model_size_in_gb", return_value=15.00)
+    @patch("instructlab.model.download.get_available_space_in_gb", return_value=10.00)
+    def test_download_insufficient_space(
+        self,
+        mock_available_space,
+        mock_model_size,
+        cli_runner: CliRunner,
+    ):
+        result = cli_runner.invoke(
+            lab.ilab,
+            [
+                "--config=DEFAULT",
+                "model",
+                "download",
+                "--hf-token=foo",
+            ],
+        )
+        assert result.exit_code == 1, f"Unexpected exit code: {result.exit_code}"
+        assert "Model size to download:  15.00 GB" in result.output
+        assert "Available local storage: 10.00 GB" in result.output
+        assert "Insufficient space to download the model!" in result.output
+        assert mock_available_space.return_value == 10.00
+        assert mock_model_size.return_value == 15.00


### PR DESCRIPTION
- check the size(model and image) and local available storage before downloading

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

Background from [2370](https://github.com/instructlab/instructlab/issues/2370) and [2206](https://github.com/instructlab/instructlab/issues/2206), model is large, so hope it can check the size first before downloading, and make sure there is enough space to store it.
- huggingface using api to check [22](https://github.com/cztomsik/ava/issues/22), [1158](https://github.com/huggingface/huggingface_hub/issues/1158)
- OCI using `skopeo inspect --raw` to check

```
$ ilab model download --repository instructlab/merlinite-7b-pt --hf-token test-test
Downloading model from Hugging Face:
    Model: instructlab/merlinite-7b-pt@main
    Destination: /Users/xx/.cache/instructlab/models

Checking the model size and local storage...
    Model size to download:  13.49 GB
    Available local storage: 604.69 GB

test:
$ ilab model download --repository instructlab/merlinite-7b-pt --hf-token  test-test
Downloading model from Hugging Face:
    Model: instructlab/merlinite-7b-pt@main
    Destination: /Users/xx/.cache/instructlab/models

Checking the model size and local storage...
    Model size to download:  15.00 GB
    Available local storage: 10.00 GB

Downloading model failed with the following Hugging Face Hub error:
    Insufficient space to download the model!
    Required: 15.00 GB, Available: 10.00 GB.
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
