### PR TITLE
chore!: Update PyTorch to 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * A new command `ilab model upload` has been introduced so users can now upload their trained models to [Hugging Face](https://huggingface.co/) via the `ilab` CLI
 * `ilab model serve` now has separate `--host` and `--port` options, replacing the `host_port` configuration. The default values are `127.0.0.1` for `--host` and `8000` for `--port`, allowing users to configure the server's binding address and port independently through the configuration file or command-line flags.
+* Extends PyTorch support to version 2.5
 
 ## v0.22
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ sentencepiece>=0.2.0
 tokenizers>=0.11.1
 toml>=0.10.2
 # Default version. Can be overridden in extra requirements
-torch>=2.3.0,<2.5.0
+torch>=2.3.0,<2.6.0
 tqdm>=4.66.2
 # 'optimum' for Intel Gaudi needs transformers <4.44.0,>=4.43.0
 transformers>=4.41.2

--- a/scripts/infra/cloud-instance.sh
+++ b/scripts/infra/cloud-instance.sh
@@ -299,7 +299,7 @@ pip_install_with_nvidia() {
 
 pip_install_with_amd() {
     "${BASH_SOURCE[0]}" "$CLOUD_TYPE" ssh -n "$INSTANCE_NAME" "pushd instructlab && source venv/bin/activate && pip cache remove llama_cpp_python && \
-    pip install -e .[rocm] --extra-index-url https://download.pytorch.org/whl/rocm6.0 \
+    pip install -e .[rocm] --extra-index-url https://download.pytorch.org/whl/rocm6.2 \
    -C cmake.args='-DGGML_HIPBLAS=on' \
    -C cmake.args='-DAMDGPU_TARGETS=all' \
    -C cmake.args='-DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang' \


### PR DESCRIPTION
This change increases the upper version of PyTorch to allow version 2.5. For the AMD variant, it also switches to ROCm 6.2, which is required for PyTorch 2.5.

Resolves #2864