### PR TITLE
feat: add discord e2e status reporting

### DIFF
--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -195,6 +195,30 @@ jobs:
             channel: 'e2e-ci-results'
             text: "*e2e-nvidia-l40s-x4* job in *${{ github.repository }}* running on branch `${{ steps.check_pr.outputs.pr_or_branch }}` completed *successfully* :meow_party: | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+      - name: Send Discord notification for failure
+        if: failure() && steps.check_pr.outputs.is_pr == 'false'
+        uses: sarisia/actions-status-discord@65843b6a7d18626c252a055e247ccad1f41b4004 # v1.15.1
+        with:
+          webhook: ${{ secrets.SON_OF_JEEVES_DISCORD_WEBHOOK }}
+          status: ${{ job.status }}
+          title: "e2e-nvidia-l40s-x4"
+          description: |
+            Job in **${{ github.repository }}** running on branch `${{ steps.check_pr.outputs.pr_or_branch }}` completed **with failures** ❌
+            Click [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) to view details.
+          color: 0xCB2431 # Red color for failure
+
+      - name: Send Discord notification for success
+        if: success() && steps.check_pr.outputs.is_pr == 'false'
+        uses: sarisia/actions-status-discord@65843b6a7d18626c252a055e247ccad1f41b4004 # v1.15.1
+        with:
+          webhook: ${{ secrets.SON_OF_JEEVES_DISCORD_WEBHOOK }}
+          status: ${{ job.status }}
+          title: "e2e-nvidia-l40s-x4"
+          description: |
+            Job in **${{ github.repository }}** running on branch `${{ steps.check_pr.outputs.pr_or_branch }}` completed **successfully** ✅
+            Click [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) to view details.
+          color: 0x28A745 # Green color for success
+
   stop-large-ec2-runner:
     needs:
       - start-large-ec2-runner

--- a/.github/workflows/e2e-nvidia-l40s-x8.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x8.yml
@@ -195,6 +195,30 @@ jobs:
             channel: 'e2e-ci-results'
             text: "*e2e-nvidia-l40s-x8* job in *${{ github.repository }}* running on branch `${{ steps.check_pr.outputs.pr_or_branch }}` completed *successfully* :meow_party: | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+      - name: Send Discord notification for failure
+        if: failure() && steps.check_pr.outputs.is_pr == 'false'
+        uses: sarisia/actions-status-discord@65843b6a7d18626c252a055e247ccad1f41b4004 # v1.15.1
+        with:
+          webhook: ${{ secrets.SON_OF_JEEVES_DISCORD_WEBHOOK }}
+          status: ${{ job.status }}
+          title: "e2e-nvidia-l40s-x8"
+          description: |
+            Job in **${{ github.repository }}** running on branch `${{ steps.check_pr.outputs.pr_or_branch }}` completed **with failures** ❌
+            Click [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) to view details.
+          color: 0xCB2431 # Red color for failure
+
+      - name: Send Discord notification for success
+        if: success() && steps.check_pr.outputs.is_pr == 'false'
+        uses: sarisia/actions-status-discord@65843b6a7d18626c252a055e247ccad1f41b4004 # v1.15.1
+        with:
+          webhook: ${{ secrets.SON_OF_JEEVES_DISCORD_WEBHOOK }}
+          status: ${{ job.status }}
+          title: "e2e-nvidia-l40s-x8"
+          description: |
+            Job in **${{ github.repository }}** running on branch `${{ steps.check_pr.outputs.pr_or_branch }}` completed **successfully** ✅
+            Click [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) to view details.
+          color: 0x28A745 # Green color for success
+
   stop-xlarge-ec2-runner:
     needs:
       - start-xlarge-ec2-runner

--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -170,6 +170,7 @@ USM
 venv
 vllm
 VRAM
+webhooks
 wikisql
 WSL
 xcode

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -69,7 +69,7 @@ You can specify the following flags to test various features of `ilab` with the
 
 ### Current E2E Jobs
 
-| Name | T-Shirt Size | Runner Host | Instance Type | OS | GPU Type | Script | Flags | Runs when? | Slack reporting? |
+| Name | T-Shirt Size | Runner Host | Instance Type | OS | GPU Type | Script | Flags | Runs when? | Slack/Discord reporting? |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | [`e2e-nvidia-t4-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-t4-x1.yml) | Small | AWS | [`g4dn.2xlarge`](https://aws.amazon.com/ec2/instance-types/g4/) | CentOS Stream 9 | 1 x NVIDIA Tesla T4 w/ 16 GB VRAM | `e2e-ci.sh` | `s` | Pull Requests, Push to `main` or `release-*` branch | No |
 | [`e2e-nvidia-l4-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l4-x1.yml) | Medium | AWS |[`g6.8xlarge`](https://aws.amazon.com/ec2/instance-types/g5/) | CentOS Stream 9 | 1 x NVIDIA L4 w/ 24 GB VRAM | `e2e-ci.sh` | `m` | Pull Requests, Push to `main` or `release-*` branch | No |
@@ -94,10 +94,12 @@ Points of clarification (*):
 1. The `simple` training pipeline uses 4-bit-quantization. We cannot use the trained model here due to [#579](https://github.com/instructlab/instructlab/issues/579)
 2. `MMLU Branch` is not run as the `full` SDG pipeline does not create the needed files in the tasks directory when only training against a skill.
 
-### Slack reporting
+### Discord/Slack reporting
 
-Some E2E jobs send their results to the InstructLab Slack workspace channel `#e2e-ci-results` via the `Son of Jeeves` bot. This has been implemented
-via [the official Slack GitHub Action](https://github.com/slackapi/slack-github-action?tab=readme-ov-file#technique-2-slack-app). You can see which jobs currently have reporting via the "Current E2E Jobs" table above.
+Some E2E jobs send their results to the channel `#e2e-ci-results` via the `Son of Jeeves` bot in both Discord and Slack. You can see which jobs currently have reporting via the "Current E2E Jobs" table above.
+
+In Slack, this has been implemented via [the official Slack GitHub Action](https://github.com/slackapi/slack-github-action?tab=readme-ov-file#technique-2-slack-app).
+In Discord, we use [actions/actions-status-discord](https://github.com/sarisia/actions-status-discord) and the built-in channel webhooks feature.
 
 ### Triggering an E2E job via GitHub Web UI
 


### PR DESCRIPTION
Since we have recently added Discord as another chat platform, we should
also report the status of E2E jobs there in addition to Slack.
This commit introduces this capability by mirroring a PR that was made in
instructlab/eval: https://github.com/instructlab/eval/pull/200

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
