### PR TITLE
fix: ensure student model path is passed

### DIFF
--- a/src/instructlab/cli/data/generate.py
+++ b/src/instructlab/cli/data/generate.py
@@ -243,14 +243,15 @@ def generate(
 
     # determine student model arch from train section of config and pick system prompt to
     # pass to SDG appropriately
-    student_model_arch = get_model_arch(pathlib.Path(ctx.obj.config.train.model_path))
+    student_model_path = pathlib.Path(ctx.obj.config.train.model_path)
+    student_model_arch = get_model_arch(student_model_path)
     system_prompt = get_sysprompt(student_model_arch)
 
     # Check if student model specifies a tokenizer config. If so, check if the special tokens specified
     # match those of granite-7b. If so, set legacy_pretraining_format to true. If no tokenizer config is
     # available, rely on model architecture to make that decision
     legacy_pretraining_format = use_legacy_pretraining_format(
-        model_path, student_model_arch
+        student_model_path, student_model_arch
     )
 
     try:


### PR DESCRIPTION
Currently the teacher model path is being passed to determine the legacy pretraining format for granite 2.0 models or the new pretraining format for granite 3.0 models. The path to the granite student model should be passed to properly make this determination


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Functional tests have been added, if necessary.
- [x] E2E Workflow tests have been added, if necessary.
