### PR TITLE
ci: bump number of epochs for XL E2E job

### DIFF
--- a/scripts/test-data/profile-l40s-x8.yaml
+++ b/scripts/test-data/profile-l40s-x8.yaml
@@ -119,15 +119,15 @@ train:
   max_batch_len: 30000
   max_seq_len: 4096
   model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
-  num_epochs: 4
+  num_epochs: 7
   save_samples: 1000
   is_padding_free: true
   nproc_per_node: 8
   phased_phase1_effective_batch_size: 32
-  phased_phase1_num_epochs: 4
+  phased_phase1_num_epochs: 7
   phased_phase1_samples_per_save: 0
   phased_phase2_effective_batch_size: 32
-  phased_phase2_num_epochs: 4
+  phased_phase2_num_epochs: 7
   phased_phase2_samples_per_save: 0
   distributed_backend: fsdp
   pipeline: accelerated


### PR DESCRIPTION
As noted in https://github.com/instructlab/instructlab/issues/2776#issuecomment-2557424247 using 4 epochs in the XL E2E job results in less than a 4 hour run time - given this is designed to be a nightly job we can increase the number of epochs to allow for more realistic testing while still generated results in a reasonable timeframe.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
