### PR TITLE
Fix: `test_bind_port` consistently failing on MacOS runner

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -219,7 +219,7 @@ test_bind_port(){
     }
 
     # configure a different port
-    exec sed -i.bak 's/8000/9999/g' %s
+    exec sed -i.bak 's/:8000/:9999/g' %s
 
     # check that ilab model serve is working on the new port
     # catch ERROR strings in the output


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves # 2753

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.

It appears that the macOS tests are failing because of a bad substitution with `sed`. We only want to update the macOS _port numbers_ from 8000 to 9999. 

Currently, the macOS temp directory created during the tests has `8000` in the string: 

```
model_path: PosixPath('/var/folders/0w/4z5l9vds32nbkz7l22n8j6s80000gn/T/tmp.jzSsqlW7a0/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf') 	[type: pathlib.PosixPath, src: default_map]
```

But after the `sed` command, we get this:

```
model_path: PosixPath('/var/folders/0w/4z5l9vds32nbkz7l22n8j6s99990gn/T/tmp.jzSsqlW7a0/.cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf') 	[type: pathlib.PosixPath, src: default_map]
[3:05](https://redhat-internal.slack.com/archives/C06U3B0JDS5/p1733515554567289?thread_ts=1733496491.357869&cid=C06U3B0JDS5)
```

Thanks @bbrowning for pointing this out