### PR TITLE
feat: support llama-cpp-python v0.3.2

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -123,7 +123,7 @@ jobs:
           nvidia-smi
           python3.11 -m pip cache remove llama_cpp_python
 
-          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install -v .
+          CMAKE_ARGS="-DGGML_CUDA=on" python3.11 -m pip install -v .
 
           # https://github.com/instructlab/instructlab/issues/1821
           # install with Torch and build dependencies installed

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -131,7 +131,7 @@ jobs:
           nvidia-smi
           python3.11 -m pip cache remove llama_cpp_python
 
-          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install -v .
+          CMAKE_ARGS="-DGGML_CUDA=on" python3.11 -m pip install -v .
 
           # https://github.com/instructlab/instructlab/issues/1821
           # install with Torch and build dependencies installed

--- a/.github/workflows/e2e-nvidia-l40s-x8.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x8.yml
@@ -131,7 +131,7 @@ jobs:
           nvidia-smi
           python3.11 -m pip cache remove llama_cpp_python
 
-          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install -v .
+          CMAKE_ARGS="-DGGML_CUDA=on" python3.11 -m pip install -v .
 
           # https://github.com/instructlab/instructlab/issues/1821
           # install with Torch and build dependencies installed

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -121,7 +121,7 @@ jobs:
           nvidia-smi
           python3.11 -m pip cache remove llama_cpp_python
 
-          CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install -v .
+          CMAKE_ARGS="-DGGML_CUDA=on" python3.11 -m pip install -v .
 
           # https://github.com/instructlab/instructlab/issues/1821
           # install with Torch and build dependencies installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Breaking Changes
 
