### PR TITLE
fix: Don't crash when system profile does not provide h/w metadata

### DIFF
--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -284,8 +284,10 @@ def walk_and_print_system_profiles(
                         # this is our config
                         cfg = sys_profile
                         break
-            if cfg is not None:
-                break
+            else:
+                if cfg is not None:
+                    break
+                continue
             arch_family_processors.setdefault(full_chip_name[0], []).append(
                 (full_chip_name, system_profile_file)
             )


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

Currently, `ilab config init`'s system profile autodetect code reads which hardware a particular system profile applies to via the `metadata` field within the profile `yaml`. However, some system profiles shipped by default (notably `test_train.yml`) do not include this metadata, and `metadata` gets initialized with default `None` values.

This can result in a scenario where `ilab config init` tries to pull metadata it wasn't able to parse, causing an `IndexError: list index out of range`.

This PR adds a default case that `continue`s to the next system profile if `cpu_info`, `gpu_manufacturer`, and `gpu_family` are all `None`. This seems to fix the crash, and allows the user to proceed to manual system profile selection.

**Issue resolved by this Pull Request:**
Resolves #2921.

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
