### PR TITLE
fix: Correct invalid YAML test file formats and add YAML linting stage to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,6 +62,9 @@ jobs:
           - name: "tomllint"
             commands: |
               tox -e tomllint
+          - name: "yamllint"
+            commands: |
+              tox -e yamllint
     steps:
       - name: "Harden Runner"
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,11 @@
+rules:
+  quoted-strings:
+    quote-type: any
+    required: false
+    allow-quoted-quotes: true
+    check-keys: true
+
+  line-length:
+    max: 120
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: false

--- a/scripts/test-data/compositional_skills/freeform/e2e-qna-freeform-palindrome-skill.yaml
+++ b/scripts/test-data/compositional_skills/freeform/e2e-qna-freeform-palindrome-skill.yaml
@@ -5,28 +5,35 @@ seed_examples:
   - question: |
       A palindrome is a word, sentence, verse, or even number that reads the
       same backward or forward. What is "kayak" reversed and is it a palindrome?
-    answer: Kayak reversed is kayak and is a palindrome.
+    answer: |
+      Kayak reversed is kayak and is a palindrome.
   - question: |
       A palindrome is a word, sentence, verse, or even number that reads the same
       backward or forward. What is banana reversed and is it a palindrome?
-    answer: Banana backwards is "ananab" and banana is not a palindrome.
+    answer: |
+      Banana backwards is "ananab" and banana is not a palindrome.
   - question: |
       A palindrome is a word, sentence, verse, or even number that reads the same
       backward or forward. What is racecar reversed and is it a palindrome?
-    answer: Racecar backwards is racecar and is a palindrome.
+    answer: |
+      Racecar backwards is racecar and is a palindrome.
   - question: |
       A palindrome is a word, sentence, verse, or even number that reads the same
       backward or forward. What is an example of a palindrome?
-    answer: Civic is a palindrome.
+    answer: |
+      Civic is a palindrome.
   - question: |
       A palindrome is a word, sentence, verse, or even number that reads the same
       backward or forward. What is "dashed" reversed and is it a palindrome?
-    answer: "Dashed" reversed is "dehsad" and the word dashed is not a palindrome.
+    answer: |
+      "Dashed" reversed is "dehsad" and the word dashed is not a palindrome.
   - question: |
       A palindrome is a word, sentence, verse, or even number that reads the same
       backward or forward. What is an example of a palindrome?
-    answer: Rotator is a palindrome.
+    answer: |
+      Rotator is a palindrome.
   - question: |
       A palindrome is a word, sentence, verse, or even number that reads the same
       backward or forward. What is tenet reversed and is it a palindrome?
-    answer: Tenet reversed is tenet and it is a palindrome.
+    answer: |
+      Tenet reversed is tenet and it is a palindrome.

--- a/scripts/test-data/compositional_skills/grounded/e2e-qna-grounded-employee-skill.yaml
+++ b/scripts/test-data/compositional_skills/grounded/e2e-qna-grounded-employee-skill.yaml
@@ -4,225 +4,225 @@ task_description: >
     Given a context document and a user's question, determine whether you have
     enough information to provide a yes-or-no answer to the user's question.
 seed_examples:
-- context: >
-    Document:
+  - context: >
+      Document:
 
-    All regular employees except those on a leave of absence (LOA) must file Form XYZ.
-    If you are a regular employee on a LOA, you do not need to file the form. If you
-    are a supplemental employee (type B1, type B2, or type B3), your employee type
-    determines which form you must file, as follows:
+      All regular employees except those on a leave of absence (LOA) must file Form XYZ.
+      If you are a regular employee on a LOA, you do not need to file the form. If you
+      are a supplemental employee (type B1, type B2, or type B3), your employee type
+      determines which form you must file, as follows:
 
-    * If you are a type B1 employee, you must follow the same rules that apply to the
-    regular employees.
+      * If you are a type B1 employee, you must follow the same rules that apply to the
+      regular employees.
 