+* llama-cpp-python has been bumped to 0.3.2. This allows for serving of Granite 3.0 GGUF Models. With this change, some previous handling of context window size has been modified to work with the 0.3.z releases of llama-cpp-python.
+
 ### Features
 
 * A new command `ilab model upload` has been introduced so users can now upload their trained models to [Hugging Face](https://huggingface.co/) via the `ilab` CLI

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
 
    ⚠️ The `python3` binary shown in the installation guides are the Python version that you installed in the above step. The command can also be `python3.11` or `python3.10` instead of `python3`. You can check Python's version by `python3 -V`.
 
-   ⏳ `pip install` may take some time, depending on your internet connection. In case the installation fails with error ``unsupported instruction `vpdpbusd'``, append `-C cmake.args="-DLLAMA_NATIVE=off"` to `pip install` command.
+   ⏳ `pip install` may take some time, depending on your internet connection. In case the installation fails with error ``unsupported instruction `vpdpbusd'``, append `-C cmake.args="-DGGML_NATIVE=off"` to `pip install` command.
 
    See [the GPU acceleration documentation](./docs/gpu-acceleration.md) for how to to enable hardware acceleration for interaction and training on AMD ROCm, Apple Metal Performance Shaders (MPS), and Nvidia CUDA.
 
@@ -149,9 +149,9 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
 
    *Additional Build Argument for Intel Macs*
    If you have a Mac with an Intel CPU, you must add a prefix of
-   `CMAKE_ARGS="-DLLAMA_METAL=off"` to the `pip install` command to ensure
+   `CMAKE_ARGS="-DGGML_METAL=off"` to the `pip install` command to ensure
    that the build is done without Apple M-series GPU support.
-   `(venv) $ CMAKE_ARGS="-DLLAMA_METAL=off" pip install ...`
+   `(venv) $ CMAKE_ARGS="-DGGML_METAL=off" pip install ...`
 
 #### Install with AMD ROCm
 
@@ -161,12 +161,12 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
    python3 -m venv --upgrade-deps venv
    source venv/bin/activate
    pip cache remove llama_cpp_python
-   CMAKE_ARGS="-DLLAMA_HIPBLAS=on \
+   CMAKE_ARGS="-DGGML_HIPBLAS=on \
       -DAMDGPU_TARGETS=all \
       -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
       -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
       -DCMAKE_PREFIX_PATH=/opt/rocm \
-      -DLLAMA_NATIVE=off" \
+      -DGGML_NATIVE=off" \
       pip install 'instructlab[rocm]' \
       --extra-index-url https://download.pytorch.org/whl/rocm6.0
    ```
@@ -181,7 +181,7 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
    python3 -m venv --upgrade-deps venv
    source venv/bin/activate
    pip cache remove llama_cpp_python
-   CMAKE_ARGS="-DLLAMA_CUDA=on -DLLAMA_NATIVE=off" pip install 'instructlab[cuda]'
+   CMAKE_ARGS="-DGGML_CUDA=on -DGGML_NATIVE=off" pip install 'instructlab[cuda]'
    pip install vllm@git+https://github.com/opendatahub-io/vllm@v0.6.2
    ```
 

--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -185,7 +185,7 @@ RUN source ${VIRTUAL_ENV}/bin/activate \
     fi \
     && pip install torch psutil \
     && pip install flash_attn --no-build-isolation \
-    && pip install "${INSTRUCTLAB_PKG}" -C cmake.args="-DLLAMA_CUDA=on" -C cmake.args="-DLLAMA_NATIVE=off" \
+    && pip install "${INSTRUCTLAB_PKG}" -C cmake.args="-DGGML_CUDA=on" -C cmake.args="-DGGML_NATIVE=off" \
     && pip install vllm@git+https://github.com/opendatahub-io/vllm@v0.6.2
 
 ENV TORCH_HOME="${VIRTUAL_ENV}/lib64/${PYTHON}/site-packages/torch"

--- a/containers/hpu/Containerfile
+++ b/containers/hpu/Containerfile
@@ -26,7 +26,7 @@ COPY containers/sitecustomize.py ${VIRTUAL_ENV}/lib/${PYTHON}/site-packages/
 COPY containers/bin/debug-* ${VIRTUAL_ENV}/bin/
 
 COPY . /tmp/instructlab
-RUN CMAKE_ARGS="-DLLAMA_NATIVE=off" \
+RUN CMAKE_ARGS="-DGGML_NATIVE=off" \
         ${VIRTUAL_ENV}/bin/pip install "/tmp/instructlab[hpu]" && \
     find ${VIRTUAL_ENV} -name __pycache__ | xargs rm -rf
 

--- a/containers/rocm/Containerfile
+++ b/containers/rocm/Containerfile
@@ -65,7 +65,7 @@ FROM pytorch AS llama
 RUN --mount=type=cache,sharing=locked,id=pipcache,target=${PIP_CACHE_DIR},mode=777,z \
     pip cache remove llama_cpp_python && \
     umask 0000 && \
-    CMAKE_ARGS="-DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER=/usr/bin/clang-${CLANG_VER} -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${CLANG_VER} -DAMDGPU_TARGETS=${AMDGPU_ARCH}" \
+    CMAKE_ARGS="-DGGML_HIPBLAS=on -DCMAKE_C_COMPILER=/usr/bin/clang-${CLANG_VER} -DCMAKE_CXX_COMPILER=/usr/bin/clang++-${CLANG_VER} -DAMDGPU_TARGETS=${AMDGPU_ARCH}" \
     FORCE_CMAKE=1 \
     ${VIRTUAL_ENV}/bin/pip install -c ${VIRTUAL_ENV}/constraints.txt llama-cpp-python
 

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -126,7 +126,7 @@ export PATH=$PATH:$CUDA_HOME/bin
 
 # Recompile llama-cpp-python using CUDA
 pip cache remove llama_cpp_python
-pip install --force-reinstall --no-deps llama_cpp_python==0.2.79 -C cmake.args="-DLLAMA_CUDA=on"
+pip install --force-reinstall --no-deps llama_cpp_python==0.2.79 -C cmake.args="-DGGML_CUDA=on"
 
 # Re-install InstructLab
 pip install ./instructlab[cuda]
@@ -139,7 +139,7 @@ supports GCC v14.1+.
 ```shell
 # Recompile llama-cpp-python using CUDA
 sudo dnf install clang17
-CUDAHOSTCXX=$(which clang++-17) pip install --force-reinstall llama_cpp_python==0.2.79 -C cmake.args="-DLLAMA_CUDA=on"
+CUDAHOSTCXX=$(which clang++-17) pip install --force-reinstall llama_cpp_python==0.2.79 -C cmake.args="-DGGML_CUDA=on"
 ```
 
 Proceed to the `Initialize` section of
@@ -221,14 +221,14 @@ we'll include that in our build command as follows:
 ```shell
 export PATH=/opt/rocm/llvm/bin:$PATH
 pip cache remove llama_cpp_python
-CMAKE_ARGS="-DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER='/opt/rocm/llvm/bin/clang' -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ -DCMAKE_PREFIX_PATH=/opt/rocm -DAMDGPU_TARGETS=gfx1100" FORCE_CMAKE=1 pip install --force-reinstall llama_cpp_python==0.2.79
+CMAKE_ARGS="-DGGML_HIPBLAS=on -DCMAKE_C_COMPILER='/opt/rocm/llvm/bin/clang' -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ -DCMAKE_PREFIX_PATH=/opt/rocm -DAMDGPU_TARGETS=gfx1100" FORCE_CMAKE=1 pip install --force-reinstall llama_cpp_python==0.2.79
 ```
 
 > **Note:** This is explicitly forcing the build to use the ROCm compilers and
 > prefix path for dependency resolution in the CMake build.  This works around
 > an issue in the CMake and ROCm version in Fedora 39 and below and is fixed in
 > Fedora 40.  With Fedora 40's ROCm packages, use
-> `CMAKE_ARGS="-DLLAMA_HIPBLAS=on -DCMAKE_C_COMPILER=/usr/bin/clang
+> `CMAKE_ARGS="-DGGML_HIPBLAS=on -DCMAKE_C_COMPILER=/usr/bin/clang
 > -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DAMDGPU_TARGETS=gfx1100"` instead.
 
 Once that package is installed, recompile `ilab` with `pip install .[rocm]`.  You also
@@ -269,7 +269,7 @@ add a few options to ensure it gets installed over the existing package:
 
 ```shell
 pip cache remove llama_cpp_python
-pip install --force-reinstall llama_cpp_python==0.2.79 -C cmake.args="-DLLAMA_METAL=on"
+pip install --force-reinstall llama_cpp_python==0.2.79 -C cmake.args="-DGGML_METAL=on"
 ```
 
 Once that package is installed, recompile `ilab` with `pip install .[mps]` and skip

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ instructlab-quantize>=0.1.0
 instructlab-schema>=0.4.0
 instructlab-sdg>=0.6.2
 instructlab-training>=0.6.0
-llama_cpp_python[server]==0.2.79
+llama_cpp_python[server]==0.3.2
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 numpy>=1.26.4,<2.0.0
 openai>=1.13.3

--- a/scripts/infra/cloud-instance.sh
+++ b/scripts/infra/cloud-instance.sh
@@ -300,7 +300,7 @@ pip_install_with_nvidia() {
 pip_install_with_amd() {
     "${BASH_SOURCE[0]}" "$CLOUD_TYPE" ssh -n "$INSTANCE_NAME" "pushd instructlab && source venv/bin/activate && pip cache remove llama_cpp_python && \
     pip install -e .[rocm] --extra-index-url https://download.pytorch.org/whl/rocm6.0 \
-   -C cmake.args='-DLLAMA_HIPBLAS=on' \
+   -C cmake.args='-DGGML_HIPBLAS=on' \
    -C cmake.args='-DAMDGPU_TARGETS=all' \
    -C cmake.args='-DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang' \
    -C cmake.args='-DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++' \

--- a/src/instructlab/cli/model/serve.py
+++ b/src/instructlab/cli/model/serve.py
@@ -10,6 +10,8 @@ import click
 
 # First Party
 from instructlab import clickext
+from instructlab.configuration import write_config
+from instructlab.defaults import DEFAULTS
 from instructlab.model.backends import backends
 from instructlab.model.serve_backend import serve_backend, signal_handler
 
@@ -116,6 +118,14 @@ def serve(
     """Starts a local server"""
 
     warn_for_unsupported_backend_param(ctx)
+
+    # we need to keep track of the max_ctx_size being uses in the active server so we don't overflow the context
+    if max_ctx_size != DEFAULTS.MAX_CONTEXT_SIZE:
+        logger.info(
+            f"Setting current_max_ctx_size in the serve config to {max_ctx_size}"
+        )
+        ctx.obj.config.serve.server.current_max_ctx_size = max_ctx_size
+        write_config(ctx.obj.config)
 
     serve_backend(
         ctx,

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -8,6 +8,7 @@ import httpx
 
 ILAB_PACKAGE_NAME = "instructlab"
 CONFIG_FILENAME = "config.yaml"
+CONFIG_LOCK_FILENAME = "config.yaml.lock"
 CONFIG_VERSION = "1.0.0"
 
 # Model families understood by ilab
@@ -127,6 +128,10 @@ class _InstructlabDefaults:
     @property
     def CONFIG_FILE(self) -> str:
         return path.join(self._config_dir, CONFIG_FILENAME)
+
+    @property
+    def CONFIG_FILE_LOCK(self) -> str:
+        return path.join(self._config_dir, CONFIG_LOCK_FILENAME)
 
     @property
     def MODELS_DIR(self) -> str:

--- a/src/instructlab/model/serve_backend.py
+++ b/src/instructlab/model/serve_backend.py
@@ -7,6 +7,7 @@ import sys
 
 # First Party
 from instructlab import log
+from instructlab.configuration import write_config
 from instructlab.model.backends import backends
 from instructlab.model.backends.common import ServerException
 from instructlab.model.backends.server import BackendServer
@@ -50,6 +51,9 @@ def serve_backend(
     except (ValueError, AttributeError) as e:
         raise ValueError(f"Failed to determine backend: {e}") from e
 
+    logger.info(f"Setting current_max_ctx_size in the serve config to {max_ctx_size}")
+    ctx.obj.config.serve.server.backend_type = backend
+    write_config(ctx.obj.config)
     if chat_template is None:
         chat_template = ctx.obj.config.serve.chat_template
 

--- a/src/instructlab/taxonomy/diff.py
+++ b/src/instructlab/taxonomy/diff.py
@@ -77,6 +77,8 @@ def diff(ctx, taxonomy_path, taxonomy_base, yaml_rules, quiet):
                     )
                     raise SystemExit(1) from exc
             for f in taxonomy_files:
+                if f is None:
+                    continue
                 click.echo(f)
 
     # validate new or changed taxonomy files

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -341,20 +341,19 @@ def test_logging(log_level, debug_level, root, instructlab, openai_httpx):
 @patch.multiple(
     config.DEFAULTS,
     _cache_home="/cache/instructlab",
-    _config_dir="/config/instructlab",
     _data_dir="/data/instructlab",
 )
 def test_compare_default_config_testdata(
-    testdata_path: pathlib.Path, tmp_path: pathlib.Path, regenerate_testdata: bool
+    testdata_path: pathlib.Path, regenerate_testdata: bool
 ):
     assert config.DEFAULTS.CHECKPOINTS_DIR == "/data/instructlab/checkpoints"
     saved_file = testdata_path / "default_config.yaml"
-    current_file = tmp_path / "current_config.yaml"
+    current_file = os.path.join(config.DEFAULTS._config_dir, "current_config.yaml")
 
     current_cfg = config.get_default_config()
     # roundtrip to verify serialization and de-serialization
     config.write_config(current_cfg, str(current_file))
-    with current_file.open(encoding="utf-8") as yamlfile:
+    with open(file=current_file, encoding="utf-8") as yamlfile:
         current_content = yaml.safe_load(yamlfile)
 
     if regenerate_testdata:

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -170,8 +170,17 @@ generate:
     # Default: /cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
     model_path: /cache/instructlab/models/mistral-7b-instruct-v0.2.Q4_K_M.gguf
     # Server configuration including host and port.
-    # Default: host='127.0.0.1' port=8000
+    # Default: host='127.0.0.1' port=8000 backend_type='' current_max_ctx_size=4096
     server:
+      # Backend Instance Type
+      # Default: ''
+      # Examples:
+      #   - llama-cpp
+      #   - vllm
+      backend_type: ''
+      # Maximum number of tokens that can be processed by the currently served model.
+      # Default: 4096
+      current_max_ctx_size: 4096
       # Host to serve on.
       # Default: 127.0.0.1
       host: 127.0.0.1
@@ -251,8 +260,17 @@ serve:
   # Default: /cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
   model_path: /cache/instructlab/models/granite-7b-lab-Q4_K_M.gguf
   # Server configuration including host and port.
-  # Default: host='127.0.0.1' port=8000
+  # Default: host='127.0.0.1' port=8000 backend_type='' current_max_ctx_size=4096
   server:
+    # Backend Instance Type
+    # Default: ''
+    # Examples:
+    #   - llama-cpp
+    #   - vllm
+    backend_type: ''
+    # Maximum number of tokens that can be processed by the currently served model.
+    # Default: 4096
+    current_max_ctx_size: 4096
     # Host to serve on.
     # Default: 127.0.0.1
     host: 127.0.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ passenv =
 # are huge. This reduces venv from 5.7 GB to 1.5 GB.
 setenv =
     PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
-    CMAKE_ARGS={env:CMAKE_ARGS:-DLLAMA_NATIVE=off}
+    CMAKE_ARGS={env:CMAKE_ARGS:-DGGML_NATIVE=off}
     ILAB_MAX_STABLE_VRAM_WAIT=0
 package = wheel
 wheel_build_env = pkg


### PR DESCRIPTION
version 0.3.5 of llama-cpp-python has a known issue https://github.com/abetlen/llama-cpp-python/issues/1861 version 0.3.2 has granite 3.0 support and does not have this issue. Bump to this version

this required some additions to how we handle chat exceptions. As of these newer 0.3.z llama-cpp-python versions,
a bad request causes the server to die. This requires us to know the max_ctx_size of the server before passing a completions request so that
we can maintain the behavior of trimming messages until we can respond to one that fits.

in order to do this, the config now contains a `current_max_ctx_size` field that we will update when spinning up a server.
in the case that a user implicitly starts a llama-cpp-python server when calling `ilab model chat`, we set the max_tokens to the
current `max_ctx_size` in the serve config.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
