### PR TITLE
add skip-server option for evaluate

### DIFF
--- a/src/instructlab/cli/model/evaluate.py
+++ b/src/instructlab/cli/model/evaluate.py
@@ -135,6 +135,11 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     help="Print serving engine logs.",
 )
+@click.option(
+    "--skip-server",
+    is_flag=True,
+    help="Skip launching the server and evaluate directly with the HuggingFace model. This option supports mmlu and mmlu_branch benchmarks.",
+)
 @click.pass_context
 @clickext.display_params
 def evaluate(
@@ -160,6 +165,7 @@ def evaluate(
     tls_client_key,  # pylint: disable=unused-argument
     tls_client_passwd,  # pylint: disable=unused-argument
     enable_serving_output,
+    skip_server: bool,
 ) -> None:
     """Evaluates a trained model"""
     try:
@@ -186,6 +192,7 @@ def evaluate(
             tls_client_key,
             tls_client_passwd,
             enable_serving_output,
+            skip_server,
         )
     except Exception as e:
         logger.error(f"An error occurred during evaluation: {str(e)}")

--- a/tests/test_lab_evaluate.py
+++ b/tests/test_lab_evaluate.py
@@ -276,12 +276,12 @@ def test_evaluate_mt_bench_branch(
     assert validate_model_mock.call_count == 3
     assert judge_answers_mock.call_count == 2
     assert gen_answers_mock.call_count == 2
-    assert launch_server_mock.call_count == 3
+    assert launch_server_mock.call_count == 4
     run_mt_bench_branch(cli_runner, 0.4567)
     assert validate_model_mock.call_count == 6
     assert judge_answers_mock.call_count == 4
     assert gen_answers_mock.call_count == 4
-    assert launch_server_mock.call_count == 6
+    assert launch_server_mock.call_count == 8
 
 
 @patch("instructlab.model.evaluate.validate_model")


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

Resolves https://github.com/instructlab/instructlab/issues/2777

1. add new option
```
$ ilab model evaluate --help
Usage: ilab model evaluate [OPTIONS]
  -ss, --skip-server              Skip launching the server and evaluate
                                  directly with the HuggingFace model. This
                                  option supports mmlu and mmlu_branch
                                  benchmarks.
```
2. refactor the launch_server request duplicate parts

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
