### PR TITLE
feat: proper process listing and status

### DIFF
--- a/src/instructlab/cli/process/list.py
+++ b/src/instructlab/cli/process/list.py
@@ -14,7 +14,9 @@ from instructlab.utils import print_table
 def list():
     process_list = list_processes()
     if process_list is not None and len(process_list) > 0:
-        print_table(["Type", "PID", "UUID", "Log File", "Runtime"], process_list)
+        print_table(
+            ["Type", "PID", "UUID", "Log File", "Runtime", "Status"], process_list
+        )
     else:
         click.secho(
             "No processes found in registry",

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -30,6 +30,12 @@ LOG_FORMAT = "%(levelname)s %(asctime)s %(name)s:%(lineno)d: %(message)s"
 RECOMMENDED_SCOPEO_VERSION = "1.9.0"
 
 
+class ILAB_PROCESS_STATUS:
+    RUNNING: str = "Running"
+    DONE: str = "Done"
+    ERRORED: str = "Errored"
+
+
 class ILAB_PROCESS_MODES:
     DETACHED: str = "detached"
     ATTACHED: str = "attached"

--- a/tests/test_lab_process_attach.py
+++ b/tests/test_lab_process_attach.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 
 # First Party
 from instructlab import lab
-from instructlab.defaults import DEFAULTS
+from instructlab.defaults import DEFAULTS, ILAB_PROCESS_STATUS
 
 
 def test_process_attach(
@@ -28,6 +28,7 @@ def test_process_attach(
         "start_time": datetime.datetime.strptime(
             start_time_str, "%Y-%m-%d %H:%M:%S"
         ).isoformat(),
+        "status": ILAB_PROCESS_STATUS.RUNNING,
     }
     # create registry json, place it in the proper dir
     os.makedirs(exist_ok=True, name=DEFAULTS.INTERNAL_DIR)

--- a/tests/test_lab_process_list.py
+++ b/tests/test_lab_process_list.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 
 # First Party
 from instructlab import lab
-from instructlab.defaults import DEFAULTS
+from instructlab.defaults import DEFAULTS, ILAB_PROCESS_STATUS
 
 
 def extract_process_entries(table_output: str) -> str:
@@ -22,7 +22,7 @@ def extract_process_entries(table_output: str) -> str:
             columns = [col.strip() for col in line.split("|")[1:-1]]
 
             # Remove the "Runtime" column (last column)
-            desired_columns = columns[:-1]
+            desired_columns = columns[:-2]
 
             # Clean and join the remaining columns
             clean_line = " | ".join(desired_columns)
@@ -42,7 +42,7 @@ def test_process_list(cli_runner: CliRunner):
         "start_time": datetime.datetime.strptime(
             start_time_str, "%Y-%m-%d %H:%M:%S"
         ).isoformat(),
-        "done": False,
+        "status": ILAB_PROCESS_STATUS.RUNNING,
     }
     # create registry json, place it in the proper dir
     os.makedirs(exist_ok=True, name=DEFAULTS.INTERNAL_DIR)
@@ -59,11 +59,11 @@ def test_process_list(cli_runner: CliRunner):
     )
 
     expected_output = textwrap.dedent("""
-+------------+-------+--------------------------------------+------------------------------------------------------------------------------------------------------------------+----------+
-| Type       | PID   | UUID                                 | Log File                                                                                                         | Runtime  |
-+------------+-------+--------------------------------------+------------------------------------------------------------------------------------------------------------------+----------+
-| Generation | 26372 | 63866b91-799a-42a7-af02-d0b68fddf19d | /Users/charliedoern/.local/share/instructlab/logs/generation/generation-63866b91-799a-42a7-af02-d0b68fddf19d.log | 00:00:06 |
-+------------+-------+--------------------------------------+------------------------------------------------------------------------------------------------------------------+----------+
++------------+-------+--------------------------------------+------------------------------------------------------------------------------------------------------------------+----------+---------+
+| Type       | PID   | UUID                                 | Log File                                                                                                         | Runtime  | Status  |
++------------+-------+--------------------------------------+------------------------------------------------------------------------------------------------------------------+----------+---------+
+| Generation | 26372 | 63866b91-799a-42a7-af02-d0b68fddf19d | /Users/charliedoern/.local/share/instructlab/logs/generation/generation-63866b91-799a-42a7-af02-d0b68fddf19d.log | 00:00:00 | Running |
++------------+-------+--------------------------------------+------------------------------------------------------------------------------------------------------------------+----------+---------+
     """).strip()
 
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
`ilab process list` was mis-representing process start times and did not have a status.

The output will now contain whether a process is running or finished. The runtime will also stop properly when the process is finished in attached mode. in detached mode the Runtime will be stopped when the user lists the finished process. We can, in the future, consider IPC to properly detect the runtime of finished processes

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