-    * If you are a type B2 employee, the rules that apply to you are different from
-    those that apply to the regular employees. See Pub. 31416 to find out which forms
-    you should file.
+      * If you are a type B2 employee, the rules that apply to you are different from
+      those that apply to the regular employees. See Pub. 31416 to find out which forms
+      you should file.
 
-    * If you are a supplemental employee of neither type B1 nor type B2, you are a
-    type B3 employee. Different rules apply for each part of the year. For information
-    on type B3 employees, see Pub. 31416.
-  question: >
-    User asks the following question:
+      * If you are a supplemental employee of neither type B1 nor type B2, you are a
+      type B3 employee. Different rules apply for each part of the year. For information
+      on type B3 employees, see Pub. 31416.
+    question: >
+      User asks the following question:
 
-    "I am a supplemental employee of type B1 on a LOA. Should I file Form XYZ?"
+      "I am a supplemental employee of type B1 on a LOA. Should I file Form XYZ?"
 
-    As the responding agent, do you have enough information to provide a yes-or-no answer
-    to the user's question? Answer Yes or No, then explain your answer.
-  answer: >
-    Yes, I have enough information to provide a yes-or-no answer to the user's question.
-    Specifically, the answer to the user's question is "no". Indeed, the user is a
-    supplemental employee of type B1 and is on a LOA. According to the document,
-    supplemental employees of type B1 must follow the same rules that apply to the
-    regular employees, and a regular employee on a LOA does not need to file Form XYZ.
-    Hence, the user does not need to file Form XYZ. I reached this conclusion using
-    only the information available in the document and in the user's question.
+      As the responding agent, do you have enough information to provide a yes-or-no answer
+      to the user's question? Answer Yes or No, then explain your answer.
+    answer: >
+      Yes, I have enough information to provide a yes-or-no answer to the user's question.
+      Specifically, the answer to the user's question is "no". Indeed, the user is a
+      supplemental employee of type B1 and is on a LOA. According to the document,
+      supplemental employees of type B1 must follow the same rules that apply to the
+      regular employees, and a regular employee on a LOA does not need to file Form XYZ.
+      Hence, the user does not need to file Form XYZ. I reached this conclusion using
+      only the information available in the document and in the user's question.
 
-- context: >
-    Document:
+  - context: >
+      Document:
 
-    All regular employees except those on a leave of absence (LOA) must file Form XYZ.
-    If you are a regular employee on a LOA, you do not need to file the form. If you
-    are a supplemental employee (type B1, type B2, or type B3), your employee type
-    determines which form you must file, as follows:
+      All regular employees except those on a leave of absence (LOA) must file Form XYZ.
+      If you are a regular employee on a LOA, you do not need to file the form. If you
+      are a supplemental employee (type B1, type B2, or type B3), your employee type
+      determines which form you must file, as follows:
 
-    * If you are a type B1 employee, you must follow the same rules that apply to the
-    regular employees.
+      * If you are a type B1 employee, you must follow the same rules that apply to the
+      regular employees.
 
-    * If you are a type B2 employee, the rules that apply to you are different from
-    those that apply to the regular employees. See Pub. 31416 to find out which forms
-    you should file.
+      * If you are a type B2 employee, the rules that apply to you are different from
+      those that apply to the regular employees. See Pub. 31416 to find out which forms
+      you should file.
 
-    * If you are a supplemental employee of neither type B1 nor type B2, you are a
-    type B3 employee. Different rules apply for each part of the year. For information
-    on type B3 employees, see Pub. 31416.
-  question: >
-    User asks the following question:
+      * If you are a supplemental employee of neither type B1 nor type B2, you are a
+      type B3 employee. Different rules apply for each part of the year. For information
+      on type B3 employees, see Pub. 31416.
+    question: >
+      User asks the following question:
 
-    "I am a supplemental employee of type B1, not on a LOA. Should I file Form XYZ?"
+      "I am a supplemental employee of type B1, not on a LOA. Should I file Form XYZ?"
 
