### PR TITLE
feat: add RTX 30 and 40 Series System Profiles

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -307,9 +307,16 @@ def walk_and_print_system_profiles(
     # if auto detection didn't work, just continue prompting as usual!
     key = prompt_user_to_choose_vendors(arch_family_processors)
 
+    list_of_gpus = []
+
     if key is not None:
-        for i, arch_family_processor in enumerate(arch_family_processors[key], start=1):
-            click.echo(f"[{i}] {' '.join(map(str, arch_family_processor[0])).upper()}")
+        for arch_family_processor in sorted(arch_family_processors[key]):
+            list_of_gpus.append(
+                f"{' '.join(map(str, arch_family_processor[0])).upper()}"
+            )
+
+        for i, gpu in enumerate(sorted(list_of_gpus), start=1):
+            click.echo(f"[{i}] {gpu}")
         # pass the specific manufacturer specific list of tuples containing config names
         cfg = prompt_user_to_choose_profile(arch_family_processors[key])
     return cfg

--- a/src/instructlab/profiles/nvidia/rtx/30/3060.yaml
+++ b/src/instructlab/profiles/nvidia/rtx/30/3060.yaml
@@ -1,0 +1,156 @@
+chat:
+  context: default
+  # Directory where chat logs are stored
+  logs_dir: ~/.local/share/instructlab/chatlogs
+  # The maximum number of tokens that can be generated in the chat completion
+  max_tokens: null
+  # Directory where model to be used for chatting with is stored
+  model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  session: null
+  # visual mode
+  vi_mode: false
+  # renders vertical overflow if enabled, displays ellipses otherwise
+  visible_overflow: true
+evaluate:
+  # Base taxonomy branch
+  base_branch: null
+  # Directory where the model to be evaluated is stored
+  base_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # Taxonomy branch containing custom skills/knowledge that should be used for evaluation runs
+  branch: null
+  # Number of GPUs to use for running evaluation
+  gpus: 1
+  # MMLU benchmarking settings
+  mmlu:
+    # batch size for evaluation.
+    # Valid values are a positive integer or 'auto' to select the largest batch size that will fit in memory
+    batch_size: auto
+    # number of question-answer pairs provided in the context preceding the question used for evaluation
+    few_shots: 5
+  # Settings to run MMLU against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mmlu_branch:
+    # Directory where custom MMLU tasks are stored
+    tasks_dir: ~/.local/share/instructlab/datasets
+  model: null
+  # multi-turn benchmarking settings for skills
+  mt_bench:
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+    max_workers: auto
+    # Directory where evaluation results are stored
+    output_dir: ~/.local/share/instructlab/internal/eval_data
+  # Settings to run MT-Bench against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mt_bench_branch:
+    # Path to where base taxonomy is stored
+    taxonomy_path: ~/.local/share/instructlab/taxonomy
+general:
+  debug_level: 0
+  log_level: INFO
+generate:
+  # maximum number of words per chunk
+  chunk_word_count: 1000
+  # Teacher model that will be used to synthetically generate training data
+  model: ~/.cache/instructlab/models/mixtral-8x7b-instruct-v0-1
+  # Number of CPU cores to use for generation
+  num_cpus: 10
+  # Directory where generated datasets are stored
+  output_dir: ~/.local/share/instructlab/datasets
+  # Directory where pipeline config files are stored
+  pipeline: /usr/share/instructlab/sdg/pipelines/agentic
+  # Path to prompt file to be used for generation
+  prompt_file: ~/.local/share/instructlab/internal/prompt.txt
+  # The total number of instructions to be generated
+  sdg_scale_factor: 30
+  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
+  # Branch of taxonomy used to calculate diff against
+  taxonomy_base: empty
+  # Directory where taxonomy is stored and accessed from
+  taxonomy_path: ~/.local/share/instructlab/taxonomy
+  # Teacher model specific settings
+  teacher:
+    # Serving backend to use to host the teacher model
+    backend: vllm
+    # Chat template to supply to the teacher model. Possible values:
+    #   - Custom chat template string
+    #   - Auto: Uses default for serving backend
+    chat_template: 'tokenizer'
+    # host and port where teacher model is being served
+    host_port: 127.0.0.1:8000
+    # Llamacpp serving settings
+    llama_cpp:
+      # number of model layers to offload to GPU
+      # -1 means all
+      gpu_layers: -1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: ''
+      # maximum number of tokens that can be processed by the model
+      max_ctx_size: 4096
+    # Path to teacher model that will be used to synthetically generate training data
+    model_path: ~/.cache/instructlab/models/TheBloke/Mistral-7B-Instruct-v0.2-GPTQ
+    # vLLM serving settings
+    vllm:
+      # number of GPUs to allocate to vLLM
+      gpus: 1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: 'mixtral'
+serve:
+  # Serving backend to use to host the model
+  backend: vllm
+  # Chat template to supply to the served model. Possible values:
+  #   - Custom chat template string
+  #   - Auto: Uses default for serving backend
+  chat_template: auto
+  # host and port where the model is being served
+  host_port: 127.0.0.1:8000
+  # Llamacpp serving settings
+  llama_cpp:
+    # number of model layers to offload to GPU
+    # -1 means all
+    gpu_layers: -1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # maximum number of tokens that can be processed by the model
+    max_ctx_size: 4096
+  # Path to model that will be served for inference
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # vLLM serving settings
+  vllm:
+    gpus: 1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # additional arguments to be supplied directly to vLLM
+    vllm_args: ["--tensor-parallel-size", "1"]
+train:
+  additional_args:
+    learning_rate: 2e-5
+    lora_alpha: 32
+    lora_dropout: 0.1
+    warmup_steps: 25
+    use_dolomite: true
+  device: cuda
+  pipeline: accelerated
+  ckpt_output_dir: ~/.local/share/instructlab/checkpoints
+  data_output_dir: ~/.local/share/instructlab/internal
+  data_path: ~/.local/share/instructlab/datasets
+  effective_batch_size: 128
+  is_padding_free: false
+  lora_quantize_dtype: null
+  lora_rank: 0
+  max_batch_len: 10000
+  max_seq_len: 4096
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  nproc_per_node: 1
+  num_epochs: 8
+  phased_mt_bench_judge: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  phased_phase1_num_epochs: 7
+  phased_phase2_num_epochs: 10
+  checkpoint_at_epoch: true
+  save_samples: 0
+metadata:
+  gpu_manufacturer: Nvidia
+  gpu_family: GeForce RTX 3060
+  gpu_count: 1
+  gpu_sku: [Ti, Laptop GPU, Ti Laptop GPU, Laptop GPU]
+version: 1.0.0

--- a/src/instructlab/profiles/nvidia/rtx/30/3070.yaml
+++ b/src/instructlab/profiles/nvidia/rtx/30/3070.yaml
@@ -1,0 +1,156 @@
+chat:
+  context: default
+  # Directory where chat logs are stored
+  logs_dir: ~/.local/share/instructlab/chatlogs
+  # The maximum number of tokens that can be generated in the chat completion
+  max_tokens: null
+  # Directory where model to be used for chatting with is stored
+  model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  session: null
+  # visual mode
+  vi_mode: false
+  # renders vertical overflow if enabled, displays ellipses otherwise
+  visible_overflow: true
+evaluate:
+  # Base taxonomy branch
+  base_branch: null
+  # Directory where the model to be evaluated is stored
+  base_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # Taxonomy branch containing custom skills/knowledge that should be used for evaluation runs
+  branch: null
+  # Number of GPUs to use for running evaluation
+  gpus: 1
+  # MMLU benchmarking settings
+  mmlu:
+    # batch size for evaluation.
+    # Valid values are a positive integer or 'auto' to select the largest batch size that will fit in memory
+    batch_size: auto
+    # number of question-answer pairs provided in the context preceding the question used for evaluation
+    few_shots: 5
+  # Settings to run MMLU against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mmlu_branch:
+    # Directory where custom MMLU tasks are stored
+    tasks_dir: ~/.local/share/instructlab/datasets
+  model: null
+  # multi-turn benchmarking settings for skills
+  mt_bench:
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+    max_workers: auto
+    # Directory where evaluation results are stored
+    output_dir: ~/.local/share/instructlab/internal/eval_data
+  # Settings to run MT-Bench against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mt_bench_branch:
+    # Path to where base taxonomy is stored
+    taxonomy_path: ~/.local/share/instructlab/taxonomy
+general:
+  debug_level: 0
+  log_level: INFO
+generate:
+  # maximum number of words per chunk
+  chunk_word_count: 1000
+  # Teacher model that will be used to synthetically generate training data
+  model: ~/.cache/instructlab/models/mixtral-8x7b-instruct-v0-1
+  # Number of CPU cores to use for generation
+  num_cpus: 10
+  # Directory where generated datasets are stored
+  output_dir: ~/.local/share/instructlab/datasets
+  # Directory where pipeline config files are stored
+  pipeline: /usr/share/instructlab/sdg/pipelines/agentic
+  # Path to prompt file to be used for generation
+  prompt_file: ~/.local/share/instructlab/internal/prompt.txt
+  # The total number of instructions to be generated
+  sdg_scale_factor: 30
+  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
+  # Branch of taxonomy used to calculate diff against
+  taxonomy_base: empty
+  # Directory where taxonomy is stored and accessed from
+  taxonomy_path: ~/.local/share/instructlab/taxonomy
+  # Teacher model specific settings
+  teacher:
+    # Serving backend to use to host the teacher model
+    backend: vllm
+    # Chat template to supply to the teacher model. Possible values:
+    #   - Custom chat template string
+    #   - Auto: Uses default for serving backend
+    chat_template: 'tokenizer'
+    # host and port where teacher model is being served
+    host_port: 127.0.0.1:8000
+    # Llamacpp serving settings
+    llama_cpp:
+      # number of model layers to offload to GPU
+      # -1 means all
+      gpu_layers: -1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: ''
+      # maximum number of tokens that can be processed by the model
+      max_ctx_size: 4096
+    # Path to teacher model that will be used to synthetically generate training data
+    model_path: ~/.cache/instructlab/models/TheBloke/Mistral-7B-Instruct-v0.2-GPTQ
+    # vLLM serving settings
+    vllm:
+      # number of GPUs to allocate to vLLM
+      gpus: 1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: 'mixtral'
+serve:
+  # Serving backend to use to host the model
+  backend: vllm
+  # Chat template to supply to the served model. Possible values:
+  #   - Custom chat template string
+  #   - Auto: Uses default for serving backend
+  chat_template: auto
+  # host and port where the model is being served
+  host_port: 127.0.0.1:8000
+  # Llamacpp serving settings
+  llama_cpp:
+    # number of model layers to offload to GPU
+    # -1 means all
+    gpu_layers: -1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # maximum number of tokens that can be processed by the model
+    max_ctx_size: 4096
+  # Path to model that will be served for inference
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # vLLM serving settings
+  vllm:
+    gpus: 1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # additional arguments to be supplied directly to vLLM
+    vllm_args: ["--tensor-parallel-size", "1"]
+train:
+  additional_args:
+    learning_rate: 2e-5
+    lora_alpha: 32
+    lora_dropout: 0.1
+    warmup_steps: 25
+    use_dolomite: true
+  device: cuda
+  pipeline: accelerated
+  ckpt_output_dir: ~/.local/share/instructlab/checkpoints
+  data_output_dir: ~/.local/share/instructlab/internal
+  data_path: ~/.local/share/instructlab/datasets
+  effective_batch_size: 128
+  is_padding_free: false
+  lora_quantize_dtype: null
+  lora_rank: 0
+  max_batch_len: 10000
+  max_seq_len: 4096
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  nproc_per_node: 1
+  num_epochs: 8
+  phased_mt_bench_judge: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  phased_phase1_num_epochs: 7
+  phased_phase2_num_epochs: 10
+  checkpoint_at_epoch: true
+  save_samples: 0
+metadata:
+  gpu_manufacturer: Nvidia
+  gpu_family: GeForce RTX 3070
+  gpu_count: 1
+  gpu_sku: [Ti, Laptop GPU, Ti Laptop GPU, Laptop GPU]
+version: 1.0.0

--- a/src/instructlab/profiles/nvidia/rtx/30/3080.yaml
+++ b/src/instructlab/profiles/nvidia/rtx/30/3080.yaml
@@ -1,0 +1,156 @@
+chat:
+  context: default
+  # Directory where chat logs are stored
+  logs_dir: ~/.local/share/instructlab/chatlogs
+  # The maximum number of tokens that can be generated in the chat completion
+  max_tokens: null
+  # Directory where model to be used for chatting with is stored
+  model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  session: null
+  # visual mode
+  vi_mode: false
+  # renders vertical overflow if enabled, displays ellipses otherwise
+  visible_overflow: true
+evaluate:
+  # Base taxonomy branch
+  base_branch: null
+  # Directory where the model to be evaluated is stored
+  base_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # Taxonomy branch containing custom skills/knowledge that should be used for evaluation runs
+  branch: null
+  # Number of GPUs to use for running evaluation
+  gpus: 1
+  # MMLU benchmarking settings
+  mmlu:
+    # batch size for evaluation.
+    # Valid values are a positive integer or 'auto' to select the largest batch size that will fit in memory
+    batch_size: auto
+    # number of question-answer pairs provided in the context preceding the question used for evaluation
+    few_shots: 5
+  # Settings to run MMLU against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mmlu_branch:
+    # Directory where custom MMLU tasks are stored
+    tasks_dir: ~/.local/share/instructlab/datasets
+  model: null
+  # multi-turn benchmarking settings for skills
+  mt_bench:
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+    max_workers: auto
+    # Directory where evaluation results are stored
+    output_dir: ~/.local/share/instructlab/internal/eval_data
+  # Settings to run MT-Bench against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mt_bench_branch:
+    # Path to where base taxonomy is stored
+    taxonomy_path: ~/.local/share/instructlab/taxonomy
+general:
+  debug_level: 0
+  log_level: INFO
+generate:
+  # maximum number of words per chunk
+  chunk_word_count: 1000
+  # Teacher model that will be used to synthetically generate training data
+  model: ~/.cache/instructlab/models/mixtral-8x7b-instruct-v0-1
+  # Number of CPU cores to use for generation
+  num_cpus: 10
+  # Directory where generated datasets are stored
+  output_dir: ~/.local/share/instructlab/datasets
+  # Directory where pipeline config files are stored
+  pipeline: /usr/share/instructlab/sdg/pipelines/agentic
+  # Path to prompt file to be used for generation
+  prompt_file: ~/.local/share/instructlab/internal/prompt.txt
+  # The total number of instructions to be generated
+  sdg_scale_factor: 30
+  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
+  # Branch of taxonomy used to calculate diff against
+  taxonomy_base: empty
+  # Directory where taxonomy is stored and accessed from
+  taxonomy_path: ~/.local/share/instructlab/taxonomy
+  # Teacher model specific settings
+  teacher:
+    # Serving backend to use to host the teacher model
+    backend: vllm
+    # Chat template to supply to the teacher model. Possible values:
+    #   - Custom chat template string
+    #   - Auto: Uses default for serving backend
+    chat_template: 'tokenizer'
+    # host and port where teacher model is being served
+    host_port: 127.0.0.1:8000
+    # Llamacpp serving settings
+    llama_cpp:
+      # number of model layers to offload to GPU
+      # -1 means all
+      gpu_layers: -1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: ''
+      # maximum number of tokens that can be processed by the model
+      max_ctx_size: 4096
+    # Path to teacher model that will be used to synthetically generate training data
+    model_path: ~/.cache/instructlab/models/TheBloke/Mistral-7B-Instruct-v0.2-GPTQ
+    # vLLM serving settings
+    vllm:
+      # number of GPUs to allocate to vLLM
+      gpus: 1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: 'mixtral'
+serve:
+  # Serving backend to use to host the model
+  backend: vllm
+  # Chat template to supply to the served model. Possible values:
+  #   - Custom chat template string
+  #   - Auto: Uses default for serving backend
+  chat_template: auto
+  # host and port where the model is being served
+  host_port: 127.0.0.1:8000
+  # Llamacpp serving settings
+  llama_cpp:
+    # number of model layers to offload to GPU
+    # -1 means all
+    gpu_layers: -1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # maximum number of tokens that can be processed by the model
+    max_ctx_size: 4096
+  # Path to model that will be served for inference
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # vLLM serving settings
+  vllm:
+    gpus: 1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # additional arguments to be supplied directly to vLLM
+    vllm_args: ["--tensor-parallel-size", "1"]
+train:
+  additional_args:
+    learning_rate: 2e-5
+    lora_alpha: 32
+    lora_dropout: 0.1
+    warmup_steps: 25
+    use_dolomite: true
+  device: cuda
+  pipeline: accelerated
+  ckpt_output_dir: ~/.local/share/instructlab/checkpoints
+  data_output_dir: ~/.local/share/instructlab/internal
+  data_path: ~/.local/share/instructlab/datasets
+  effective_batch_size: 128
+  is_padding_free: false
+  lora_quantize_dtype: null
+  lora_rank: 0
+  max_batch_len: 10000
+  max_seq_len: 4096
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  nproc_per_node: 1
+  num_epochs: 8
+  phased_mt_bench_judge: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  phased_phase1_num_epochs: 7
+  phased_phase2_num_epochs: 10
+  checkpoint_at_epoch: true
+  save_samples: 0
+metadata:
+  gpu_manufacturer: Nvidia
+  gpu_family: GeForce RTX 3080
+  gpu_count: 1
+  gpu_sku: [Ti, Laptop GPU, Ti Laptop GPU, Laptop GPU]
+version: 1.0.0

--- a/src/instructlab/profiles/nvidia/rtx/30/3090.yaml
+++ b/src/instructlab/profiles/nvidia/rtx/30/3090.yaml
@@ -1,0 +1,156 @@
+chat:
+  context: default
+  # Directory where chat logs are stored
+  logs_dir: ~/.local/share/instructlab/chatlogs
+  # The maximum number of tokens that can be generated in the chat completion
+  max_tokens: null
+  # Directory where model to be used for chatting with is stored
+  model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  session: null
+  # visual mode
+  vi_mode: false
+  # renders vertical overflow if enabled, displays ellipses otherwise
+  visible_overflow: true
+evaluate:
+  # Base taxonomy branch
+  base_branch: null
+  # Directory where the model to be evaluated is stored
+  base_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # Taxonomy branch containing custom skills/knowledge that should be used for evaluation runs
+  branch: null
+  # Number of GPUs to use for running evaluation
+  gpus: 1
+  # MMLU benchmarking settings
+  mmlu:
+    # batch size for evaluation.
+    # Valid values are a positive integer or 'auto' to select the largest batch size that will fit in memory
+    batch_size: auto
+    # number of question-answer pairs provided in the context preceding the question used for evaluation
+    few_shots: 5
+  # Settings to run MMLU against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mmlu_branch:
+    # Directory where custom MMLU tasks are stored
+    tasks_dir: ~/.local/share/instructlab/datasets
+  model: null
+  # multi-turn benchmarking settings for skills
+  mt_bench:
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+    max_workers: auto
+    # Directory where evaluation results are stored
+    output_dir: ~/.local/share/instructlab/internal/eval_data
+  # Settings to run MT-Bench against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mt_bench_branch:
+    # Path to where base taxonomy is stored
+    taxonomy_path: ~/.local/share/instructlab/taxonomy
+general:
+  debug_level: 0
+  log_level: INFO
+generate:
+  # maximum number of words per chunk
+  chunk_word_count: 1000
+  # Teacher model that will be used to synthetically generate training data
+  model: ~/.cache/instructlab/models/mixtral-8x7b-instruct-v0-1
+  # Number of CPU cores to use for generation
+  num_cpus: 10
+  # Directory where generated datasets are stored
+  output_dir: ~/.local/share/instructlab/datasets
+  # Directory where pipeline config files are stored
+  pipeline: /usr/share/instructlab/sdg/pipelines/agentic
+  # Path to prompt file to be used for generation
+  prompt_file: ~/.local/share/instructlab/internal/prompt.txt
+  # The total number of instructions to be generated
+  sdg_scale_factor: 30
+  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
+  # Branch of taxonomy used to calculate diff against
+  taxonomy_base: empty
+  # Directory where taxonomy is stored and accessed from
+  taxonomy_path: ~/.local/share/instructlab/taxonomy
+  # Teacher model specific settings
+  teacher:
+    # Serving backend to use to host the teacher model
+    backend: vllm
+    # Chat template to supply to the teacher model. Possible values:
+    #   - Custom chat template string
+    #   - Auto: Uses default for serving backend
+    chat_template: 'tokenizer'
+    # host and port where teacher model is being served
+    host_port: 127.0.0.1:8000
+    # Llamacpp serving settings
+    llama_cpp:
+      # number of model layers to offload to GPU
+      # -1 means all
+      gpu_layers: -1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: ''
+      # maximum number of tokens that can be processed by the model
+      max_ctx_size: 4096
+    # Path to teacher model that will be used to synthetically generate training data
+    model_path: ~/.cache/instructlab/models/TheBloke/Mistral-7B-Instruct-v0.2-GPTQ
+    # vLLM serving settings
+    vllm:
+      # number of GPUs to allocate to vLLM
+      gpus: 1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: 'mixtral'
+serve:
+  # Serving backend to use to host the model
+  backend: vllm
+  # Chat template to supply to the served model. Possible values:
+  #   - Custom chat template string
+  #   - Auto: Uses default for serving backend
+  chat_template: auto
+  # host and port where the model is being served
+  host_port: 127.0.0.1:8000
+  # Llamacpp serving settings
+  llama_cpp:
+    # number of model layers to offload to GPU
+    # -1 means all
+    gpu_layers: -1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # maximum number of tokens that can be processed by the model
+    max_ctx_size: 4096
+  # Path to model that will be served for inference
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # vLLM serving settings
+  vllm:
+    gpus: 1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # additional arguments to be supplied directly to vLLM
+    vllm_args: ["--tensor-parallel-size", "1"]
+train:
+  additional_args:
+    learning_rate: 2e-5
+    lora_alpha: 32
+    lora_dropout: 0.1
+    warmup_steps: 25
+    use_dolomite: true
+  device: cuda
+  pipeline: accelerated
+  ckpt_output_dir: ~/.local/share/instructlab/checkpoints
+  data_output_dir: ~/.local/share/instructlab/internal
+  data_path: ~/.local/share/instructlab/datasets
+  effective_batch_size: 128
+  is_padding_free: false
+  lora_quantize_dtype: null
+  lora_rank: 0
+  max_batch_len: 10000
+  max_seq_len: 4096
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  nproc_per_node: 1
+  num_epochs: 8
+  phased_mt_bench_judge: ~/.cache/instructlab/models/prometheus-eval/prometheus-7b-v2.0
+  phased_phase1_num_epochs: 7
+  phased_phase2_num_epochs: 10
+  checkpoint_at_epoch: true
+  save_samples: 0
+metadata:
+  gpu_manufacturer: Nvidia
+  gpu_family: GeForce RTX 3090
+  gpu_count: 1
+  gpu_sku: [Ti, Laptop GPU, Ti Laptop GPU, Laptop GPU]
+version: 1.0.0

--- a/src/instructlab/profiles/nvidia/rtx/40/4050.yaml
+++ b/src/instructlab/profiles/nvidia/rtx/40/4050.yaml
@@ -1,0 +1,156 @@
+chat:
+  context: default
+  # Directory where chat logs are stored
+  logs_dir: ~/.local/share/instructlab/chatlogs
+  # The maximum number of tokens that can be generated in the chat completion
+  max_tokens: null
+  # Directory where model to be used for chatting with is stored
+  model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  session: null
+  # visual mode
+  vi_mode: false
+  # renders vertical overflow if enabled, displays ellipses otherwise
+  visible_overflow: true
+evaluate:
+  # Base taxonomy branch
+  base_branch: null
+  # Directory where the model to be evaluated is stored
+  base_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # Taxonomy branch containing custom skills/knowledge that should be used for evaluation runs
+  branch: null
+  # Number of GPUs to use for running evaluation
+  gpus: 1
+  # MMLU benchmarking settings
+  mmlu:
+    # batch size for evaluation.
+    # Valid values are a positive integer or 'auto' to select the largest batch size that will fit in memory
+    batch_size: auto
+    # number of question-answer pairs provided in the context preceding the question used for evaluation
+    few_shots: 5
+  # Settings to run MMLU against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mmlu_branch:
+    # Directory where custom MMLU tasks are stored
+    tasks_dir: ~/.local/share/instructlab/datasets
+  model: null
+  # multi-turn benchmarking settings for skills
+  mt_bench:
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+    max_workers: auto
+    # Directory where evaluation results are stored
+    output_dir: ~/.local/share/instructlab/internal/eval_data
+  # Settings to run MT-Bench against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mt_bench_branch:
+    # Path to where base taxonomy is stored
+    taxonomy_path: ~/.local/share/instructlab/taxonomy
+general:
+  debug_level: 0
+  log_level: INFO
+generate:
+  # maximum number of words per chunk
+  chunk_word_count: 1000
+  # Teacher model that will be used to synthetically generate training data
+  model: ~/.cache/instructlab/models/mixtral-8x7b-instruct-v0-1
+  # Number of CPU cores to use for generation
+  num_cpus: 10
+  # Directory where generated datasets are stored
+  output_dir: ~/.local/share/instructlab/datasets
+  # Directory where pipeline config files are stored
+  pipeline: /usr/share/instructlab/sdg/pipelines/agentic
+  # Path to prompt file to be used for generation
+  prompt_file: ~/.local/share/instructlab/internal/prompt.txt
+  # The total number of instructions to be generated
+  sdg_scale_factor: 30
+  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
+  # Branch of taxonomy used to calculate diff against
+  taxonomy_base: empty
+  # Directory where taxonomy is stored and accessed from
+  taxonomy_path: ~/.local/share/instructlab/taxonomy
+  # Teacher model specific settings
+  teacher:
+    # Serving backend to use to host the teacher model
+    backend: vllm
+    # Chat template to supply to the teacher model. Possible values:
+    #   - Custom chat template string
+    #   - Auto: Uses default for serving backend
+    chat_template: 'tokenizer'
+    # host and port where teacher model is being served
+    host_port: 127.0.0.1:8000
+    # Llamacpp serving settings
+    llama_cpp:
+      # number of model layers to offload to GPU
+      # -1 means all
+      gpu_layers: -1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: ''
+      # maximum number of tokens that can be processed by the model
+      max_ctx_size: 4096
+    # Path to teacher model that will be used to synthetically generate training data
+    model_path: ~/.cache/instructlab/models/TheBloke/Mistral-7B-Instruct-v0.2-GPTQ
+    # vLLM serving settings
+    vllm:
+      # number of GPUs to allocate to vLLM
+      gpus: 1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: 'mixtral'
+serve:
+  # Serving backend to use to host the model
+  backend: vllm
+  # Chat template to supply to the served model. Possible values:
+  #   - Custom chat template string
+  #   - Auto: Uses default for serving backend
+  chat_template: auto
+  # host and port where the model is being served
+  host_port: 127.0.0.1:8000
+  # Llamacpp serving settings
+  llama_cpp:
+    # number of model layers to offload to GPU
+    # -1 means all
+    gpu_layers: -1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # maximum number of tokens that can be processed by the model
+    max_ctx_size: 4096
+  # Path to model that will be served for inference
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # vLLM serving settings
+  vllm:
+    gpus: 1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # additional arguments to be supplied directly to vLLM
+    vllm_args: ["--tensor-parallel-size", "1"]
+train:
+  additional_args:
+    learning_rate: 2e-5
+    lora_alpha: 32
+    lora_dropout: 0.1
+    warmup_steps: 25
+    use_dolomite: true
+  device: cuda
+  pipeline: accelerated
+  ckpt_output_dir: ~/.local/share/instructlab/checkpoints
+  data_output_dir: ~/.local/share/instructlab/internal
+  data_path: ~/.local/share/instructlab/datasets
+  effective_batch_size: 128
+  is_padding_free: false
+  lora_quantize_dtype: null
+  lora_rank: 0
+  max_batch_len: 10000
+  max_seq_len: 4096
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  nproc_per_node: 1
+  num_epochs: 8
+  phased_mt_bench_judge: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  phased_phase1_num_epochs: 7
+  phased_phase2_num_epochs: 10
+  checkpoint_at_epoch: true
+  save_samples: 0
+metadata:
+  gpu_manufacturer: Nvidia
+  gpu_family: GeForce RTX 4050
+  gpu_count: 1
+  gpu_sku: [Ti, Laptop GPU, Ti Laptop GPU, Laptop GPU]
+version: 1.0.0

--- a/src/instructlab/profiles/nvidia/rtx/40/4060.yaml
+++ b/src/instructlab/profiles/nvidia/rtx/40/4060.yaml
@@ -1,0 +1,156 @@
+chat:
+  context: default
+  # Directory where chat logs are stored
+  logs_dir: ~/.local/share/instructlab/chatlogs
+  # The maximum number of tokens that can be generated in the chat completion
+  max_tokens: null
+  # Directory where model to be used for chatting with is stored
+  model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  session: null
+  # visual mode
+  vi_mode: false
+  # renders vertical overflow if enabled, displays ellipses otherwise
+  visible_overflow: true
+evaluate:
+  # Base taxonomy branch
+  base_branch: null
+  # Directory where the model to be evaluated is stored
+  base_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # Taxonomy branch containing custom skills/knowledge that should be used for evaluation runs
+  branch: null
+  # Number of GPUs to use for running evaluation
+  gpus: 1
+  # MMLU benchmarking settings
+  mmlu:
+    # batch size for evaluation.
+    # Valid values are a positive integer or 'auto' to select the largest batch size that will fit in memory
+    batch_size: auto
+    # number of question-answer pairs provided in the context preceding the question used for evaluation
+    few_shots: 5
+  # Settings to run MMLU against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mmlu_branch:
+    # Directory where custom MMLU tasks are stored
+    tasks_dir: ~/.local/share/instructlab/datasets
+  model: null
+  # multi-turn benchmarking settings for skills
+  mt_bench:
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+    max_workers: auto
+    # Directory where evaluation results are stored
+    output_dir: ~/.local/share/instructlab/internal/eval_data
+  # Settings to run MT-Bench against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mt_bench_branch:
+    # Path to where base taxonomy is stored
+    taxonomy_path: ~/.local/share/instructlab/taxonomy
+general:
+  debug_level: 0
+  log_level: INFO
+generate:
+  # maximum number of words per chunk
+  chunk_word_count: 1000
+  # Teacher model that will be used to synthetically generate training data
+  model: ~/.cache/instructlab/models/mixtral-8x7b-instruct-v0-1
+  # Number of CPU cores to use for generation
+  num_cpus: 10
+  # Directory where generated datasets are stored
+  output_dir: ~/.local/share/instructlab/datasets
+  # Directory where pipeline config files are stored
+  pipeline: /usr/share/instructlab/sdg/pipelines/agentic
+  # Path to prompt file to be used for generation
+  prompt_file: ~/.local/share/instructlab/internal/prompt.txt
+  # The total number of instructions to be generated
+  sdg_scale_factor: 30
+  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
+  # Branch of taxonomy used to calculate diff against
+  taxonomy_base: empty
+  # Directory where taxonomy is stored and accessed from
+  taxonomy_path: ~/.local/share/instructlab/taxonomy
+  # Teacher model specific settings
+  teacher:
+    # Serving backend to use to host the teacher model
+    backend: vllm
+    # Chat template to supply to the teacher model. Possible values:
+    #   - Custom chat template string
+    #   - Auto: Uses default for serving backend
+    chat_template: 'tokenizer'
+    # host and port where teacher model is being served
+    host_port: 127.0.0.1:8000
+    # Llamacpp serving settings
+    llama_cpp:
+      # number of model layers to offload to GPU
+      # -1 means all
+      gpu_layers: -1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: ''
+      # maximum number of tokens that can be processed by the model
+      max_ctx_size: 4096
+    # Path to teacher model that will be used to synthetically generate training data
+    model_path: ~/.cache/instructlab/models/TheBloke/Mistral-7B-Instruct-v0.2-GPTQ
+    # vLLM serving settings
+    vllm:
+      # number of GPUs to allocate to vLLM
+      gpus: 1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: 'mixtral'
+serve:
+  # Serving backend to use to host the model
+  backend: vllm
+  # Chat template to supply to the served model. Possible values:
+  #   - Custom chat template string
+  #   - Auto: Uses default for serving backend
+  chat_template: auto
+  # host and port where the model is being served
+  host_port: 127.0.0.1:8000
+  # Llamacpp serving settings
+  llama_cpp:
+    # number of model layers to offload to GPU
+    # -1 means all
+    gpu_layers: -1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # maximum number of tokens that can be processed by the model
+    max_ctx_size: 4096
+  # Path to model that will be served for inference
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # vLLM serving settings
+  vllm:
+    gpus: 1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # additional arguments to be supplied directly to vLLM
+    vllm_args: ["--tensor-parallel-size", "1"]
+train:
+  additional_args:
+    learning_rate: 2e-5
+    lora_alpha: 32
+    lora_dropout: 0.1
+    warmup_steps: 25
+    use_dolomite: true
+  device: cuda
+  pipeline: accelerated
+  ckpt_output_dir: ~/.local/share/instructlab/checkpoints
+  data_output_dir: ~/.local/share/instructlab/internal
+  data_path: ~/.local/share/instructlab/datasets
+  effective_batch_size: 128
+  is_padding_free: false
+  lora_quantize_dtype: null
+  lora_rank: 0
+  max_batch_len: 10000
+  max_seq_len: 4096
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  nproc_per_node: 1
+  num_epochs: 8
+  phased_mt_bench_judge: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  phased_phase1_num_epochs: 7
+  phased_phase2_num_epochs: 10
+  checkpoint_at_epoch: true
+  save_samples: 0
+metadata:
+  gpu_manufacturer: Nvidia
+  gpu_family: GeForce RTX 4060
+  gpu_count: 1
+  gpu_sku: [Ti, Laptop GPU, Ti Laptop GPU, Laptop GPU]
+version: 1.0.0

--- a/src/instructlab/profiles/nvidia/rtx/40/4070.yaml
+++ b/src/instructlab/profiles/nvidia/rtx/40/4070.yaml
@@ -1,0 +1,156 @@
+chat:
+  context: default
+  # Directory where chat logs are stored
+  logs_dir: ~/.local/share/instructlab/chatlogs
+  # The maximum number of tokens that can be generated in the chat completion
+  max_tokens: null
+  # Directory where model to be used for chatting with is stored
+  model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  session: null
+  # visual mode
+  vi_mode: false
+  # renders vertical overflow if enabled, displays ellipses otherwise
+  visible_overflow: true
+evaluate:
+  # Base taxonomy branch
+  base_branch: null
+  # Directory where the model to be evaluated is stored
+  base_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # Taxonomy branch containing custom skills/knowledge that should be used for evaluation runs
+  branch: null
+  # Number of GPUs to use for running evaluation
+  gpus: 1
+  # MMLU benchmarking settings
+  mmlu:
+    # batch size for evaluation.
+    # Valid values are a positive integer or 'auto' to select the largest batch size that will fit in memory
+    batch_size: auto
+    # number of question-answer pairs provided in the context preceding the question used for evaluation
+    few_shots: 5
+  # Settings to run MMLU against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mmlu_branch:
+    # Directory where custom MMLU tasks are stored
+    tasks_dir: ~/.local/share/instructlab/datasets
+  model: null
+  # multi-turn benchmarking settings for skills
+  mt_bench:
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+    max_workers: auto
+    # Directory where evaluation results are stored
+    output_dir: ~/.local/share/instructlab/internal/eval_data
+  # Settings to run MT-Bench against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mt_bench_branch:
+    # Path to where base taxonomy is stored
+    taxonomy_path: ~/.local/share/instructlab/taxonomy
+general:
+  debug_level: 0
+  log_level: INFO
+generate:
+  # maximum number of words per chunk
+  chunk_word_count: 1000
+  # Teacher model that will be used to synthetically generate training data
+  model: ~/.cache/instructlab/models/mixtral-8x7b-instruct-v0-1
+  # Number of CPU cores to use for generation
+  num_cpus: 10
+  # Directory where generated datasets are stored
+  output_dir: ~/.local/share/instructlab/datasets
+  # Directory where pipeline config files are stored
+  pipeline: /usr/share/instructlab/sdg/pipelines/agentic
+  # Path to prompt file to be used for generation
+  prompt_file: ~/.local/share/instructlab/internal/prompt.txt
+  # The total number of instructions to be generated
+  sdg_scale_factor: 30
+  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
+  # Branch of taxonomy used to calculate diff against
+  taxonomy_base: empty
+  # Directory where taxonomy is stored and accessed from
+  taxonomy_path: ~/.local/share/instructlab/taxonomy
+  # Teacher model specific settings
+  teacher:
+    # Serving backend to use to host the teacher model
+    backend: vllm
+    # Chat template to supply to the teacher model. Possible values:
+    #   - Custom chat template string
+    #   - Auto: Uses default for serving backend
+    chat_template: 'tokenizer'
+    # host and port where teacher model is being served
+    host_port: 127.0.0.1:8000
+    # Llamacpp serving settings
+    llama_cpp:
+      # number of model layers to offload to GPU
+      # -1 means all
+      gpu_layers: -1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: ''
+      # maximum number of tokens that can be processed by the model
+      max_ctx_size: 4096
+    # Path to teacher model that will be used to synthetically generate training data
+    model_path: ~/.cache/instructlab/models/TheBloke/Mistral-7B-Instruct-v0.2-GPTQ
+    # vLLM serving settings
+    vllm:
+      # number of GPUs to allocate to vLLM
+      gpus: 1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: 'mixtral'
+serve:
+  # Serving backend to use to host the model
+  backend: vllm
+  # Chat template to supply to the served model. Possible values:
+  #   - Custom chat template string
+  #   - Auto: Uses default for serving backend
+  chat_template: auto
+  # host and port where the model is being served
+  host_port: 127.0.0.1:8000
+  # Llamacpp serving settings
+  llama_cpp:
+    # number of model layers to offload to GPU
+    # -1 means all
+    gpu_layers: -1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # maximum number of tokens that can be processed by the model
+    max_ctx_size: 4096
+  # Path to model that will be served for inference
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # vLLM serving settings
+  vllm:
+    gpus: 1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # additional arguments to be supplied directly to vLLM
+    vllm_args: ["--tensor-parallel-size", "1"]
+train:
+  additional_args:
+    learning_rate: 2e-5
+    lora_alpha: 32
+    lora_dropout: 0.1
+    warmup_steps: 25
+    use_dolomite: true
+  device: cuda
+  pipeline: accelerated
+  ckpt_output_dir: ~/.local/share/instructlab/checkpoints
+  data_output_dir: ~/.local/share/instructlab/internal
+  data_path: ~/.local/share/instructlab/datasets
+  effective_batch_size: 128
+  is_padding_free: false
+  lora_quantize_dtype: null
+  lora_rank: 0
+  max_batch_len: 10000
+  max_seq_len: 4096
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  nproc_per_node: 1
+  num_epochs: 8
+  phased_mt_bench_judge: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  phased_phase1_num_epochs: 7
+  phased_phase2_num_epochs: 10
+  checkpoint_at_epoch: true
+  save_samples: 0
+metadata:
+  gpu_manufacturer: Nvidia
+  gpu_family: GeForce RTX 4070
+  gpu_count: 1
+  gpu_sku: [Ti, Laptop GPU, Ti Laptop GPU, Laptop GPU]
+version: 1.0.0

--- a/src/instructlab/profiles/nvidia/rtx/40/4080.yaml
+++ b/src/instructlab/profiles/nvidia/rtx/40/4080.yaml
@@ -1,0 +1,156 @@
+chat:
+  context: default
+  # Directory where chat logs are stored
+  logs_dir: ~/.local/share/instructlab/chatlogs
+  # The maximum number of tokens that can be generated in the chat completion
+  max_tokens: null
+  # Directory where model to be used for chatting with is stored
+  model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  session: null
+  # visual mode
+  vi_mode: false
+  # renders vertical overflow if enabled, displays ellipses otherwise
+  visible_overflow: true
+evaluate:
+  # Base taxonomy branch
+  base_branch: null
+  # Directory where the model to be evaluated is stored
+  base_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # Taxonomy branch containing custom skills/knowledge that should be used for evaluation runs
+  branch: null
+  # Number of GPUs to use for running evaluation
+  gpus: 1
+  # MMLU benchmarking settings
+  mmlu:
+    # batch size for evaluation.
+    # Valid values are a positive integer or 'auto' to select the largest batch size that will fit in memory
+    batch_size: auto
+    # number of question-answer pairs provided in the context preceding the question used for evaluation
+    few_shots: 5
+  # Settings to run MMLU against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mmlu_branch:
+    # Directory where custom MMLU tasks are stored
+    tasks_dir: ~/.local/share/instructlab/datasets
+  model: null
+  # multi-turn benchmarking settings for skills
+  mt_bench:
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+    max_workers: auto
+    # Directory where evaluation results are stored
+    output_dir: ~/.local/share/instructlab/internal/eval_data
+  # Settings to run MT-Bench against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mt_bench_branch:
+    # Path to where base taxonomy is stored
+    taxonomy_path: ~/.local/share/instructlab/taxonomy
+general:
+  debug_level: 0
+  log_level: INFO
+generate:
+  # maximum number of words per chunk
+  chunk_word_count: 1000
+  # Teacher model that will be used to synthetically generate training data
+  model: ~/.cache/instructlab/models/mixtral-8x7b-instruct-v0-1
+  # Number of CPU cores to use for generation
+  num_cpus: 10
+  # Directory where generated datasets are stored
+  output_dir: ~/.local/share/instructlab/datasets
+  # Directory where pipeline config files are stored
+  pipeline: /usr/share/instructlab/sdg/pipelines/agentic
+  # Path to prompt file to be used for generation
+  prompt_file: ~/.local/share/instructlab/internal/prompt.txt
+  # The total number of instructions to be generated
+  sdg_scale_factor: 30
+  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
+  # Branch of taxonomy used to calculate diff against
+  taxonomy_base: empty
+  # Directory where taxonomy is stored and accessed from
+  taxonomy_path: ~/.local/share/instructlab/taxonomy
+  # Teacher model specific settings
+  teacher:
+    # Serving backend to use to host the teacher model
+    backend: vllm
+    # Chat template to supply to the teacher model. Possible values:
+    #   - Custom chat template string
+    #   - Auto: Uses default for serving backend
+    chat_template: 'tokenizer'
+    # host and port where teacher model is being served
+    host_port: 127.0.0.1:8000
+    # Llamacpp serving settings
+    llama_cpp:
+      # number of model layers to offload to GPU
+      # -1 means all
+      gpu_layers: -1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: ''
+      # maximum number of tokens that can be processed by the model
+      max_ctx_size: 4096
+    # Path to teacher model that will be used to synthetically generate training data
+    model_path: ~/.cache/instructlab/models/TheBloke/Mistral-7B-Instruct-v0.2-GPTQ
+    # vLLM serving settings
+    vllm:
+      # number of GPUs to allocate to vLLM
+      gpus: 1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: 'mixtral'
+serve:
+  # Serving backend to use to host the model
+  backend: vllm
+  # Chat template to supply to the served model. Possible values:
+  #   - Custom chat template string
+  #   - Auto: Uses default for serving backend
+  chat_template: auto
+  # host and port where the model is being served
+  host_port: 127.0.0.1:8000
+  # Llamacpp serving settings
+  llama_cpp:
+    # number of model layers to offload to GPU
+    # -1 means all
+    gpu_layers: -1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # maximum number of tokens that can be processed by the model
+    max_ctx_size: 4096
+  # Path to model that will be served for inference
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # vLLM serving settings
+  vllm:
+    gpus: 1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # additional arguments to be supplied directly to vLLM
+    vllm_args: ["--tensor-parallel-size", "1"]
+train:
+  additional_args:
+    learning_rate: 2e-5
+    lora_alpha: 32
+    lora_dropout: 0.1
+    warmup_steps: 25
+    use_dolomite: true
+  device: cuda
+  pipeline: accelerated
+  ckpt_output_dir: ~/.local/share/instructlab/checkpoints
+  data_output_dir: ~/.local/share/instructlab/internal
+  data_path: ~/.local/share/instructlab/datasets
+  effective_batch_size: 128
+  is_padding_free: false
+  lora_quantize_dtype: null
+  lora_rank: 0
+  max_batch_len: 10000
+  max_seq_len: 4096
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  nproc_per_node: 1
+  num_epochs: 8
+  phased_mt_bench_judge: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  phased_phase1_num_epochs: 7
+  phased_phase2_num_epochs: 10
+  checkpoint_at_epoch: true
+  save_samples: 0
+metadata:
+  gpu_manufacturer: Nvidia
+  gpu_family: GeForce RTX 4080
+  gpu_count: 1
+  gpu_sku: [Ti, Laptop GPU, Ti Laptop GPU, Laptop GPU]
+version: 1.0.0

--- a/src/instructlab/profiles/nvidia/rtx/40/4090.yaml
+++ b/src/instructlab/profiles/nvidia/rtx/40/4090.yaml
@@ -1,0 +1,156 @@
+chat:
+  context: default
+  # Directory where chat logs are stored
+  logs_dir: ~/.local/share/instructlab/chatlogs
+  # The maximum number of tokens that can be generated in the chat completion
+  max_tokens: null
+  # Directory where model to be used for chatting with is stored
+  model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  session: null
+  # visual mode
+  vi_mode: false
+  # renders vertical overflow if enabled, displays ellipses otherwise
+  visible_overflow: true
+evaluate:
+  # Base taxonomy branch
+  base_branch: null
+  # Directory where the model to be evaluated is stored
+  base_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # Taxonomy branch containing custom skills/knowledge that should be used for evaluation runs
+  branch: null
+  # Number of GPUs to use for running evaluation
+  gpus: 1
+  # MMLU benchmarking settings
+  mmlu:
+    # batch size for evaluation.
+    # Valid values are a positive integer or 'auto' to select the largest batch size that will fit in memory
+    batch_size: auto
+    # number of question-answer pairs provided in the context preceding the question used for evaluation
+    few_shots: 5
+  # Settings to run MMLU against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mmlu_branch:
+    # Directory where custom MMLU tasks are stored
+    tasks_dir: ~/.local/share/instructlab/datasets
+  model: null
+  # multi-turn benchmarking settings for skills
+  mt_bench:
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+    max_workers: auto
+    # Directory where evaluation results are stored
+    output_dir: ~/.local/share/instructlab/internal/eval_data
+  # Settings to run MT-Bench against a branch of taxonomy containing
+  # custom skills/knowledge used for training
+  mt_bench_branch:
+    # Path to where base taxonomy is stored
+    taxonomy_path: ~/.local/share/instructlab/taxonomy
+general:
+  debug_level: 0
+  log_level: INFO
+generate:
+  # maximum number of words per chunk
+  chunk_word_count: 1000
+  # Teacher model that will be used to synthetically generate training data
+  model: ~/.cache/instructlab/models/mixtral-8x7b-instruct-v0-1
+  # Number of CPU cores to use for generation
+  num_cpus: 10
+  # Directory where generated datasets are stored
+  output_dir: ~/.local/share/instructlab/datasets
+  # Directory where pipeline config files are stored
+  pipeline: /usr/share/instructlab/sdg/pipelines/agentic
+  # Path to prompt file to be used for generation
+  prompt_file: ~/.local/share/instructlab/internal/prompt.txt
+  # The total number of instructions to be generated
+  sdg_scale_factor: 30
+  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
+  # Branch of taxonomy used to calculate diff against
+  taxonomy_base: empty
+  # Directory where taxonomy is stored and accessed from
+  taxonomy_path: ~/.local/share/instructlab/taxonomy
+  # Teacher model specific settings
+  teacher:
+    # Serving backend to use to host the teacher model
+    backend: vllm
+    # Chat template to supply to the teacher model. Possible values:
+    #   - Custom chat template string
+    #   - Auto: Uses default for serving backend
+    chat_template: 'tokenizer'
+    # host and port where teacher model is being served
+    host_port: 127.0.0.1:8000
+    # Llamacpp serving settings
+    llama_cpp:
+      # number of model layers to offload to GPU
+      # -1 means all
+      gpu_layers: -1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: ''
+      # maximum number of tokens that can be processed by the model
+      max_ctx_size: 4096
+    # Path to teacher model that will be used to synthetically generate training data
+    model_path: ~/.cache/instructlab/models/TheBloke/Mistral-7B-Instruct-v0.2-GPTQ
+    # vLLM serving settings
+    vllm:
+      # number of GPUs to allocate to vLLM
+      gpus: 1
+      # the family of model being served - used to determine the appropriate chat template
+      llm_family: 'mixtral'
+serve:
+  # Serving backend to use to host the model
+  backend: vllm
+  # Chat template to supply to the served model. Possible values:
+  #   - Custom chat template string
+  #   - Auto: Uses default for serving backend
+  chat_template: auto
+  # host and port where the model is being served
+  host_port: 127.0.0.1:8000
+  # Llamacpp serving settings
+  llama_cpp:
+    # number of model layers to offload to GPU
+    # -1 means all
+    gpu_layers: -1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # maximum number of tokens that can be processed by the model
+    max_ctx_size: 4096
+  # Path to model that will be served for inference
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  # vLLM serving settings
+  vllm:
+    gpus: 1
+    # the family of model being served - used to determine the appropriate chat template
+    llm_family: ''
+    # additional arguments to be supplied directly to vLLM
+    vllm_args: ["--tensor-parallel-size", "1"]
+train:
+  additional_args:
+    learning_rate: 2e-5
+    lora_alpha: 32
+    lora_dropout: 0.1
+    warmup_steps: 25
+    use_dolomite: true
+  device: cuda
+  pipeline: accelerated
+  ckpt_output_dir: ~/.local/share/instructlab/checkpoints
+  data_output_dir: ~/.local/share/instructlab/internal
+  data_path: ~/.local/share/instructlab/datasets
+  effective_batch_size: 128
+  is_padding_free: false
+  lora_quantize_dtype: null
+  lora_rank: 0
+  max_batch_len: 10000
+  max_seq_len: 4096
+  model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+  nproc_per_node: 1
+  num_epochs: 8
+  phased_mt_bench_judge: ~/.cache/instructlab/models/prometheus-eval/prometheus-7b-v2.0
+  phased_phase1_num_epochs: 7
+  phased_phase2_num_epochs: 10
+  checkpoint_at_epoch: true
+  save_samples: 0
+metadata:
+  gpu_manufacturer: Nvidia
+  gpu_family: GeForce RTX 4090
+  gpu_count: 1
+  gpu_sku: [Ti, Laptop GPU, Ti Laptop GPU, Laptop GPU]
+version: 1.0.0


### PR DESCRIPTION
This introduces system profiles for the following cards:
RTX 3060 (all SKUs)
RTX 3070 (all SKUs)
RTX 3080 (all SKUs)
RTX 3090 (all SKUs)

RTX 4050 (all SKUs)
RTX 4060 (all SKUs)
RTX 4070 (all SKUs)
RTX 4080 (all SKUs)
RTX 4090 (all SKUs)

as a reminder, the list of SKUs for these cards can be found here: https://github.com/NVIDIA/open-gpu-kernel-modules/blob/main/src/nvidia/generated/g_nv_name_released.h

As we add more of these profiles, the list is becoming long. I modified the sorting of the list to group the same GPUs together in a better way than it does now

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
