### PR TITLE
feat: Implement Process Management, `ilab data generate -dt`, `ilab process list`, `ilab process attach`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ issues = "https://github.com/instructlab/instructlab/issues"
 
 [project.entry-points."instructlab.command.process"]
 "list" = "instructlab.cli.process.list:list"
+"attach" = "instructlab.cli.process.attach:attach"
 
 [project.entry-points."instructlab.command.config"]
 "edit" = "instructlab.config.edit:edit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,15 @@ issues = "https://github.com/instructlab/instructlab/issues"
 
 # command entry points
 [project.entry-points."instructlab.command"]
+"process" = "instructlab.cli.process.process:process"
 "config" = "instructlab.config.config:config"
 "data" = "instructlab.cli.data.data:data"
 "model" = "instructlab.model.model:model"
 "system" = "instructlab.cli.system.system:system"
 "taxonomy" = "instructlab.taxonomy.taxonomy:taxonomy"
+
+[project.entry-points."instructlab.command.process"]
+"list" = "instructlab.cli.process.list:list"
 
 [project.entry-points."instructlab.command.config"]
 "edit" = "instructlab.config.edit:edit"
@@ -100,6 +104,8 @@ include = [
   "instructlab.cli",
   "instructlab.cli.model",
   "instructlab.model",
+  "instructlab.cli.process",
+  "instructlab.process",
   "instructlab.train",
   "instructlab.train.lora_mlx",
   "instructlab.train.lora_mlx.models",

--- a/scripts/e2e-ci.sh
+++ b/scripts/e2e-ci.sh
@@ -210,8 +210,14 @@ test_taxonomy() {
 }
 
 test_generate() {
-    task Generate synthetic data
-    ilab data generate
+    task Generate synthetic data in detached mode
+    ilab data generate -dt
+    task Data generation started
+    task List all processes
+    ilab process list
+    task Listing processes Complete
+    task Attach to the most recent process
+    ilab process attach --latest
     task Synthetic data generation Complete
 }
 

--- a/src/instructlab/cli/data/generate.py
+++ b/src/instructlab/cli/data/generate.py
@@ -293,7 +293,8 @@ def generate(
             legacy_pretraining_format,
             process_mode=process_mode,
         )
-        click.echo("ᕦ(òᴗóˇ)ᕤ Data generate completed successfully! ᕦ(òᴗóˇ)ᕤ")
+        if not detached:
+            click.echo("ᕦ(òᴗóˇ)ᕤ Data generate completed successfully! ᕦ(òᴗóˇ)ᕤ")
     except Exception as exc:
         click.secho(f"failed to generate data with exception: {exc}", fg="red")
         raise click.exceptions.Exit(1)

--- a/src/instructlab/cli/data/generate.py
+++ b/src/instructlab/cli/data/generate.py
@@ -15,6 +15,7 @@ from instructlab import clickext
 from instructlab.client_utils import HttpClientParams
 from instructlab.configuration import DEFAULTS
 from instructlab.data.generate_data import gen_data  # type: ignore
+from instructlab.defaults import ILAB_PROCESS_MODES
 from instructlab.utils import (
     contains_argument,
     get_model_arch,
@@ -160,6 +161,9 @@ logger = logging.getLogger(__name__)
     type=click.IntRange(min=512),
     cls=clickext.ConfigOption,
 )
+@click.option(
+    "-dt", "--detached", is_flag=True, help="Run ilab data generate in the background"
+)
 @click.pass_context
 @clickext.display_params
 def generate(
@@ -187,6 +191,7 @@ def generate(
     batch_size,
     gpus,
     max_num_tokens,
+    detached,
 ):
     """Generates synthetic data to enhance your example data"""
 
@@ -257,6 +262,10 @@ def generate(
             student_model_path, student_model_arch
         )
 
+    process_mode = ILAB_PROCESS_MODES.ATTACHED
+    if detached:
+        process_mode = ILAB_PROCESS_MODES.DETACHED
+
     try:
         gen_data(
             serve_cfg,
@@ -282,6 +291,7 @@ def generate(
             max_num_tokens,
             system_prompt,
             legacy_pretraining_format,
+            process_mode=process_mode,
         )
         click.echo("ᕦ(òᴗóˇ)ᕤ Data generate completed successfully! ᕦ(òᴗóˇ)ᕤ")
     except Exception as exc:

--- a/src/instructlab/cli/data/generate.py
+++ b/src/instructlab/cli/data/generate.py
@@ -292,6 +292,7 @@ def generate(
             system_prompt,
             legacy_pretraining_format,
             process_mode=process_mode,
+            log_level=ctx.obj.config.general.log_level,
         )
         if not detached:
             click.echo("ᕦ(òᴗóˇ)ᕤ Data generate completed successfully! ᕦ(òᴗóˇ)ᕤ")

--- a/src/instructlab/cli/process/attach.py
+++ b/src/instructlab/cli/process/attach.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Third Party
+import click
+
+# First Party
+from instructlab import clickext
+from instructlab.process.process import attach_process, get_latest_process
+
+
+@click.command(name="attach")
+@clickext.display_params
+@click.option("--uuid", type=click.STRING, help="UUID of the process to attach to")
+@click.option("--latest", is_flag=True, help="Attach to the latest process")
+def attach(uuid, latest):
+    if latest:
+        uuid = get_latest_process()
+        if uuid is None:
+            click.secho(
+                "No processes found in registry",
+                fg="red",
+            )
+            raise click.exceptions.Exit(1)
+    attach_process(local_uuid=uuid)

--- a/src/instructlab/cli/process/list.py
+++ b/src/instructlab/cli/process/list.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Third Party
+import click
+
+# First Party
+from instructlab import clickext
+from instructlab.process.process import list_processes
+from instructlab.utils import print_table
+
+
+@click.command(name="list")
+@clickext.display_params
+def list():
+    process_list = list_processes()
+    if process_list is not None and len(process_list) > 0:
+        print_table(["Type", "PID", "UUID", "Log File", "Runtime"], process_list)
+    else:
+        click.secho(
+            "No processes found in registry",
+            fg="red",
+        )
+        raise click.exceptions.Exit(0)

--- a/src/instructlab/cli/process/process.py
+++ b/src/instructlab/cli/process/process.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+
+# Third Party
+import click
+
+# First Party
+from instructlab import clickext
+from instructlab.configuration import storage_dirs_exist
+
+
+@click.group(
+    cls=clickext.LazyEntryPointGroup,
+    ep_group="instructlab.command.process",
+)
+@click.pass_context
+def process(ctx):
+    """Command Group for Interacting with the Processes run by InstructLab.
+
+    If this is your first time running ilab, it's best to start with `ilab config init` to create the environment.
+    """
+    ctx.obj = ctx.parent.obj
+    ctx.obj.ensure_config(ctx)
+    if not storage_dirs_exist():
+        click.secho(
+            "Some ilab storage directories do not exist yet. Please run `ilab config init` before continuing.",
+            fg="red",
+        )
+        raise click.exceptions.Exit(1)
+    ctx.default_map = ctx.parent.default_map

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1209,6 +1209,7 @@ def ensure_storage_directories_exist() -> bool:
         DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_DIR,
         DEFAULTS.PHASED_DIR,
         DEFAULTS.SYSTEM_PROFILE_DIR,
+        DEFAULTS.LOGS_DIR,
     ]
 
     for dirpath in dirs_to_make:
@@ -1492,5 +1493,6 @@ def storage_dirs_exist() -> bool:
         DEFAULTS.TRAIN_ADDITIONAL_OPTIONS_DIR,
         DEFAULTS.PHASED_DIR,
         DEFAULTS.SYSTEM_PROFILE_DIR,
+        DEFAULTS.LOGS_DIR,
     ]
     return all(os.path.exists(dirpath) for dirpath in dirs_to_check)

--- a/src/instructlab/data/generate_data.py
+++ b/src/instructlab/data/generate_data.py
@@ -126,7 +126,6 @@ def create_server_and_generate(
 
     # First Party
     from instructlab.client_utils import http_client
-
     http_client_params = HttpClientParams(
         {
             "tls_client_cert": tls_client_cert,
@@ -142,7 +141,6 @@ def create_server_and_generate(
         # First Party
         from instructlab.model.backends import backends
         from instructlab.model.backends.llama_cpp import Server as llama_cpp_server
-
         backend_instance = backends.select_backend(cfg=serve_cfg, model_path=model_name)
         if (
             backend_instance.get_backend_type() is not backends.VLLM

--- a/src/instructlab/data/generate_data.py
+++ b/src/instructlab/data/generate_data.py
@@ -127,7 +127,6 @@ def create_server_and_generate(
     # First Party
     from instructlab.client_utils import http_client
 
-    print(tls_client_cert, tls_client_key, tls_client_passwd, tls_insecure)
     http_client_params = HttpClientParams(
         {
             "tls_client_cert": tls_client_cert,

--- a/src/instructlab/data/generate_data.py
+++ b/src/instructlab/data/generate_data.py
@@ -39,14 +39,18 @@ def gen_data(
     from instructlab.defaults import ILAB_PROCESS_TYPES
     from instructlab.process.process import add_process
 
-    print(http_client_params)
-
     add_process(
         process_mode=process_mode,
         process_type=ILAB_PROCESS_TYPES.DATA_GENERATION,
         target=create_server_and_generate,
         extra_imports=[
-            ("instructlab.configuration", "_serve", "_serve_vllm", "_serve_llama_cpp")
+            (
+                "instructlab.configuration",
+                "_serve",
+                "_serve_vllm",
+                "_serve_llama_cpp",
+                "_serve_server",
+            )
         ],
         serve_cfg=serve_cfg,
         model_name=model_path,
@@ -121,7 +125,7 @@ def create_server_and_generate(
     import openai
 
     # First Party
-    from instructlab.client_utils import HttpClientParams, http_client
+    from instructlab.client_utils import http_client
 
     print(tls_client_cert, tls_client_key, tls_client_passwd, tls_insecure)
     http_client_params = HttpClientParams(
@@ -133,10 +137,6 @@ def create_server_and_generate(
         }
     )
 
-    print(http_client_params)
-
-    # logger.info("testing")
-    # logger.debug("testing2")
     if endpoint_url:
         api_base = endpoint_url
     else:

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -30,6 +30,17 @@ LOG_FORMAT = "%(levelname)s %(asctime)s %(name)s:%(lineno)d: %(message)s"
 RECOMMENDED_SCOPEO_VERSION = "1.9.0"
 
 
+class ILAB_PROCESS_MODES:
+    DETACHED: str = "detached"
+    ATTACHED: str = "attached"
+
+
+class ILAB_PROCESS_TYPES:
+    DATA_GENERATION: str = "Generation"
+
+    TRAINING: str = "Training"
+
+
 class STORAGE_DIR_NAMES:
     ILAB = "instructlab"
     DATASETS = "datasets"
@@ -42,6 +53,7 @@ class STORAGE_DIR_NAMES:
     )
     CHATLOGS = "chatlogs"
     PHASED = "phased"
+    LOGS = "logs"
 
 
 class _InstructlabDefaults:
@@ -112,6 +124,10 @@ class _InstructlabDefaults:
         self._cache_home = path.join(xdg_cache_home(), ILAB_PACKAGE_NAME)
         self._config_dir = path.join(xdg_config_home(), ILAB_PACKAGE_NAME)
         self._data_dir = path.join(xdg_data_home(), ILAB_PACKAGE_NAME)
+
+    @property
+    def LOGS_DIR(self) -> str:
+        return path.join(self._data_dir, STORAGE_DIR_NAMES.LOGS)
 
     @property
     def CHECKPOINTS_DIR(self) -> str:
@@ -232,6 +248,14 @@ class _InstructlabDefaults:
     @property
     def TRAIN_L4_X8_PROFILE(self) -> str:
         return path.join(self.TRAIN_PROFILE_DIR, "L4_x8.yaml")
+
+    @property
+    def PROCESS_REGISTRY_FILE(self) -> str:
+        return path.join(self.INTERNAL_DIR, "process_registry.json")
+
+    @property
+    def PROCESS_REGISTRY_LOCK_FILE(self) -> str:
+        return path.join(self.INTERNAL_DIR, "process_registry.json.lock")
 
 
 DEFAULTS = _InstructlabDefaults()

--- a/src/instructlab/process/process.py
+++ b/src/instructlab/process/process.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from datetime import datetime
+from typing import Callable
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+import uuid
+
+# Third Party
+from filelock import FileLock
+import psutil
+
+# First Party
+from instructlab.configuration import DEFAULTS
+from instructlab.defaults import ILAB_PROCESS_MODES, ILAB_PROCESS_TYPES
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessRegistry:
+    def __init__(self):
+        self.processes = {}
+
+    def add_process(self, local_uuid, pid, children_pids, type, log_file, start_time):
+        self.processes[str(local_uuid)] = {
+            "pid": pid,
+            "children_pids": children_pids,
+            "type": type,
+            "log_file": log_file,
+            "start_time": datetime.strptime(
+                start_time, "%Y-%m-%d %H:%M:%S"
+            ).isoformat(),
+        }
+
+    def load_entry(self, key, value):
+        self.processes[key] = value
+
+
+def load_registry() -> ProcessRegistry:
+    process_registry = ProcessRegistry()
+    lock_path = DEFAULTS.PROCESS_REGISTRY_LOCK_FILE
+    lock = FileLock(lock_path, timeout=1)
+    """Load the process registry from a file, if it exists."""
+    # we do not want a persistent registry in memory. This causes issues when in scenarios where you switch registry files (ex, in a unit test, or with multiple users)
+    # but the registry with incorrect processes still exists in memory.
+    with lock:
+        if os.path.exists(DEFAULTS.PROCESS_REGISTRY_FILE):
+            with open(DEFAULTS.PROCESS_REGISTRY_FILE, "r") as f:
+                data = json.load(f)
+                for key, value in data.items():
+                    process_registry.load_entry(key=key, value=value)
+        else:
+            logger.debug("No existing process registry found. Starting fresh.")
+    return process_registry
+
+
+def save_registry(process_registry):
+    """Save the current process registry to a file."""
+    lock_path = DEFAULTS.PROCESS_REGISTRY_LOCK_FILE
+    lock = FileLock(lock_path, timeout=1)
+    with lock, open(DEFAULTS.PROCESS_REGISTRY_FILE, "w") as f:
+        json.dump(dict(process_registry.processes), f)
+
+
+class Tee:
+    def __init__(self, log_file):
+        """
+        Initialize a Tee object.
+
+        Args:
+            log_file (str): Path to the log file where the output should be written.
+        """
+        self.log_file = log_file
+        self.terminal = sys.stdout
+        self.log = log_file  # Line-buffered
+
+    def write(self, message):
+        """
+        Write the message to both the terminal and the log file.
+
+        Args:
+            message (str): The message to write.
+        """
+        self.terminal.write(message)
+        self.log.write(message)
+
+    def flush(self):
+        """
+        Ensure all data is written to the terminal and the log file.
+        """
+        self.terminal.flush()
+        self.log.flush()
+
+    def close(self):
+        """
+        Close the log file.
+        """
+        if self.log:
+            self.log.close()
+
+
+def format_command(
+    target: Callable, extra_imports: list[tuple[str, ...]], **kwargs
+) -> str:
+    """
+    Formats a command given the target and any extra python imports to add
+
+    Args:
+        target: Callable
+        extra_imports: list[tuple[str, ...]]
+    Returns:
+        cmd: str
+    """
+    # Prepare the subprocess command string
+    cmd = (
+        f"import {target.__module__}; {target.__module__}.{target.__name__}(**{kwargs})"
+    )
+
+    # Handle extra imports (if any)
+    if extra_imports:
+        import_statements = "\n".join(
+            [f"from {imp[0]} import {', '.join(imp[1:])}" for imp in extra_imports]
+        )
+        cmd = f"{import_statements}\n{cmd}"
+    return cmd
+
+
+def start_process(cmd: str, log) -> tuple[int | None, list[int] | None]:
+    """
+    Starts a subprocess and captures PID and Children PIDs
+
+    Args:
+        cmd: str
+        log: _FILE
+
+    Returns:
+        pid: int
+        children_pids: list[int]
+    """
+    children_pids = []
+    p = subprocess.Popen(
+        ["python", "-c", cmd],
+        universal_newlines=True,
+        text=True,
+        stdout=log,
+        stderr=log,
+        start_new_session=True,
+        encoding="utf-8",
+        bufsize=1,  # Line-buffered for real-time output
+    )
+    time.sleep(1)
+    # we need to get all of the children processes spawned
+    # to be safe, we will need to try and kill all of the ones which still exist when the user wants us to
+    # however, representing this to the user is difficult. So let's track the parent pid and associate the children with it in the registry
+    max_retries = 5
+    retry_interval = 0.5  # seconds
+    parent = psutil.Process(p.pid)
+    for _ in range(max_retries):
+        children = parent.children(recursive=True)
+        if children:
+            for child in children:
+                children_pids.append(child.pid)
+            break
+        time.sleep(retry_interval)
+    else:
+        logger.debug("No child processes detected. Tracking parent process.")
+    # Check if subprocess was successfully started
+    if p.poll() is not None:
+        logger.warning(f"Process {p.pid} failed to start.")
+        return None, None  # Process didn't start
+    return p.pid, children_pids
+
+
+def add_process(
+    process_mode: str,
+    process_type: ILAB_PROCESS_TYPES,
+    target: Callable,
+    extra_imports: list[tuple[str, ...]],
+    **kwargs,
+):
+    """
+    Start a detached process using subprocess.Popen, logging its output.
+
+    Args:
+        process_mode (str): Mode we are running in, Detached or Attached.
+        process_type (str): Type of process, ex: Generation.
+        target (func): The target function to kick off in the subprocess or to run in the foreground.
+        extra_imports (list[tuple(str...)]): a list of the extra imports to splice into the python subprocess command.
+
+    Returns:
+        None
+    """
+    process_registry = load_registry()
+    if target is None:
+        return None, None
+
+    local_uuid = uuid.uuid1()
+    log_file = None
+
+    log_dir = os.path.join(DEFAULTS.LOGS_DIR, process_type.lower())
+
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir)
+
+    log_file = os.path.join(log_dir, f"{process_type.lower()}-{local_uuid}.log")
+    pid: int | None = os.getpid()
+    children_pids: list[int] | None = []
+    start_time_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    if process_mode == ILAB_PROCESS_MODES.DETACHED:
+        assert isinstance(log_file, str)
+        cmd = format_command(target=target, extra_imports=extra_imports, **kwargs)
+        # Open the subprocess in the background, redirecting stdout and stderr to the log file
+        with open(log_file, "a+") as log:
+            pid, children_pids = start_process(cmd=cmd, log=log)
+            if pid is None or children_pids is None:
+                # process didn't start
+                return None
+            assert isinstance(pid, int) and isinstance(children_pids, list)
+    # Add the process info to the shared registry
+    process_registry.add_process(
+        local_uuid=local_uuid,
+        pid=pid,
+        children_pids=children_pids,
+        type=process_type,
+        log_file=log_file,
+        start_time=start_time_str,
+    )
+    logger.info(
+        f"Started subprocess with PID {pid}. Logs are being written to {log_file}."
+    )
+    save_registry(
+        process_registry=process_registry
+    )  # Persist registry after adding process
+    if process_mode == ILAB_PROCESS_MODES.ATTACHED:
+        with open(log_file, "a+") as log:
+            sys.stdout = Tee(log)
+            sys.stderr = sys.stdout
+            try:
+                target(**kwargs)  # Call the function
+            finally:
+                # Restore the original stdout and stderr after the function completes
+                process_registry.processes.pop(str(local_uuid))
+                save_registry(process_registry=process_registry)
+                sys.stdout = sys.__stdout__
+                sys.stderr = sys.__stderr__

--- a/src/instructlab/process/process.py
+++ b/src/instructlab/process/process.py
@@ -213,6 +213,7 @@ def add_process(
     pid: int | None = os.getpid()
     children_pids: list[int] | None = []
     start_time_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    kwargs["log_file"] = log_file
     if process_mode == ILAB_PROCESS_MODES.DETACHED:
         assert isinstance(log_file, str)
         cmd = format_command(target=target, extra_imports=extra_imports, **kwargs)

--- a/tests/common.py
+++ b/tests/common.py
@@ -61,7 +61,6 @@ def vllm_setup_test(runner, args, mock_popen, *_mock_args):
 
     return mock_popen.call_args_list[0][1]["args"]
 
-
 def assert_tps(args, tps):
     assert args[-2] == "--tensor-parallel-size"
     assert args[-1] == tps

--- a/tests/common.py
+++ b/tests/common.py
@@ -61,6 +61,7 @@ def vllm_setup_test(runner, args, mock_popen, *_mock_args):
 
     return mock_popen.call_args_list[0][1]["args"]
 
+
 def assert_tps(args, tps):
     assert args[-2] == "--tensor-parallel-size"
     assert args[-1] == tps

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -133,6 +133,9 @@ subcommands: list[Command] = [
     Command(("system", "info"), needs_config=False, should_fail=False),
     Command(("taxonomy",), needs_config=False, should_fail=False),
     Command(("taxonomy", "diff")),
+    Command(("process",), needs_config=False, should_fail=False),
+    Command(("process", "list")),
+    Command(("process", "attach")),
 ]
 
 aliases = [

--- a/tests/test_lab_process_attach.py
+++ b/tests/test_lab_process_attach.py
@@ -1,0 +1,65 @@
+# Standard
+import datetime
+import json
+import os
+
+# Third Party
+from click.testing import CliRunner
+
+# First Party
+from instructlab import lab
+from instructlab.defaults import DEFAULTS
+
+
+def test_process_attach(
+    cli_runner: CliRunner,
+):
+    # create empty log file, put it in proc reg, and attach for a second
+    process_registry = {}
+    start_time_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    process_registry["63866b91-799a-42a7-af02-d0b68fddf19d"] = {
+        "pid": 26372,
+        "children_pids": [111, 222, 333],
+        "type": "Generation",
+        "log_file": os.path.join(
+            DEFAULTS.LOGS_DIR,
+            "generation/generation-63866b91-799a-42a7-af02-d0b68fddf19d.log",
+        ),
+        "start_time": datetime.datetime.strptime(
+            start_time_str, "%Y-%m-%d %H:%M:%S"
+        ).isoformat(),
+    }
+    # create registry json, place it in the proper dir
+    os.makedirs(exist_ok=True, name=DEFAULTS.INTERNAL_DIR)
+    with open(DEFAULTS.PROCESS_REGISTRY_FILE, "w", encoding="utf-8") as f:
+        json.dump(process_registry, f)
+    # list processes and expect output
+    os.makedirs(exist_ok=True, name=os.path.join(DEFAULTS.LOGS_DIR, "generation"))
+    with open(
+        os.path.join(
+            DEFAULTS.LOGS_DIR,
+            "generation/generation-63866b91-799a-42a7-af02-d0b68fddf19d.log",
+        ),
+        "w",
+        encoding="utf-8",
+    ) as _:
+        pass  # Do nothing, just create the file
+    result = cli_runner.invoke(
+        lab.ilab,
+        ["--config=DEFAULT", "process", "attach", "--latest"],
+    )
+    assert result.exit_code == 0
+    assert (
+        "Attaching to process 63866b91-799a-42a7-af02-d0b68fddf19d. Press Ctrl+C to detach and kill."
+        in result.output
+    )
+
+
+def test_process_attach_none(cli_runner: CliRunner):
+    # attach to process and expect error
+    result = cli_runner.invoke(
+        lab.ilab,
+        ["--config=DEFAULT", "process", "attach", "--latest"],
+    )
+    assert result.exit_code == 1, result.output
+    assert "No processes found in registry" in result.output

--- a/tests/test_lab_process_list.py
+++ b/tests/test_lab_process_list.py
@@ -1,0 +1,86 @@
+# Standard
+import datetime
+import json
+import os
+import textwrap
+
+# Third Party
+from click.testing import CliRunner
+
+# First Party
+from instructlab import lab
+from instructlab.defaults import DEFAULTS
+
+
+def extract_process_entries(table_output: str) -> str:
+    lines = table_output.splitlines()
+    entries = []
+
+    for line in lines:
+        if line.startswith("|") and not line.startswith("+"):
+            # Split the line into columns based on the pipe delimiter
+            columns = [col.strip() for col in line.split("|")[1:-1]]
+
+            # Remove the "Runtime" column (last column)
+            desired_columns = columns[:-1]
+
+            # Clean and join the remaining columns
+            clean_line = " | ".join(desired_columns)
+            entries.append(clean_line)
+
+    return "\n".join(entries)
+
+
+def test_process_list(cli_runner: CliRunner):
+    process_registry = {}
+    start_time_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    process_registry["63866b91-799a-42a7-af02-d0b68fddf19d"] = {
+        "pid": 26372,
+        "children_pids": [111, 222, 333],
+        "type": "Generation",
+        "log_file": "/Users/charliedoern/.local/share/instructlab/logs/generation/generation-63866b91-799a-42a7-af02-d0b68fddf19d.log",
+        "start_time": datetime.datetime.strptime(
+            start_time_str, "%Y-%m-%d %H:%M:%S"
+        ).isoformat(),
+        "done": False,
+    }
+    # create registry json, place it in the proper dir
+    os.makedirs(exist_ok=True, name=DEFAULTS.INTERNAL_DIR)
+    with open(DEFAULTS.PROCESS_REGISTRY_FILE, "w", encoding="utf-8") as f:
+        json.dump(process_registry, f)
+    # list processes and expect output
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "process",
+            "list",
+        ],
+    )
+
+    expected_output = textwrap.dedent("""
++------------+-------+--------------------------------------+------------------------------------------------------------------------------------------------------------------+----------+
+| Type       | PID   | UUID                                 | Log File                                                                                                         | Runtime  |
++------------+-------+--------------------------------------+------------------------------------------------------------------------------------------------------------------+----------+
+| Generation | 26372 | 63866b91-799a-42a7-af02-d0b68fddf19d | /Users/charliedoern/.local/share/instructlab/logs/generation/generation-63866b91-799a-42a7-af02-d0b68fddf19d.log | 00:00:06 |
++------------+-------+--------------------------------------+------------------------------------------------------------------------------------------------------------------+----------+
+    """).strip()
+
+    assert result.exit_code == 0, result.output
+    assert extract_process_entries(result.output) == extract_process_entries(
+        expected_output
+    ), result.output
+
+
+def test_process_list_none(cli_runner: CliRunner):
+    # list processes and expect output
+    result = cli_runner.invoke(
+        lab.ilab,
+        [
+            "--config=DEFAULT",
+            "process",
+            "list",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "No processes found in registry" in result.output


### PR DESCRIPTION
this PR introduces process management, with the first detachable command being `ilab data generate`

a user can run `ilab data generate -dt` and a few things happen:
1. a log file is created in ~/.local/share/instructlab/logs/generate/generate-UUID.log where UUID is generated on each SDG run
2. SDG is kicked off in its own process. This includes server creation, and the calling of the SDG library. Both of these tasks are crucial to running SDG. One lives in the InstructLab repo while the other lives in the SDG repo, causing this to be the point where an independent process must be split off.
3. The UUID and log file are printed so the user can re-attach or directly check on the log file.
4. ilab then tracks the children processes created by the new python process. These are added to the process registry along with the PID of the parent, the log file, and the start time. This registry is written to `~/.local/share/instructlab/internal/process_registry.json`. The registry is read from disk into memory on each invocation of the `process` package which manages this data
5. The user can now list, attach to, and kill processes. 

this necessitates the creation of the `ilab process` command group. This command group will begin with two commands: 
`ilab process list`
`ilab process attach --uuid UUID_HERE --latest` where the user can pass either a UUID or just attach to the latest process kicked off. 
here is what the workflow looks like:

<img width="1508" alt="Screenshot 2024-12-13 at 8 58 13 PM" src="https://github.com/user-attachments/assets/ce677912-19b1-4a5f-a21b-a85e77ac9233" />


Some concrete design goals here:

this should _not_ live in the CLI sub-directory or execute `ilab` commands directly. This is because eventual consumers of this rearchitecture will want to call `generate_data` without needing to pass through unecessary click parsing and initialization.

Keeping lower-level process functionality and workflow code separate from the upper level CLI code is a purposeful decision here. A user should be able to run `ilab data generate -dt` but also eventually be able to curl the ilab.socket without needing to pass CLI level arguments or go through that level of parsing. Our process splitting should happen on this "lower level" right before we execute actual functionality of the LAB methodology

resolves #2689
resolves #2690

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  6. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
