### PR TITLE
fix: Change temporary write directory in all e2e CI jobs from `tmpfs` to `/home/tmp`

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -29,6 +29,7 @@ concurrency:
 
 env:
   LC_ALL: en_US.UTF-8
+  TMPDIR: /home/tmp
 
 defaults:
   run:
@@ -99,6 +100,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
+          mkdir -p /home/tmp
           sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
 
       - name: Checkout

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -12,6 +12,9 @@ on:
         required: true
         default: 'main'
 
+env:
+  TMPDIR: /home/tmp
+
 jobs:
   start-large-ec2-runner:
     runs-on: ubuntu-latest
@@ -57,6 +60,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
+          mkdir -p /home/tmp
           sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
 
       - name: Checkout

--- a/.github/workflows/e2e-nvidia-l40s-x8.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x8.yml
@@ -12,6 +12,9 @@ on:
         required: true
         default: 'main'
 
+env:
+  TMPDIR: /home/tmp
+
 jobs:
   start-xlarge-ec2-runner:
     runs-on: ubuntu-latest
@@ -57,6 +60,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
+          mkdir -p /home/tmp
           sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
 
       - name: Checkout

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -29,6 +29,7 @@ concurrency:
 
 env:
   LC_ALL: en_US.UTF-8
+  TMPDIR: /home/tmp
 
 defaults:
   run:
@@ -99,6 +100,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
+          mkdir -p /home/tmp
           sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
 
       - name: Checkout


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #2866

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.

Keep in mind that while PR _does_ resolve #2866, which only mentions the medium e2e job having OOM issues, we have started to see OOM issues in the large e2e jobs this morning under certain conditions. So as a preventative measure, I've updated all default temporary write directories from `/tmp` to `/home/tmp`.

Also note: In order to successfully test these workflow changes in a pull request, I had to temporarily modify the trigger conditions in the workflow files. I've since reverted those trigger conditions, so you don't see the changes in this PR reflected in the current logging.

Original line of code that I have since removed:
https://github.com/instructlab/instructlab/commit/ae08713cbb44bd70786b5e8f2719413bc8719701#diff-f84f57a944419bb3920eea214c71890696e3d711cf15fcdcde1bb0e3bcbe5737R11

Here is the previous run from the same medium e2e job when I had the temporary trigger conditions in place: https://github.com/instructlab/instructlab/actions/runs/12677138707/job/35331915188

You can confirm by viewing the "Install Packages" and "Run e2e test" steps under the `e2e-medium-test` job linked above. You will see things like:
<img width="586" alt="Screenshot 2025-01-08 at 4 13 04 PM" src="https://github.com/user-attachments/assets/e90d8e43-da52-4e59-912f-8a319e4b778a" />
<img width="586" alt="Screenshot 2025-01-08 at 4 13 15 PM" src="https://github.com/user-attachments/assets/ccc97188-fd88-4ba1-a24c-ff73b7dfebe7" />
<img width="716" alt="Screenshot 2025-01-08 at 4 13 31 PM" src="https://github.com/user-attachments/assets/1e567366-966b-4c72-9dab-e1f9133b23a2" />

^ which includes my `/home/tmp` changes.

See rest of logs for more details