### PR TITLE
fix is_taxonomy_file and get_taxonomy_diff type issue

### DIFF
--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -233,10 +233,12 @@ def get_taxonomy_diff(
     modified_files = [
         d.b_path
         for d in head_commit.diff(None)
-        if not d.deleted_file and is_taxonomy_file(d.b_path)
+        if d.b_path is not None and not d.deleted_file and is_taxonomy_file(d.b_path)
     ]
 
-    updated_taxonomy_files = list(set(untracked_files + modified_files))
+    updated_taxonomy_files = list(
+        {f for f in untracked_files + modified_files if f is not None}
+    )
     return updated_taxonomy_files
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
