### PR TITLE
Fix learning rate override log

### DIFF
--- a/src/instructlab/model/accelerated_train.py
+++ b/src/instructlab/model/accelerated_train.py
@@ -499,7 +499,7 @@ def _training_phase(
 
     if learning_rate is not None:
         logger.debug(
-            f"Phased Training -- training phase -- Overriding learning rate: {train_args.save_samples} with {learning_rate}"
+            f"Phased Training -- training phase -- Overriding learning rate: {train_args.learning_rate} with {learning_rate}"
         )
         train_args.learning_rate = learning_rate
 


### PR DESCRIPTION
Logging an incorrect value for overriden learning rate in phased training

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
