### PR TITLE
Update vLLM to 0.6.6.post1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.24
+
+### Breaking Changes
+
+### Features
+
+- Update vLLM to version 0.6.6.post1. As a requirement for this new vLLM version, PyTorch is updated to 2.5.1
+
 ## v0.23
 
 ### Breaking Changes

--- a/requirements-vllm-cuda.txt
+++ b/requirements-vllm-cuda.txt
@@ -2,4 +2,4 @@
 # Dependencies for installing vLLM on CUDA
 
 # vLLM only supports Linux platform (including WSL)
-vllm @git+https://github.com/opendatahub-io/vllm@v0.6.4.post1 ; sys_platform == 'linux' and platform_machine == 'x86_64'
+vllm @git+https://github.com/opendatahub-io/vllm@v0.6.6.post1 ; sys_platform == 'linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
This PR is a follow-up to #2865 that relaxed the PyTorch version range. Even with that range extension, we realized that PyTorch 2.4 is still used when installing `instructlab[vllm-cuda]`, because vLLM 0.6.2 has a requirement on PyTorch 2.4.

This new PR updates the version of vLLM to 0.6.6.post1, which is the latest available in the Open Data Hub fork of vLLM. The vLLM changelog doesn't highlight much risk in this version bump.

Resolves #2702