### PR TITLE
fix: config init -- Add retry when an invalid HW vendor is selected

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -176,7 +176,7 @@ def prompt_user_to_choose_vendors(
 
     system_profile_selection = click.prompt(
         "Enter the number of your choice",
-        type=int,
+        type=click.IntRange(0, len(keys)),
         default=0,
     )
     if 1 <= system_profile_selection <= len(keys):

--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -205,7 +205,7 @@ def prompt_user_to_choose_profile(arch_family_processors) -> Config | None:
     cfg = None
     system_profile_selection = click.prompt(
         "Enter the number of your choice [hit enter for hardware defaults]",
-        type=int,
+        type=click.IntRange(0, len(arch_family_processors)),
         default=0,
     )
     # the file is SYSTEM_PROFILE_DIR/arch_family_procesors[key][selection-1]
@@ -217,12 +217,6 @@ def prompt_user_to_choose_profile(arch_family_processors) -> Config | None:
         click.echo(
             "No profile selected - ilab will use generic code defaults - these may not be optimized for your system."
         )
-    else:
-        click.secho(
-            "Invalid selection. Please select a valid system profile option.",
-            fg="red",
-        )
-        raise click.exceptions.Exit(1)
     return cfg
 
 


### PR DESCRIPTION
During the HW vendor selection of `ilab config init`, add a retry when the user enters an invalid selection for the vendor and system profile.

CHANGE:
```
First, please select the hardware vendor your system falls into
[0] NO SYSTEM PROFILE
[1] AMD
[2] APPLE
[3] INTEL
[4] NVIDIA
Enter the number of your choice: 5                                                                                                                                                                                 
Error: 5 is not in the range 0<=x<=4.                                                                                                                                                                              
Enter the number of your choice: 4                                                                                                                                                                                 
You selected: NVIDIA

Next, please select the specific hardware configuration that most closely matches your system.                                                                                                                     
[0] NO SYSTEM PROFILE                                                                                                                                                                                              
[1] NVIDIA A100 X2                                                                                                                                                                                                 
[2] NVIDIA A100 X4                                                                                                                                                                                                 
[3] NVIDIA A100 X8                                                                                                                                                                                                 
[4] NVIDIA H100 X2                                                                                                                                                                                                 
[5] NVIDIA H100 X4                                                                                                                                                                                                 
[6] NVIDIA H100 X8                                                                                                                                                                                                 
[7] NVIDIA L4 X8                                                                                                                                                                                                   
[8] NVIDIA L40S X4                                                                                                                                                                                                 
[9] NVIDIA L40S X8                                                                                                                                                                                                 
Enter the number of your choice [hit enter for hardware defaults]: 10                                                                                                                                              
Error: 10 is not in the range 0<=x<=9.                                                                                                                                                                             
Enter the number of your choice [hit enter for hardware defaults]: -1                                                                                                                                              
Error: -1 is not in the range 0<=x<=9.                                                                                                                                                                             
Enter the number of your choice [hit enter for hardware defaults]: 11                                                                                                                                              
Error: 11 is not in the range 0<=x<=9.                                                                                                                                                                             
Enter the number of your choice [hit enter for hardware defaults]: 99                                                                                                                                              
Error: 99 is not in the range 0<=x<=9.                                                                                                                                                                             
Enter the number of your choice [hit enter for hardware defaults]: 9
```

**Issue resolved by this Pull Request:**
Resolves # [RHELAI-2399](https://issues.redhat.com/browse/RHELAI-2399)


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
