### PR TITLE
add a model exist check for backend

### DIFF
--- a/src/instructlab/model/backends/backends.py
+++ b/src/instructlab/model/backends/backends.py
@@ -105,6 +105,15 @@ def get(model_path: pathlib.Path, backend: str | None) -> str:
     return backend
 
 
+def check_model_path_exists(model_path: pathlib.Path) -> None:
+    if not model_path.exists():
+        click.secho(
+            f"{model_path} does not exist. Please download model first.",
+            fg="red",
+        )
+        raise click.exceptions.Exit(1)
+
+
 def select_backend(
     cfg: serve_config,
     backend: Optional[str] = None,
@@ -118,6 +127,7 @@ def select_backend(
     logger.debug("Selecting backend for model %s", model_path)
 
     model_path = pathlib.Path(model_path or cfg.model_path)
+    check_model_path_exists(model_path)
     backend_name = backend if backend is not None else cfg.backend
     try:
         backend = get(model_path, backend_name)

--- a/tests/common.py
+++ b/tests/common.py
@@ -32,6 +32,9 @@ def setup_gpus_config(section_path="serve", gpus=None, tps=None, vllm_args=lambd
     return _CFG_FILE_NAME
 
 
+@mock.patch(
+    "instructlab.model.backends.backends.check_model_path_exists", return_value=None
+)
 @mock.patch("instructlab.model.backends.vllm.check_api_base", return_value=False)
 # ^ mimic server *not* running already
 @mock.patch(

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -419,3 +419,18 @@ def test_get_model_template(tmp_path: pathlib.Path):
     )
     assert eos == "<|endoftext|>"
     assert bos == "<|begginingoftext|>"
+
+
+def test_model_exist_check(cli_runner: CliRunner):
+    cmd = [
+        "--config",
+        "DEFAULT",
+        "model",
+        "chat",
+        "-m",
+        "test-model.gguf",
+    ]
+    result = cli_runner.invoke(lab.ilab, cmd)
+    assert (
+        "test-model.gguf does not exist. Please download model first." in result.stdout
+    )


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

Based on [2254](https://github.com/instructlab/instructlab/issues/2254), try to state the model doesn't exist simply if not download before `model chat`

```
From: 
$ ilab model chat
Failed to determine backend: Cannot determine which backend to use: The model file /Users/xx/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf is not a GGUF format nor a directory containing huggingface safetensors files. Cannot determine which backend to use.
Please use a GGUF file for llama-cpp or a directory containing huggingface safetensors files for vllm.
Note that vLLM is only supported on Linux.

To:
$ ilab model chat
Model /Users/xx/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf does not exist. Please download the model first.
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