-    As the responding agent, do you have enough information to provide a yes-or-no answer
-    to the user's question? Answer Yes or No, then explain your answer.
-  answer: >
-    Yes, I have enough information to provide a yes-or-no answer to the user's question.
-    Specifically, the answer to the user's question is "yes". Indeed, the user is a
-    supplemental employee of type B1 and is not on a LOA. According to the document,
-    supplemental employees of type B1 must follow the same rules that apply to the
-    regular employees, and all regular employees except those on a LOA must file
-    Form XYZ. Hence, the user must file Form XYZ. I reached this conclusion using only
-    the information available in the document and in the user's question.
+      As the responding agent, do you have enough information to provide a yes-or-no answer
+      to the user's question? Answer Yes or No, then explain your answer.
+    answer: >
+      Yes, I have enough information to provide a yes-or-no answer to the user's question.
+      Specifically, the answer to the user's question is "yes". Indeed, the user is a
+      supplemental employee of type B1 and is not on a LOA. According to the document,
+      supplemental employees of type B1 must follow the same rules that apply to the
+      regular employees, and all regular employees except those on a LOA must file
+      Form XYZ. Hence, the user must file Form XYZ. I reached this conclusion using only
+      the information available in the document and in the user's question.
 
-- context: >
-    Document:
+  - context: >
+      Document:
 
-    The Helping Hands Program enables the employees of XYZ Technologies to support
-    nonprofit organizations within the communities where the employees live and work.
-    All active, regular employees of XYZ Technologies are eligible to participate in
-    the program. The following categories are ineligible to participate in the program:
+      The Helping Hands Program enables the employees of XYZ Technologies to support
+      nonprofit organizations within the communities where the employees live and work.
+      All active, regular employees of XYZ Technologies are eligible to participate in
+      the program. The following categories are ineligible to participate in the program:
 
-    * Retirees who no longer work at XYZ Technologies
+      * Retirees who no longer work at XYZ Technologies
 
-    * XYZ employees on a leave of absence
+      * XYZ employees on a leave of absence
 
-    * Supplemental employees and contractors who are not regular XYZ employees
+      * Supplemental employees and contractors who are not regular XYZ employees
 
-    Please note that XYZ employees on a leave of absence can participate in the Helping
-    Hands Program once they return to an active status.
-  question: >
-    User asks the following question:
+      Please note that XYZ employees on a leave of absence can participate in the Helping
+      Hands Program once they return to an active status.
+    question: >
+      User asks the following question:
 
-    "I am an active, regular employee of XYZ Technologies. I am not on a leave of absence.
-    Can I participate in the Helping Hands Program?"
+      "I am an active, regular employee of XYZ Technologies. I am not on a leave of absence.
+      Can I participate in the Helping Hands Program?"
 
-    As the responding agent, do you have enough information to provide a yes-or-no answer
-    to the user's question? Answer Yes or No, then explain your answer.
-  answer: >
-    Yes, I have enough information to provide a yes-or-no answer to the user's question.
-    Specifically, the answer to the user's question is "yes". Indeed, the user is an
-    active, regular employee of XYZ Technologies. According to the document, all active,
-    regular employees of XYZ Technologies are eligible to participate in the Helping
-    Hands Program. The document excludes retirees, XYZ employees on a leave of absence,
-    and those who are not regular XYZ employees; however, the user is an active and
-    regular employee who is not on a leave of absence, so the exclusions do not apply.
-    Therefore, the user can participate in the Helping Hands Program. I reached this
-    conclusion using only the information available in the document and in the user's
-    question.
+      As the responding agent, do you have enough information to provide a yes-or-no answer
+      to the user's question? Answer Yes or No, then explain your answer.
+    answer: >
+      Yes, I have enough information to provide a yes-or-no answer to the user's question.
+      Specifically, the answer to the user's question is "yes". Indeed, the user is an
+      active, regular employee of XYZ Technologies. According to the document, all active,
+      regular employees of XYZ Technologies are eligible to participate in the Helping
+      Hands Program. The document excludes retirees, XYZ employees on a leave of absence,
+      and those who are not regular XYZ employees; however, the user is an active and
+      regular employee who is not on a leave of absence, so the exclusions do not apply.
+      Therefore, the user can participate in the Helping Hands Program. I reached this
+      conclusion using only the information available in the document and in the user's
+      question.
 
