### PR TITLE
cloud-instance: Update nvidia-setup reference and readme

### DIFF
--- a/scripts/infra/README.md
+++ b/scripts/infra/README.md
@@ -67,6 +67,8 @@ scripts/infra/cloud-instance.sh ec2 launch
 # Clone instructlab onto the instance and setup the development environment
 scripts/infra/cloud-instance.sh ec2 setup-rh-devenv
 # Install nvidia drivers and reboot
+# Depending on the age of your image, you may want to `sudo dnf update`, reboot your instance
+# and remove any old kernel and kernel-core packages before continuing.
 scripts/infra/cloud-instance.sh ec2 install-rh-nvidia-drivers
 scripts/infra/cloud-instance.sh ec2 ssh sudo reboot
 # Install instructlab

--- a/scripts/infra/cloud-instance.sh
+++ b/scripts/infra/cloud-instance.sh
@@ -320,7 +320,7 @@ install_rh_nvidia_drivers() {
         wait_ssh_listen "$CLOUD_TYPE"
         "${BASH_SOURCE[0]}" "$CLOUD_TYPE" ssh -n "$INSTANCE_NAME" sudo dnf remove --oldinstallonly -y
     fi
-    "${BASH_SOURCE[0]}" "$CLOUD_TYPE" scp -n "$INSTANCE_NAME" nvidia-setup.sh
+    "${BASH_SOURCE[0]}" "$CLOUD_TYPE" scp -n "$INSTANCE_NAME" "${SCRIPT_DIR}"/nvidia-setup.sh
     "${BASH_SOURCE[0]}" "$CLOUD_TYPE" ssh -n "$INSTANCE_NAME" "sudo ./nvidia-setup.sh"
     echo "You may want to reboot even though the install is live (${BASH_SOURCE[0]} ${CLOUD_TYPE} ssh sudo reboot)"
 }
@@ -338,7 +338,6 @@ sync() {
     local branch
     branch="$(git symbolic-ref HEAD 2>/dev/null)"
     branch=${branch##refs/heads/}
-    SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
     if [ "$TEMP_COMMIT" = true ] && [ -n "$(git status --porcelain=v1 2>/dev/null)" ]; then
         trap 'git reset HEAD~' EXIT
         git add "${SCRIPT_DIR}"/../..
@@ -359,7 +358,6 @@ sync_library() {
     user_name="$(instance_user_name)"
     local user_home
     user_home="$(instance_user_home)"
-    SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
     local repo_dir
     repo_dir="${SCRIPT_DIR}/../../../${LIBRARY}"
 
@@ -536,6 +534,7 @@ Commands
 }
 
 if [[ "$1" == "ibm" || "$1" == "ec2" ]]; then
+    SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
     run_cmd "$@"
 else
     echo "Invalid cloud type: $1" >&2


### PR DESCRIPTION
The previous reference to nvidia-setup.sh only worked with cloud-instance.sh was run from the same directory.

The update to the readme was to handle cases when multiple kernels are installed or the devel package for the installed kernel is no longer available.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
