### PR TITLE
split `ilab model list` click cmds from functionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ issues = "https://github.com/instructlab/instructlab/issues"
 "serve" = "instructlab.cli.model.serve:serve"
 "test" = "instructlab.model.test:test"
 "train" = "instructlab.cli.model.train:train"
-"list" = "instructlab.model.list:model_list"
+"list" = "instructlab.cli.model.list:model_list"
 
 [project.entry-points."instructlab.command.system"]
 "info" = "instructlab.system.info:info"

--- a/src/instructlab/cli/model/list.py
+++ b/src/instructlab/cli/model/list.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from pathlib import Path
+from typing import List
+import logging
+
+# Third Party
+import click
+
+# First Party
+from instructlab import clickext
+from instructlab.configuration import DEFAULTS
+from instructlab.model.list import list_and_print_models
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(name="list")
+@clickext.display_params
+@click.option(
+    "--model-dirs",
+    help="Base directories where models are stored.",
+    multiple=True,
+    default=[DEFAULTS.MODELS_DIR],
+    show_default=True,
+)
+@click.option(
+    "--list-checkpoints",
+    help="Also list checkpoints [in addition to existing models].",
+    is_flag=True,
+)
+def model_list(model_dirs: List[str], list_checkpoints: bool):
+    """Lists models"""
+    # Convert model_dirs to Path
+    model_path_dirs = [Path(m) for m in model_dirs]
+
+    # Delegate functionality to the core function
+    list_and_print_models(model_path_dirs, list_checkpoints)

--- a/src/instructlab/model/list.py
+++ b/src/instructlab/model/list.py
@@ -3,38 +3,15 @@
 # Standard
 from pathlib import Path
 from typing import List
-import logging
-
-# Third Party
-import click
 
 # First Party
-from instructlab import clickext
-from instructlab.configuration import DEFAULTS
 from instructlab.utils import list_models, print_table
 
-logger = logging.getLogger(__name__)
 
-
-@click.command(name="list")
-@clickext.display_params
-@click.option(
-    "--model-dirs",
-    help="Base directories where models are stored.",
-    multiple=True,
-    default=[DEFAULTS.MODELS_DIR],
-    show_default=True,
-)
-@click.option(
-    "--list-checkpoints",
-    help="Also list checkpoints [in addition to existing models].",
-    is_flag=True,
-)
-def model_list(model_dirs: List[str], list_checkpoints: bool):
-    """Lists models"""
-    # click converts lists into tuples when using multiple
-    model_path_dirs = [Path(m) for m in model_dirs]
-
+def list_and_print_models(model_path_dirs: List[Path], list_checkpoints: bool):
+    """
+    Core functionality for listing models and optionally listing checkpoints.
+    """
     data = list_models(model_path_dirs, list_checkpoints)
     data_as_lists = [list(item) for item in data]  # this is to satisfy mypy
     print_table(["Model Name", "Last Modified", "Size"], data_as_lists)


### PR DESCRIPTION
Refactored click command handling into a dedicated `cli` module and kept the core list functionality in a separate module. This restructing lays the groundwork for future API handlers and multi-processing work.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
