### PR TITLE
Fixup slack version sha

### DIFF
--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Post job results to Slack if the workflow failed
         if: failure() && steps.check_pr.outputs.is_pr == 'false'
         id: slack-report-failure
-        uses: slackapi/slack-github-action@e598089eaef53883a2d9b325e044899548518a03 # v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           token: ${{ secrets.SON_OF_JEEVES_TOKEN }}
           method: chat.postMessage
@@ -180,7 +180,7 @@ jobs:
       - name: Post job results to Slack if the workflow succeeded
         if: success() && steps.check_pr.outputs.is_pr == 'false'
         id: slack-report-success
-        uses: slackapi/slack-github-action@e598089eaef53883a2d9b325e044899548518a03 # v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           token: ${{ secrets.SON_OF_JEEVES_TOKEN }}
           method: chat.postMessage


### PR DESCRIPTION
For some reason, this commit https://github.com/instructlab/instructlab/pull/2657/files included the wrong sha.  The correct sha included in the other repos was: https://github.com/instructlab/sdg/pull/385/files

This fix has been tested against an instructlab slack branch and the results made it to slack here: https://instruct-lab.slack.com/archives/C07KGUPMSNB/p1732128870580879

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
