### PR TITLE
deps: add yq as installation dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ wandb>=0.16.4
 xdg-base-dirs>=6.0.1
 psutil>=6.0.0
 huggingface_hub[hf_transfer]>=0.1.8
+yq>=3.0.0


### PR DESCRIPTION
There is a missing dependency on yq which cause 'ilab taxonomy diff' command to fail with below error:

  WARNING (...)  instructlab.schema.taxonomy:336: could not run yq command
  Traceback (most recent call last):
  File "(...)/lib64/python3.11/site-packages/instructlab/schema/taxonomy.py", line 331, in _schema_validate
    line = subprocess.check_output(["yq", yq_expression], input=text, text=True)
  File "/usr/lib64/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib64/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
  subprocess.CalledProcessError: Command '['yq', '.seed_examples[19].questions_and_answers | line']' returned non-zero exit status 3.
