### PR TITLE
add -nd option for chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Update vLLM to version 0.6.6.post1. As a requirement for this new vLLM version, PyTorch is updated to 2.5.1
+- `ilab model chat` now has `--no-decoration` option to display chat responses without decoration.
 
 ## v0.23
 

--- a/src/instructlab/cli/model/chat.py
+++ b/src/instructlab/cli/model/chat.py
@@ -142,6 +142,12 @@ logger = logging.getLogger(__name__)
     config_class="rag",
     config_sections="retriever",
 )
+@click.option(
+    "-nd",
+    "--no-decoration",
+    is_flag=True,
+    help="Disable decorations for chat responses.",
+)
 @click.pass_context
 @clickext.display_params
 def chat(
@@ -166,6 +172,7 @@ def chat(
     collection_name,
     embedding_model_path,
     top_k,
+    no_decoration,
 ):
     """Runs a chat using the modified model"""
     chat_model(
@@ -189,6 +196,7 @@ def chat(
         collection_name,
         embedding_model_path,
         top_k,
+        no_decoration,
         backend_type=ctx.obj.config.serve.server.backend_type,
         host=ctx.obj.config.serve.server.host,
         port=ctx.obj.config.serve.server.port,

--- a/tests/test_model_chat.py
+++ b/tests/test_model_chat.py
@@ -2,11 +2,11 @@
 from unittest.mock import MagicMock
 import contextlib
 import logging
-import re
 
 # Third Party
 from click.testing import CliRunner
 from rich.console import Console
+from rich.panel import Panel
 import pytest
 
 # First Party
@@ -60,18 +60,20 @@ def test_retriever_is_called_when_present():
         retriever.augmented_context.assert_called_with(user_query=user_query)
 
 
-def handle_output(output):
-    return re.sub(r"\s+", " ", output).strip()
-
-
-def test_list_contexts_output():
+def test_list_contexts_and_decoration():
     chatbot = ConsoleChatBot(model="/var/model/file", client=None, loaded={})
 
-    def mock_sys_print(output):
-        mock_sys_print.output = output
+    def mock_sys_print_output(*args, **kwargs):
+        if chatbot.box:
+            panel = Panel(*args, **kwargs)
+            mock_sys_print_output.output = panel
+        else:
+            mock_sys_print_output.output = args[0]
 
-    chatbot._sys_print = mock_sys_print
+    chatbot._sys_print = mock_sys_print_output
 
+    # Test when box=True
+    chatbot.box = True
     mock_prompt_session = MagicMock()
     mock_prompt_session.prompt.return_value = "/lc"
     chatbot.input = mock_prompt_session
@@ -81,15 +83,50 @@ def test_list_contexts_output():
 
     console = Console(force_terminal=False)
     with console.capture() as capture:
-        console.print(mock_sys_print.output)
+        console.print(mock_sys_print_output.output)
 
     rendered_output = capture.get().strip()
 
-    expected_output = (
-        "Available contexts:\n\n"
-        "default: I am an advanced AI language model designed to assist you with a wide range of tasks and provide helpful, clear, and accurate responses. My primary role is to serve as a chat assistant, engaging in natural, conversational dialogue, answering questions, generating ideas, and offering support across various topics.\n\n"
-        "cli_helper: You are an expert for command line interface and know all common "
+    expected_output_with_box = (
+        "╭──────────────────────────────────────────────────────────────────────────────╮\n"
+        "│ Available contexts:                                                          │\n"
+        "│                                                                              │\n"
+        "│ default: I am an advanced AI language model designed to assist you with a    │\n"
+        "│ wide range of tasks and provide helpful, clear, and accurate responses. My   │\n"
+        "│ primary role is to serve as a chat assistant, engaging in natural,           │\n"
+        "│ conversational dialogue, answering questions, generating ideas, and offering │\n"
+        "│ support across various topics.                                               │\n"
+        "│                                                                              │\n"
+        "│ cli_helper: You are an expert for command line interface and know all common │\n"
+        "│ commands. Answer the command to execute as it without any explanation.       │\n"
+        "╰──────────────────────────────────────────────────────────────────────────────╯"
+    )
+
+    assert rendered_output == expected_output_with_box
+
+    # Test when box=False
+    chatbot.box = False
+    mock_prompt_session = MagicMock()
+    mock_prompt_session.prompt.return_value = "/lc"
+    chatbot.input = mock_prompt_session
+
+    with contextlib.suppress(KeyboardInterrupt):
+        chatbot.start_prompt(logger=None)
+
+    with console.capture() as capture:
+        console.print(mock_sys_print_output.output)
+
+    rendered_output = capture.get().strip()
+
+    expected_output_without_box = (
+        "Available contexts:                                                             \n\n"
+        "default: I am an advanced AI language model designed to assist you with a wide  \n"
+        "range of tasks and provide helpful, clear, and accurate responses. My primary   \n"
+        "role is to serve as a chat assistant, engaging in natural, conversational       \n"
+        "dialogue, answering questions, generating ideas, and offering support across    \n"
+        "various topics.                                                                 \n\n"
+        "cli_helper: You are an expert for command line interface and know all common    \n"
         "commands. Answer the command to execute as it without any explanation."
     )
 
-    assert handle_output(rendered_output) == handle_output(expected_output)
+    assert rendered_output == expected_output_without_box


### PR DESCRIPTION
- add a option to remove the decoration for the chat

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

Baed on [2712](https://github.com/instructlab/instructlab/issues/2712), add the no decoration mode
```
$ ilab model chat --help
  -nd, --no-decoration      Disable decorations for chat responses.

$ ilab model chat -nd
Welcome to InstructLab Chat w/ **GRANITE-7B-LAB-Q4_K_M.GGUF** (type `/h` for help)
>>> /h
Help / TL;DR

 • /q: quit
 • /h: show help
 • /a assistant: amend assistant (i.e., model)
 • /c context: change context (available contexts: default, cli_helper)
 • /lc: list contexts
 • /m: toggle multiline (for the next session only)
 • /M: toggle multiline
 • /n: new session
 • /N: new session (ignoring loaded)
 • /d <int>: display previous response based on input, if passed 1 then previous, if 2 then second last
   response and so on.
 • /p <int>: previous response in plain text based on input, if passed 1 then previous, if 2 then second last
   response and so on.
 • /md <int>: previous response in Markdown based on input, if passed 1 then previous, if 2 then second last
   response and so on.
 • /s filepath: save current session to filepath
 • /l filepath: load filepath and start a new session
 • /L filepath: load filepath (permanently) and start a new session

Press Alt (or Meta) and Enter or Esc Enter to end multiline input.

>>> hi
Hello! I'm glad you reached out. I'd be happy to help answer any questions you have.
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
