### PR TITLE
fix: don't error out if serve/chat model don't match

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -489,13 +489,13 @@ test_model_print(){
         exit 1
     fi
 
-    # validate that we fail on invalid model
+    # validate that we don't fail on invalid model
     if ! expect -d -c '
         set timeout 30
         spawn ilab model chat -m bar
         expect {
             timeout { exit 124 }
-           -re "Executing chat failed with: Model bar is not served by the server" { exit 0 }
+           -re "Requested model bar is not served by the server. Proceeding to chat with served model" { exit 0 }
         }
     '; then
         echo "Error: expect test failed"

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -781,14 +781,13 @@ def chat_cli(
     model_ids = []
     for m in model_list:
         model_ids.append(m.id)
-    if not any(model == m for m in model_ids):
-        if model == "merlinite-7b-lab-Q4_K_M":
-            logger.info(
-                f"Model {model} is not a full path. Try running ilab config init or edit your config to have the full model path for serving, chatting, and generation."
-            )
-        raise ChatException(
-            f"Model {model} is not served by the server. These are the served models: {model_ids}"
+    # if a model is already being served, ignore whatever model may have been supplied with the chat command
+    if (len(model_ids) > 0) and (not any(model == m for m in model_ids)):
+        # assuming chatting with first model in list if there are multiple. Temp fix
+        logger.info(
+            f"Requested model {model} is not served by the server. Proceeding to chat with served model: {model_ids[0]}"
         )
+        model = model_ids[0]
 
     # Load context/session
     loaded = {}


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

We supply a default model to `ilab model chat`. If this does not match the model being served separately (if there is one), instead of erroring out we should inform the user that we are ignoring what they supplied in favor of what is being served 

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
