### PR TITLE
Change the way how GGUF model directory is checked

### DIFF
--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -790,6 +790,11 @@ def is_model_gguf(model_path: pathlib.Path) -> bool:
     Returns:
         bool: True if the file is a GGUF file, False otherwise.
     """
+
+    if os.path.isdir(model_path):
+        logger.debug(f"GGUF Path {model_path} is a directory")
+        return False
+
     # Third Party
     from gguf.constants import GGUF_MAGIC
 
@@ -806,9 +811,6 @@ def is_model_gguf(model_path: pathlib.Path) -> bool:
             f"Failed to unpack the first four bytes of {model_path}. "
             f"The file might not be a valid GGUF file or is corrupted: {e}"
         )
-        return False
-    except IsADirectoryError as e:
-        logger.debug(f"GGUF Path {model_path} is a directory, returning {e}")
         return False
     except OSError as e:
         logger.debug(f"An unexpected error occurred while processing {model_path}: {e}")


### PR DESCRIPTION
Instead of handling exception, we simply can check if path is a directory and skip the location immediately. This will address below errors on "ilab model list" command.

DEBUG 2024-12-02 07:17:52,163 instructlab.utils:811: GGUF Path /(...)/.cache/instructlab/models/.cache is a directory, returning [Errno 21]
						     Is a directory: '/(...)/.cache/instructlab/models/.cache'
DEBUG 2024-12-02 07:17:52,164 instructlab.utils:811: GGUF Path /(...)/.cache/instructlab/models/.cache/huggingface is a directory, returning [Errno 21]
                                                     Is a directory: '/(...)/.cache/instructlab/models/.cache/huggingface'
