### PR TITLE
chore: Increase the number of epochs from 4 to 6 in the XL e2e job

### DIFF
--- a/scripts/test-data/profile-l40s-x8.yaml
+++ b/scripts/test-data/profile-l40s-x8.yaml
@@ -119,15 +119,15 @@ train:
   max_batch_len: 30000
   max_seq_len: 4096
   model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
-  num_epochs: 4
+  num_epochs: 6
   save_samples: 1000
   is_padding_free: true
   nproc_per_node: 8
   phased_phase1_effective_batch_size: 32
-  phased_phase1_num_epochs: 4
+  phased_phase1_num_epochs: 6
   phased_phase1_samples_per_save: 0
   phased_phase2_effective_batch_size: 32
-  phased_phase2_num_epochs: 4
+  phased_phase2_num_epochs: 6
   phased_phase2_samples_per_save: 0
   distributed_backend: fsdp
   pipeline: accelerated


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #2776

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.

TESTING:

This PR aims to update the number of epochs in the XL e2e job from 4 to 6, and is a follow-up PR to #2743, which created the initial XL e2e job. Please see referenced issue for more information.

This is just testing what happens if we use 6.