### PR TITLE
Add skills only training strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.22
+
+### Breaking Changes
+
+### Features
+
+* `ilab train --pipeline=accelerated --strategy=lab-skills-only` supports training with only the skills phase (leaving out knowledge).
+
 ## v0.21
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -724,7 +724,8 @@ After running `ilab model train`, the output locations depend on the chosen pipe
 | `simple`                           | MacOS                | Model saved in `<model_name>-mlx-q` directory.                                                                           |
 | `full`                             | Linux & MacOS        | `.bin` and `.gguf` models saved in `~/.local/share/instructlab/checkpoints/hf_format` directory. Two models in each `sample_*` directory: one quantized (`Q4-M-K` suffix) and one full precision. |
 | `accelerated`                      | Linux                | Models saved in `~/.local/share/instructlab/checkpoints`. Can be evaluated with `ilab model evaluate` to choose the best one. |
-| `lab-multiphase`                   | Linux                | Phase 1 models saved in `~/.local/share/instructlab/phased/phase1/checkpoints` (Knowledge training). Phase 2 models saved in `~/.local/share/instructlab/phased/phase2/checkpoints` (Skills training). Evaluation is run for both phases to identify the best checkpoint. |
+| `lab-multiphase`                   | Linux                | Phase 1 models saved in `~/.local/share/instructlab/phased/phase1/checkpoints` (Knowledge training). Phase 2 models saved in `~/.local/share/instructlab/phased/phase2/checkpoints` (Skills training). Evaluation is run for phase 2 to identify the best checkpoint. |
+| `lab-skills-only`                  | Linux                | Phase 2 models saved in `~/.local/share/instructlab/phased/phase2/checkpoints` (Skills training). Evaluation is run for phase 2 to identify the best checkpoint. |
 
 To limit training time, you can adjust the `num_epoch` paramater in the `config.yaml` file. The maximum number of epochs for running the InstructLab end-to-end workkflow is 10.
 

