### PR TITLE
Revert "e2e: Use fork of wait-for-status-checks action with needed fix"

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -50,7 +50,7 @@ jobs:
           jq -nr '[$ARGS.positional[] | split("\\s"; null) | map(select(. != ""))] | flatten | join("|") | ("match_pattern=(" + . + ")")' --args "${{ inputs.job_ids }}" >> "$GITHUB_OUTPUT"
 
       - name: "Wait for status checks"
-        uses: bjhargrave/wait-for-status-checks@dce002a192e8eeb4c5b622283216263577ffd5d4 # v0.5.0_1
+        uses: poseidon/wait-for-status-checks@899c768d191b56eef585c18f8558da19e1f3e707 # v0.6.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           match_pattern: ${{ steps.set_variables.outputs.match_pattern }}


### PR DESCRIPTION
Reverts instructlab/instructlab#2412

New upstream release has BJ's fix: https://github.com/poseidon/wait-for-status-checks/releases/tag/v0.6.0