### PR TITLE
add a message for download

### DIFF
--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -22,7 +22,9 @@ from instructlab.utils import (
     check_skopeo_version,
     is_huggingface_repo,
     is_oci_repo,
+    list_models,
     load_json,
+    print_table,
 )
 
 logger = logging.getLogger(__name__)
@@ -341,11 +343,14 @@ def download(ctx, repositories, releases, filenames, model_dir, hf_token):
 
         try:
             downloader.download()
+            click.echo(
+                f"\nᕦ(òᴗóˇ)ᕤ {downloader.repository} model download completed successfully! ᕦ(òᴗóˇ)ᕤ\n"
+            )
         # pylint: disable=broad-exception-caught
         except (ValueError, Exception) as exc:
             if isinstance(exc, ValueError) and "HF_TOKEN" in str(exc):
                 click.secho(
-                    f"\n{downloader.repository} requires a HF Token to be set.\nPlease use '--hf-token' or 'export HF_TOKEN' to download all necessary models.",
+                    f"\n{downloader.repository} requires a HF Token to be set.\nPlease use '--hf-token' or 'export HF_TOKEN' to download all necessary models.\n",
                     fg="yellow",
                 )
             else:
@@ -354,3 +359,8 @@ def download(ctx, repositories, releases, filenames, model_dir, hf_token):
                     fg="red",
                 )
                 raise click.exceptions.Exit(1)
+
+    click.echo("Available models (`ilab model list`):")
+    data = list_models([Path(model_dir)], False)
+    data_as_lists = [list(item) for item in data]
+    print_table(["Model Name", "Last Modified", "Size"], data_as_lists)

--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -62,6 +62,8 @@ class TestLabDownload:
         )
         assert result.exit_code == 0
         mock_oci_download.assert_called_once()
+        assert "model download completed successfully!" in result.output
+        assert "Available models (`ilab model list`):" in result.output
 
     def test_oci_download_repository_error(self, cli_runner: CliRunner):
         result = cli_runner.invoke(


### PR DESCRIPTION
-  [2651](https://github.com/instructlab/instructlab/issues/2651) add success message for download and print the model list after download

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

```
$ ilab model download --hf-token test
Downloading model from Hugging Face:
    Model: instructlab/granite-7b-lab-GGUF@main
    Destination: /Users/xx/.cache/instructlab/models

ᕦ(òᴗóˇ)ᕤ instructlab/granite-7b-lab-GGUF model download completed successfully! ᕦ(òᴗóˇ)ᕤ

Downloading model from Hugging Face:
    Model: instructlab/merlinite-7b-lab-GGUF@main
    Destination: /Users/xx/.cache/instructlab/models

ᕦ(òᴗóˇ)ᕤ instructlab/merlinite-7b-lab-GGUF model download completed successfully! ᕦ(òᴗóˇ)ᕤ

Downloading model from Hugging Face:
    Model: TheBloke/Mistral-7B-Instruct-v0.2-GGUF@main
    Destination: /Users/xx/.cache/instructlab/models

ᕦ(òᴗóˇ)ᕤ TheBloke/Mistral-7B-Instruct-v0.2-GGUF model download completed successfully! ᕦ(òᴗóˇ)ᕤ

Available models (`ilab model list`):
+--------------------------------------+---------------------+---------+
| Model Name                           | Last Modified       | Size    |
+--------------------------------------+---------------------+---------+
| prometheus-eval/prometheus-8x7b-v2.0 | 2024-11-06 16:16:09 | 87.0 GB |
| instructlab/granite-7b-lab           | 2024-11-06 14:39:06 | 12.6 GB |
| merlinite-7b-lab-Q4_K_M.gguf         | 2024-09-14 06:45:33 | 4.1 GB  |
| mistral-7b-instruct-v0.2.Q4_K_M.gguf | 2024-11-06 16:58:49 | 4.1 GB  |
| granite-7b-lab-Q4_K_M.gguf           | 2024-11-28 00:39:47 | 3.8 GB  |
+--------------------------------------+---------------------+---------+
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
