### PR TITLE
Fix docs linting after PROMOPTING-FAQ.md

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Welcome to InstructLab's documentation!
    README.md
    release-strategy.md
    instructlab_models.md
+   PROMPTING-FAQ.md
 
 
 Indices and tables


### PR DESCRIPTION
https://github.com/instructlab/instructlab/pull/2703

Created the issue:

```/home/runner/work/instructlab/instructlab/docs/PROMPTING-FAQ.md: WARNING: document isn't included in any toctree```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