-- context: >
-    Document:
+  - context: >
+      Document:
 
-    Applying for a driver's license is as easy as 1-2-3! You can apply for a driver's license
-    if you bring documents from each of the three sections below:
+      Applying for a driver's license is as easy as 1-2-3! You can apply for a driver's license
+      if you bring documents from each of the three sections below:
 
-    Section 1. Proof of Identity - one document is required from the list below:
+      Section 1. Proof of Identity - one document is required from the list below:
 
-    * Unexpired passport
+      * Unexpired passport
 
-    * Birth certificate
+      * Birth certificate
 
-    * Certificate of naturalization or citizenship
+      * Certificate of naturalization or citizenship
 
-    * Valid, unexpired Permanent Resident Card
+      * Valid, unexpired Permanent Resident Card
 
-    Section 2. Proof of Social Security Number - one document is required from the list below:
+      Section 2. Proof of Social Security Number - one document is required from the list below:
 
-    * Social Security card
+      * Social Security card
 
-    * W-2 form
+      * W-2 form
 
-    * SSA-1099 form
+      * SSA-1099 form
 
-    * Paystub
+      * Paystub
 
-    Section 3. Proof of Residency - two different documents are required from the list below:
+      Section 3. Proof of Residency - two different documents are required from the list below:
 
-    * Home utility bill
+      * Home utility bill
 
-    * Medical document
+      * Medical document
 
-    * Proof of car registration
+      * Proof of car registration
 
-    * Proof of employment
+      * Proof of employment
 
-    * Proof of insurance
+      * Proof of insurance
 
-    * Mortgage bill
+      * Mortgage bill
 
-    * Lease agreement
+      * Lease agreement
 
-    * Tax return
-  question: >
-    User asks the following question:
+      * Tax return
+    question: >
+      User asks the following question:
 
-    "Can I apply for a driver's license if I bring my birth certificate, my W-2 form, and
-    my proof of car registration?"
+      "Can I apply for a driver's license if I bring my birth certificate, my W-2 form, and
+      my proof of car registration?"
 
-    As the responding agent, do you have enough information to provide a yes-or-no answer
-    to the user's question? Answer Yes or No, then explain your answer.
-  answer: >
-    Yes, I have enough information to provide a yes-or-no answer to the user's question.
-    Specifically, the answer to the user's question is "no". Indeed, the user wants to
-    bring a birth certificate, a W-2 form, and a proof of car registration. According to
-    the context document, to apply for a driver's license, the user must bring one proof
-    of Identity, one proof of Social Security Number, and two different proof of Residency
-    documents. A birth certificate is one proof of Identity, a W-2 form is one proof of
-    Social Security Number, and a proof of car registration is one proof of Residency
-    document. The user cannot apply for a driver's license without bringing a second proof
-    of Residency document. I reached this conclusion using only the information available
-    in the context document and in the user's question.
+      As the responding agent, do you have enough information to provide a yes-or-no answer
+      to the user's question? Answer Yes or No, then explain your answer.
+    answer: >
+      Yes, I have enough information to provide a yes-or-no answer to the user's question.
+      Specifically, the answer to the user's question is "no". Indeed, the user wants to
+      bring a birth certificate, a W-2 form, and a proof of car registration. According to
+      the context document, to apply for a driver's license, the user must bring one proof
+      of Identity, one proof of Social Security Number, and two different proof of Residency
+      documents. A birth certificate is one proof of Identity, a W-2 form is one proof of
+      Social Security Number, and a proof of car registration is one proof of Residency
+      document. The user cannot apply for a driver's license without bringing a second proof
+      of Residency document. I reached this conclusion using only the information available
+      in the context document and in the user's question.
 
-- context: >
-    Document:
+  - context: >
+      Document:
 
