### PR TITLE
feat: update release-strategy to include discord

### DIFF
--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -57,6 +57,7 @@ The following are the steps for how Y-stream and Z-stream releases gets cut.
 1. Create a new release on GitHub targeting the release branch and using the latest Y-Stream tag as the previous release (e.g. `0.15.1` precedes `0.16.0`).
 1. Announce release via the following:
     - The `#announce` channel on Slack
+    - The `#announce` channel on Discord
     - The `announce` mailing list
 1. Create a milestone on GitHub for the next release without a milestone.
 
@@ -67,6 +68,7 @@ The following are the steps for how Y-stream and Z-stream releases gets cut.
 1. Create a new release on GitHub targeting the release branch and using the previous Z-Stream tag as the previous release (e.g. `0.15.0` precedes `0.15.1`).
 1. If changes warrant an announcement, announce via the following:
     - The `#announce` channel on Slack
+    - The `#announce` channel on Discord
     - The `announce` mailing list
 
 ## Release Notes


### PR DESCRIPTION
In order to facilliate the addition of Discord as a new chat platform, we will be mirroring
all announcements made regarding releases as currently happens on Slack to also take place
on Discord. This commit updates our policy document to reflect this change

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