--- a/scripts/e2e-ci.sh
+++ b/scripts/e2e-ci.sh
@@ -215,7 +215,6 @@ test_train() {
 test_phased_train() {
     task Train the model with LAB multi-phase training
 
-    # 'Declare and assign separately to avoid masking return values' <-- error.
     local knowledge_data_path
     local skills_data_path
     knowledge_data_path=$(find "${DATA_HOME}"/instructlab/datasets -name 'knowledge_train_msgs*' | head -n 1)
@@ -238,10 +237,42 @@ test_phased_train() {
     task Multi-phase training Complete
 }
 
+test_skills_only_train() {
+    task Train the model with LAB skills-only training
+
+    local skills_data_path
+    skills_data_path=$(find "${DATA_HOME}"/instructlab/datasets -name 'skills_train_msgs*' | head -n 1)
+
+    local skills_phased_base_dir
+    skills_phased_base_dir="${DATA_HOME}/instructlab/skills-only"
+    
+    mkdir -p "${skills_phased_base_dir}"
+
+    # general skills-only training args
+    local train_args
+    train_args+=(
+        "--strategy=lab-skills-only"
+        "--phased-phase2-data=${skills_data_path}"
+        "--phased-phase2-num-epochs=1"
+        "--skip-user-confirm"
+        "--phased-base-dir=${skills_phased_base_dir}"
+    )
+
+    export HF_DATASETS_TRUST_REMOTE_CODE=true
+    ilab model train "${train_args[@]}" 2>&1 | tee "${E2E_TEST_DIR}"/skills_only_training.log
+
+    # final best model is written to log
+    grep "Training finished! Best final checkpoint: " "${E2E_TEST_DIR}"/skills_only_training.log | grep -o "/[^ ]*"
+
+    # cleanup the skills phased base dir
+    rm -rf "${skills_phased_base_dir}"
+
+    task Skills-only training Complete
+}
+
 test_phased_train_resume() {
     task Train the model with LAB multi-phase training resume
 
-    # 'Declare and assign separately to avoid masking return values' <-- error.
     local knowledge_data_path
     local skills_data_path
     knowledge_data_path=$(find "${DATA_HOME}"/instructlab/datasets -name 'knowledge_train_msgs*' | head -n 1)
@@ -350,6 +381,8 @@ test_exec() {
     if [ "$LARGE" -eq 1 ]; then
       # Validate a single epoch per phase with resumption
       test_phased_train_resume
+      # Validate skills-only training
+      test_skills_only_train
       # Validate the phased training happy path
       test_phased_train
     else

--- a/src/instructlab/cli/model/train.py
+++ b/src/instructlab/cli/model/train.py
@@ -2,7 +2,6 @@
 
 # Standard
 from pathlib import Path
-import enum
 import logging
 import os
 import pathlib
@@ -14,16 +13,11 @@ import click
 # First Party
 from instructlab import clickext
 from instructlab.configuration import DEFAULTS, map_train_to_library
+from instructlab.model.accelerated_train import SupportedTrainingStrategies
 
 logger = logging.getLogger(__name__)
 
 ADDITIONAL_ARGUMENTS = "additional_args"
-
-
-class SupportedTrainingStrategies(enum.Enum):
-    """Available advanced training strategies"""
-
-    LAB_MULTIPHASE: str = "lab-multiphase"
 
 
 def clickpath_setup(is_dir: bool) -> click.Path:
@@ -285,7 +279,11 @@ def clickpath_setup(is_dir: bool) -> click.Path:
 @click.option(
     "--strategy",
     type=click.Choice(
-        [SupportedTrainingStrategies.LAB_MULTIPHASE.value], case_sensitive=False
+        [
+            SupportedTrainingStrategies.LAB_MULTIPHASE.value,
+            SupportedTrainingStrategies.LAB_SKILLS_ONLY.value,
+        ],
+        case_sensitive=False,
     ),
     show_default=True,
     help="If chosen, will run the selected training strategy instead of a single training run.",
@@ -416,11 +414,12 @@ def train(
     Takes synthetic data generated locally with `ilab data generate` and the previous model and learns a new model using the MLX API.
     On success, writes newly learned model to {model_dir}/mlx_model, which is where `chatmlx` will look for a model.
     """
-    if (
-        pipeline in ("full", "simple")
-        and strategy == SupportedTrainingStrategies.LAB_MULTIPHASE.value
+    if pipeline in ("full", "simple") and SupportedTrainingStrategies.has_strategy(
+        strategy
     ):
-        ctx.fail("Multi Phase training is only supported with `--pipeline accelerated`")
+        ctx.fail(
+            "Multi Phase and Skills Only training is only supported with `--pipeline accelerated`"
+        )
 
     # TODO: cdoern, remove this flag
     if not input_dir:
@@ -432,7 +431,7 @@ def train(
 
     if (
         pipeline in ("full", "accelerated")
-    ) and strategy != SupportedTrainingStrategies.LAB_MULTIPHASE.value:
+    ) and not SupportedTrainingStrategies.has_strategy(strategy):
         if not os.path.isfile(data_path):
             ctx.fail(
                 f"Data path must be to a valid .jsonl file. Value given: {data_path}"

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -493,7 +493,7 @@ class _train(BaseModel):
         description="Additional arguments to pass to the training script. These arguments are passed as key-value pairs to the training script.",
     )
     # additional training configuration for
-    # lab-multiphase training.
+    # lab-multiphase and skills-only training as applicable.
     # TODO: could move into its own object.
     # Not strictly necessary for a correct training object.
     phased_phase1_num_epochs: int | None = Field(

--- a/src/instructlab/model/accelerated_train.py
+++ b/src/instructlab/model/accelerated_train.py
@@ -33,6 +33,11 @@ class SupportedTrainingStrategies(enum.Enum):
     """Available advanced training strategies"""
 
     LAB_MULTIPHASE: str = "lab-multiphase"
+    LAB_SKILLS_ONLY: str = "lab-skills-only"
+
+    @classmethod
+    def has_strategy(cls, value):
+        return value in cls._value2member_map_
 
 
 def accelerated_train(
@@ -60,7 +65,7 @@ def accelerated_train(
     # run_training is a dynamic attribute, pylint is not clever enough
     # to detect it.
     # Third Party
-    if strategy == SupportedTrainingStrategies.LAB_MULTIPHASE.value:
+    if SupportedTrainingStrategies.has_strategy(strategy):
         if (
             distributed_backend
             and distributed_backend not in DistributedBackend._value2member_map_
@@ -77,17 +82,29 @@ def accelerated_train(
             pprint.pformat(train_args),
         )
 
-        if not (phased_phase1_data and phased_phase2_data):
-            # pylint: disable=broad-exception-raised
-            raise Exception(
-                "End-to-end training minimally requires: `--phased-phase1-data`, and `--phased-phase2-data`. One or more wasn't correctly specified."
-            )
+        if strategy == SupportedTrainingStrategies.LAB_MULTIPHASE.value:
+            if not (phased_phase1_data and phased_phase2_data):
+                # pylint: disable=broad-exception-raised
+                raise Exception(
+                    f"{SupportedTrainingStrategies.LAB_MULTIPHASE} training minimally requires: `--phased-phase1-data`, and `--phased-phase2-data`. One or more wasn't correctly specified."
+                )
 
-        # if they both exist, must be Path objects
-        if not (phased_phase1_data.exists() and phased_phase2_data.exists()):
-            raise FileNotFoundError(
-                "Data for both phase1 and phase2 must be specified for phased training."
-            )
+            # if they both exist, must be Path objects
+            if not (phased_phase1_data.exists() and phased_phase2_data.exists()):
+                raise FileNotFoundError(
+                    "Data for both phase1 and phase2 must be specified for phased training."
+                )
+        else:  # strategy == SupportedTrainingStrategies.LAB_SKILLS_ONLY.value
+            if not phased_phase2_data:
+                # pylint: disable=broad-exception-raised
+                raise Exception(
+                    f"{SupportedTrainingStrategies.LAB_SKILLS_ONLY} training minimally requires: `--phased-phase2-data`"
+                )
+
+            if not phased_phase2_data.exists():
+                raise FileNotFoundError(
+                    "Data for phase2 must be specified for {SupportedTrainingStrategies.LAB_SKILLS_ONLY} training."
+                )
 
         mt_bench_judge: pathlib.Path
         if phased_mt_bench_judge is None:
@@ -112,12 +129,13 @@ def accelerated_train(
         journal = TrainingJournal(journalfile=training_journal)
         click.secho("\n\n~~~~~~~~~~~~~STARTING MULTI-PHASE TRAINING~~~~~~~~~~~~~")
 
-        # experimental preference.
-        if phased_phase1_num_epochs != 7:
-            click.secho(
-                f"Running phased training with '{phased_phase1_num_epochs}' epochs.\nNote: 7 epochs is the recommended amount for optimal performance.",
-                fg="yellow",
-            )
+        if strategy == SupportedTrainingStrategies.LAB_MULTIPHASE.value:
+            # experimental preference.
+            if phased_phase1_num_epochs != 7:
+                click.secho(
+                    f"Running phased training with '{phased_phase1_num_epochs}' epochs.\nNote: 7 epochs is the recommended amount for optimal performance.",
+                    fg="yellow",
+                )
 
         if journal.was_loaded:
             click.secho(
@@ -136,6 +154,9 @@ def accelerated_train(
                 bg="yellow",
                 fg="black",
             )
+            # Start at phase 2 for skills only training
+            if strategy == SupportedTrainingStrategies.LAB_SKILLS_ONLY.value:
+                journal.journal.current_phase = TrainingPhases.TRAIN2
             journal.commit(create_new=True)
 
         user_clear_cache: bool = False
@@ -187,6 +208,7 @@ def accelerated_train(
             journal=journal,
             eval_serve=eval_serve,
             eval_gpus=eval_gpus,
+            strategy=strategy,
         )
     else:
         # Third Party
@@ -249,11 +271,15 @@ def _run_phase(
         raise click.exceptions.Exit(1) from exception
 
 
+def _get_checkpoints(phase_checkpoints_dir):
+    return list(phase_checkpoints_dir.iterdir())
+
+
 def _run_phased_training(
     train_args: TrainingArgs,
     torch_args: TorchrunArgs,
     base_dir: pathlib.Path,
-    phase1_data: pathlib.Path,
+    phase1_data: pathlib.Path | None,
     phase1_num_epochs: int | None,
     phase1_samples_per_save: int | None,
     phase1_checkpoints_dir: pathlib.Path,
@@ -263,6 +289,7 @@ def _run_phased_training(
     phase2_samples_per_save: int | None,
     phase2_checkpoints_dir: pathlib.Path,
     phased_phase2_effective_batch_size: int | None,
+    strategy: str | None,
     phase2_eval_cache: pathlib.Path,
     mtbench_judge: pathlib.Path,
     enable_serving_output: bool,
@@ -282,6 +309,12 @@ def _run_phased_training(
 
     if journal.current_phase == TrainingPhases.TRAIN1:
         click.secho("Training Phase 1/2...", fg="cyan")
+
+        if phase1_data is None:
+            # pylint: disable=broad-exception-raised
+            raise Exception(
+                f"Phase 1 data is required for phase '{TrainingPhases.TRAIN1}'"
+            )
 
         phase_model = journal.journal.train_1
         if phase_model is None:
@@ -316,7 +349,7 @@ def _run_phased_training(
     # if phase_model is None:
     #     # if it's not None, it already exists and may have 'results', so we shouldn't overwrite it.
     #     phase_model = EvalPhaseModel(
-    #         checkpoints=list(phase1_checkpoints_dir.iterdir())
+    #         checkpoints=_get_checkpoints(phase1_checkpoints_dir)
     #     )
     #     journal.journal.eval_1 = phase_model
     # journal.commit()
@@ -350,29 +383,31 @@ def _run_phased_training(
         #         "Training journal field 'eval_1' cannot be None for phase 'train_2'"
         #     )
 
-        # NOTE:
-        # this is a recent change, implemented to ignore MMLU. We just look at the checkpoints
-        # from the phase 1 training and take the most recent one.
-        phase1_checkpoints_dir_hf = phase1_checkpoints_dir / "hf_format"
-        if not phase1_checkpoints_dir_hf.exists():
-            raise FileNotFoundError(
-                f"{phase1_checkpoints_dir_hf} doesn't exist. This likely means that no checkpoints were saved from phase 1."
+        next_checkpoint = None
+        if strategy == SupportedTrainingStrategies.LAB_MULTIPHASE.value:
+            # NOTE:
+            # this is a recent change, implemented to ignore MMLU. We just look at the checkpoints
+            # from the phase 1 training and take the most recent one.
+            phase1_checkpoints_dir_hf = phase1_checkpoints_dir / "hf_format"
+            if not phase1_checkpoints_dir_hf.exists():
+                raise FileNotFoundError(
+                    f"{phase1_checkpoints_dir_hf} doesn't exist. This likely means that no checkpoints were saved from phase 1."
+                )
+
+            phase1_checkpoints = sorted(
+                _get_checkpoints(phase1_checkpoints_dir_hf),
+                reverse=True,
+                # XXX(osilkin): This line takes the checkpoint name "samples_NNN" and tells sorted
+                #               to use the last NNN string as an integer
+                key=lambda x: int(str(x).rsplit("_", maxsplit=1)[-1]),
             )
 
-        phase1_checkpoints = sorted(
-            list(phase1_checkpoints_dir_hf.iterdir()),
-            reverse=True,
-            # XXX(osilkin): This line takes the checkpoint name "samples_NNN" and tells sorted
-            #               to use the last NNN string as an integer
-            key=lambda x: int(str(x).rsplit("_", maxsplit=1)[-1]),
-        )
+            if len(phase1_checkpoints) == 0:
+                raise FileNotFoundError(
+                    f"{phase1_checkpoints_dir_hf} Has no checkpoints. This likely means that no checkpoints were saved from phase 1."
+                )
 
-        if len(phase1_checkpoints) == 0:
-            raise FileNotFoundError(
-                f"{phase1_checkpoints_dir_hf} Has no checkpoints. This likely means that no checkpoints were saved from phase 1."
-            )
-
-        next_checkpoint = phase1_checkpoints[0]
+            next_checkpoint = phase1_checkpoints[0]
         _run_phase(
             train_args=train_args,
             torch_args=torch_args,
@@ -399,7 +434,7 @@ def _run_phased_training(
         if phase_model is None:
             # if it's not None, it already exists and may have 'results', so we shouldn't overwrite it.
             phase_model = EvalPhaseModel(
-                checkpoints=list(phase2_checkpoints_dir.iterdir())
+                checkpoints=_get_checkpoints(phase2_checkpoints_dir)
             )
             journal.journal.eval_2 = phase_model
         journal.commit()


### PR DESCRIPTION
This new strategy only runs the skills phase and corresponding eval of skills with mt_bench (skipping knowledge).  It is useful to bypass phase 1 of multiphase training if you don't have any knowledge to train the model with.


**Checklist:**
- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [*] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [*] Documentation has been updated, if necessary.
- [*] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [*] E2E Workflow tests have been added, if necessary.
