### PR TITLE
Disable Auto-Detection for HPU and HIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
 
    You can download this model with `ilab model download` command as well.
 
-4. The InstructLab CLI auto-detects your hardware and select the exact system profile that matches your machine. System profiles populate the `config.yaml` file with the proper parameter values based on your detected GPU types and available vRAM.
+4. The InstructLab CLI auto-detects your hardware and select the exact system profile that matches your machine. System profiles populate the `config.yaml` file with the proper parameter values based on your detected CPU/GPU types. This system is only applicable to Apple M-Series Chips, Nvidia GPUs, and Intel/AMD CPUs.
 
    *Example output of profile auto-detection*
 

--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -314,6 +314,19 @@ def walk_and_print_system_profiles(
     return cfg
 
 
+def is_hpu_available() -> bool:
+    # Third Party
+    import torch
+
+    # Check for HPU availability without errors
+    try:
+        hpu_available = hasattr(torch, "hpu") and torch.device("hpu") is not None
+        return hpu_available
+    # pylint: disable=broad-exception-caught
+    except Exception:
+        return False
+
+
 def get_gpu_or_cpu() -> tuple[str, bool, bool, int, int]:
     """
     get_gpu_or_cpu figures out what kind of hardware the user has and returns the name in the form of 'nvidia l4 x4' as well as if this is a CPU and if the user is on Linux
@@ -327,7 +340,11 @@ def get_gpu_or_cpu() -> tuple[str, bool, bool, int, int]:
     is_cpu = False
     is_linux = False
     # try nvidia
-    if torch.cuda.is_available() and torch.version.hip is None:
+    if (
+        torch.cuda.is_available()
+        and torch.version.hip is None
+        and not is_hpu_available()
+    ):
         click.echo("Detecting hardware...")
         gpus = torch.cuda.device_count()
         for i in range(gpus):
@@ -337,7 +354,7 @@ def get_gpu_or_cpu() -> tuple[str, bool, bool, int, int]:
             total_vram += properties.total_memory  # memory in B
 
     vram = int(floor(convert_bytes_to_proper_mag(total_vram)[0]))
-    if vram == 0:
+    if vram == 0 and torch.version.hip is None and not is_hpu_available():
         # if no vRAM, try to see if we are on a CPU
         chip_name, is_cpu, is_linux = get_chip_name()
         # ok, now we have a chip name. this means we can walk the supported profile names and see if they match

--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -315,6 +315,11 @@ def walk_and_print_system_profiles(
 
 
 def is_hpu_available() -> bool:
+    """
+    is_hpu_available checks if torch is built with HPU support
+    if torch has the hpu attribute or we can successfully create a torch.device for HPU, return true.
+    else, return false.
+    """
     # Third Party
     import torch
 

--- a/tests/test_lab_init.py
+++ b/tests/test_lab_init.py
@@ -16,6 +16,52 @@ from instructlab.configuration import DEFAULTS, read_config
 
 class TestLabInit:
     @patch(
+        "torch.cuda.is_available",
+        return_value=False,
+    )
+    @patch("instructlab.config.init.is_hpu_available", return_value=True)
+    def test_is_hpu_available_true(
+        self,
+        is_hpu_available_mock,  # pylint: disable=unused-argument
+        is_cuda_available_mock,  # pylint: disable=unused-argument
+        cli_runner: CliRunner,
+    ):
+        result = cli_runner.invoke(lab.ilab, ["config", "init", "--interactive"])
+        assert result.exit_code == 0, result.stdout
+
+    @patch(
+        "torch.cuda.is_available",
+        return_value=True,
+    )
+    @patch("instructlab.config.init.is_hpu_available", return_value=False)
+    def test_is_hpu_available_false(
+        self,
+        is_hpu_available_mock,  # pylint: disable=unused-argument
+        is_cuda_available_mock,  # pylint: disable=unused-argument
+        cli_runner: CliRunner,
+    ):
+        result = cli_runner.invoke(lab.ilab, ["config", "init", "--interactive"])
+        assert result.exit_code == 0, result.stdout
+
+    @patch("instructlab.config.init.is_hpu_available", return_value=False)
+    @patch(
+        "torch.cuda.is_available",
+        return_value=True,
+    )
+    @patch(
+        "torch.version.hip",
+        "6.2.41134",
+    )
+    def test_hip_and_cuda_active(
+        self,
+        is_cuda_available_mock,  # pylint: disable=unused-argument
+        is_hpu_available_mock,  # pylint: disable=unused-argument
+        cli_runner: CliRunner,
+    ):
+        result = cli_runner.invoke(lab.ilab, ["config", "init", "--interactive"])
+        assert result.exit_code == 0, result.stdout
+
+    @patch(
         "instructlab.config.init.get_gpu_or_cpu",
         return_value=("nvidia a100 x2", False, True, 0, 0),
     )


### PR DESCRIPTION
AMD and Intel GPUs are still triggering auto-detection because `get_chip_name` seems to be properly returning the AMD GPU names.

disable these checks for hip and hpu

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
