### PR TITLE
Update epel install to more consistent mechanism

### DIFF
--- a/scripts/infra/nvidia-setup.sh
+++ b/scripts/infra/nvidia-setup.sh
@@ -163,7 +163,7 @@ fi \
         sed -i -e "/^VARIANT_ID=/ {s/^VARIANT_ID=.*/VARIANT_ID=rhel_ai/; t}" -e "\$aVARIANT_ID=rhel_ai" /usr/lib/os-release; \
         sed -i -e "/^BUILD_ID=/ {s/^BUILD_ID=.*/BUILD_ID='${IMAGE_VERSION}'/; t}" -e "\$aBUILD_ID='${IMAGE_VERSION}'" /usr/lib/os-release; \
         fi \
-    && dnf config-manager --set-enabled crb \
+    && dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
     && dnf install -y epel-release epel-next-release \
     && dnf install -y nvtop \
     && dnf clean all \


### PR DESCRIPTION
`dnf config-manager --set-enabled crb` isn't working consistently with centos stream minimal and RHEL.  Switching to use the more reliable rpm download.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
