### PR TITLE
chore!: Update vLLM to 0.6.4.post1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - A new command `ilab model upload` has been introduced so users can now upload their trained models to [Hugging Face](https://huggingface.co/) and OCI registry endpoints via the `ilab` CLI
 - `ilab model serve` now has separate `--host` and `--port` options, replacing the `host_port` configuration. The default values are `127.0.0.1` for `--host` and `8000` for `--port`, allowing users to configure the server's binding address and port independently through the configuration file or command-line flags.
-- Extends PyTorch support to version 2.5
+- Update vLLM to version 0.6.4.post1. As a requirement for this new vLLM version, PyTorch is updated to 2.5.1
 - `--disable-accelerate-full-state-at-epoch` added for accelerated training. With this option only HuggingFace checkpoints are saved which are required for multi-phase training. However, if set this switch also disables resumeable training because "full resumeability" requires full-state checkpoints. This option should be used if storage is limited and/or resumeability isn't required.
 
 ## v0.22

--- a/requirements-vllm-cuda.txt
+++ b/requirements-vllm-cuda.txt
@@ -2,4 +2,4 @@
 # Dependencies for installing vLLM on CUDA
 
 # vLLM only supports Linux platform (including WSL)
-vllm @git+https://github.com/opendatahub-io/vllm@v0.6.2 ; sys_platform == 'linux' and platform_machine == 'x86_64'
+vllm @git+https://github.com/opendatahub-io/vllm@v0.6.4.post1 ; sys_platform == 'linux' and platform_machine == 'x86_64'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ httpx>=0.25.0
 instructlab-eval>=0.4.2
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.4.0
-instructlab-sdg>=0.6.2
+instructlab-sdg>=0.6.3
 instructlab-training>=0.6.0
 llama_cpp_python[server]==0.3.2
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'


### PR DESCRIPTION
As an intermediate step to updating vLLM to 0.6.6.post1 in #2892, this pull request updates vLLM to 0.6.4.post1 to ensure that the CI tests succeed with this version too.