-    XYZ Corporation released three models of phones in 2024: Model MX, Model MY, and
-    Model MZ. Model MX is the budget-conscious choice, it has 6-inch screen, a single
-    rear camera, and 32 GB of storage. Model MY is the most portable choice, with a
-    5-inch screen, a dual rear camera, and 32 GB of storage. Model MZ is the luxury
-    choice, sporting a 7-inch screen, a dual rear camera, and 64 GB of storage.
-    These three models are the only ones available for sale in our store.
-  question: >
-    User asks the following question:
+      XYZ Corporation released three models of phones in 2024: Model MX, Model MY, and
+      Model MZ. Model MX is the budget-conscious choice, it has 6-inch screen, a single
+      rear camera, and 32 GB of storage. Model MY is the most portable choice, with a
+      5-inch screen, a dual rear camera, and 32 GB of storage. Model MZ is the luxury
+      choice, sporting a 7-inch screen, a dual rear camera, and 64 GB of storage.
+      These three models are the only ones available for sale in our store.
+    question: >
+      User asks the following question:
 
-    "Does your store sell a phone made by XYZ Corporation that has a 6-inch screen and
-    a dual rear camera?"
+      "Does your store sell a phone made by XYZ Corporation that has a 6-inch screen and
+      a dual rear camera?"
 
-    As the responding agent, do you have enough information to provide a yes-or-no answer
-    to the user's question? Answer Yes or No, then explain your answer.
-  answer: >
-    Yes, I have enough information to provide a yes-or-no answer to the user's question.
-    Specifically, the answer to the user's question is "no". Indeed, the user is looking
-    for a phone made by XYZ Corporation that has a 6-inch screen and a dual rear camera.
-    According to the document, our store sells only three models of phones made by
-    XYZ Corporation: Model MX, Model MY, and Model MZ. Only Model MX has a 6-inch screen,
-    but it has a single rear camera; models MY and MZ do not have a 6-inch screen. Hence,
-    our store does not sell a phone the user is looking for. I reached this conclusion
-    using only the information available in the document and in the user's question.
+      As the responding agent, do you have enough information to provide a yes-or-no answer
+      to the user's question? Answer Yes or No, then explain your answer.
+    answer: >
+      Yes, I have enough information to provide a yes-or-no answer to the user's question.
+      Specifically, the answer to the user's question is "no". Indeed, the user is looking
+      for a phone made by XYZ Corporation that has a 6-inch screen and a dual rear camera.
+      According to the document, our store sells only three models of phones made by
+      XYZ Corporation: Model MX, Model MY, and Model MZ. Only Model MX has a 6-inch screen,
+      but it has a single rear camera; models MY and MZ do not have a 6-inch screen. Hence,
+      our store does not sell a phone the user is looking for. I reached this conclusion
+      using only the information available in the document and in the user's question.
 
-- context: >
-    Document:
+  - context: >
+      Document:
 
-    Solar System Overview
+      Solar System Overview
 
-    The solar system has one star, eight planets, five dwarf planets, at least 290 moons,
-    more than 1.3 million asteroids, and about 3,900 comets. It is located in an outer
-    spiral arm of the Milky Way galaxy called the Orion Arm, or Orion Spur. Our solar
-    system orbits the center of the galaxy at about 515,000 mph (828,000 kph). It takes
-    about 230 million years to complete one orbit around the galactic center.
+      The solar system has one star, eight planets, five dwarf planets, at least 290 moons,
+      more than 1.3 million asteroids, and about 3,900 comets. It is located in an outer
+      spiral arm of the Milky Way galaxy called the Orion Arm, or Orion Spur. Our solar
+      system orbits the center of the galaxy at about 515,000 mph (828,000 kph). It takes
+      about 230 million years to complete one orbit around the galactic center.
 
