### PR TITLE
fix: Require `instructlab-sdg>=0.6.2` to resolve dependency issues + require `pydantic<=2.9.2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ httpx>=0.25.0
 instructlab-eval>=0.4.0
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.4.0
-instructlab-sdg>=0.6.0
+instructlab-sdg>=0.6.2
 instructlab-training>=0.6.0
 llama_cpp_python[server]==0.2.79
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'

--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,7 @@ package = wheel
 wheel_build_env = pkg
 # equivalent to `pip install instructlab[cpu]`
 extras = cpu
-deps =
-    pytest
-    pytest-asyncio
-    pytest-cov
-    pytest-html
+deps = -r requirements-dev.txt
 commands =
     ilab --version
     {envpython} -m instructlab --version
@@ -138,12 +134,13 @@ commands =
 description = Python type checking with mypy
 basepython = {[testenv:py3]basepython}
 deps =
-  mypy>=1.10.0,<2.0
+  mypy>=1.10.0,<1.14
   types-PyYAML
   types-requests
   types-tqdm
   types-psutil
   pytest
+  pydantic<=2.9.2
 commands =
   mypy {posargs}
 


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #2765
Resolves #2773

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.

In the `docling-parse` v3.0.0 release, the maintainers rearranged a lot of logic and deprecated certain syntaxes, which has resulted in our InstructLab e2e tests failing to build. (See #2765 for more details.) Since `docling-parse` is indirectly pulled in via the `instructlab-sdg` package,  the `docling-parse`/`docling` issues were resolved in `instructlab-sdg` release [v0.6.2](https://github.com/instructlab/sdg/releases/tag/v0.6.2) and I have therefore updated this PR to require `instructlab-sdg>=0.6.2`.

Also, there was another unforeseen issue that this PR fixes: We use `mypy` to execute our linting steps, but one of `mypy`'s dependencies was recently updated with breaking changes:

<img width="1316" alt="Screenshot 2024-12-09 at 5 05 51 PM" src="https://github.com/user-attachments/assets/4a14c45d-9d8c-4f42-bb50-b625d2badc29">

Doing a quick investigation, I see that `mypy` has some issues filed for this problem:

  - https://github.com/python/mypy/issues/18191
  - https://github.com/pydantic/pydantic/issues/10950

To workaround this dependency issue, I pinned the related dependency, `pydantic`, to `<=v2.9.2` in our `tox.ini` file. This will force our latest `mypy` to use a compatible `pydantic`. However, note that I did also pin `mypy>=1.0,<1.14`. I did this as a safety measure for when the `mypy` maintainers inevitably fix the issue in v1.14 or later.