-    We call it the solar system because it is made up of our star, the Sun, and everything
-    bound to it by gravity - the planets Mercury, Venus, Earth, Mars, Jupiter, Saturn,
-    Uranus, and Neptune; dwarf planets Pluto, Ceres, Makemake, Haumea, and Eris - along
-    with hundreds of moons; and millions of asteroids, comets, and meteoroids.
-  question: >
-    User asks the following question:
+      We call it the solar system because it is made up of our star, the Sun, and everything
+      bound to it by gravity - the planets Mercury, Venus, Earth, Mars, Jupiter, Saturn,
+      Uranus, and Neptune; dwarf planets Pluto, Ceres, Makemake, Haumea, and Eris - along
+      with hundreds of moons; and millions of asteroids, comets, and meteoroids.
+    question: >
+      User asks the following question:
 
-    "Does the solar system have two stars?"
+      "Does the solar system have two stars?"
 
-    As the responding agent, do you have enough information to provide a yes-or-no answer
-    to the user's question? Answer Yes or No, then explain your answer.
-  answer: >
-    Yes, I have enough information to provide a yes-or-no answer to the user's question.
-    Specifically, the answer to the user's question is "no". According to the document,
-    the solar system has only one star - the Sun, not two stars. I reached this
-    conclusion using only the information available in the document and in the user's
-    question.
+      As the responding agent, do you have enough information to provide a yes-or-no answer
+      to the user's question? Answer Yes or No, then explain your answer.
+    answer: >
+      Yes, I have enough information to provide a yes-or-no answer to the user's question.
+      Specifically, the answer to the user's question is "no". According to the document,
+      the solar system has only one star - the Sun, not two stars. I reached this
+      conclusion using only the information available in the document and in the user's
+      question.

--- a/scripts/test-data/compositional_skills/grounded/e2e-qna-grounded-punctuation-skill.yaml
+++ b/scripts/test-data/compositional_skills/grounded/e2e-qna-grounded-punctuation-skill.yaml
@@ -17,7 +17,7 @@ seed_examples:
       colonial Massachusetts. The target was the Tea Act of May 10 1773,
       which allowed the East India Company to sell tea from China in
       American colonies, without paying taxes apart from those imposed
-      by the Townshend Acts. The Sons of Liberty strongly opposed the 
+      by the Townshend Acts. The Sons of Liberty strongly opposed the
       taxes in the Townshend Act as a violation of their rights. In
       response the Sons of Liberty, some disguised as Native Americans
       destroyed an entire shipment of tea sent by the East India Company.

--- a/scripts/test-data/knowledge/e2e-qna-knowledge-mbta.yaml
+++ b/scripts/test-data/knowledge/e2e-qna-knowledge-mbta.yaml
@@ -218,7 +218,7 @@ document_outline: |
   Information about the MBTA including streetcar ear, MTA incorporation,
   bus expansion, debt concerns, and major incidents.
 document:
-    repo: https://github.com/juliadenham/Summit_knowledge
-    commit: 2e05aafd6aaee95b689b8a637aa0224793a8233e
-    patterns:
-      - mbta.md
+  repo: https://github.com/juliadenham/Summit_knowledge
+  commit: 2e05aafd6aaee95b689b8a637aa0224793a8233e
+  patterns:
+    - mbta.md

--- a/tox.ini
+++ b/tox.ini
@@ -105,6 +105,16 @@ commands =
     sh -c 'git diff --exit-code || (echo "pyproject.toml formatting is incorrect. Please run \"make toml-fmt\" and commit the changes." && exit 1)'
 allowlist_externals = make, sh
 
+[testenv:yamllint]
+description = lint and format YAML test files
+skip_install = true
+skipsdist = true
+deps =
+  yamllint>=1.35.1
+commands =
+  yamllint scripts/test-data/compositional_skills
+  yamllint scripts/test-data/knowledge
+
 [testenv:spellcheck]
 description = spell check (needs 'aspell' command)
 basepython = {[testenv:py3]basepython}


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #2824

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [x] E2E Workflow tests have been added, if necessary.

Some of the YAML test files I added cause the `ilab taxonomy diff` command to fail during the XL e2e tests due to formatting issues, so I've corrected the formatting.

Also: To avoid this issue in the future, I've also added a YAML linting stage to auto-detect YAML formatting issues for the `test-data` files.

I will create a follow-up PR to validate/standardize our other YAML files in the repo.