### PR TITLE
Allow functional tests to run on MacOS

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -36,6 +36,14 @@ init_config() {
         else
             echo "system_profiler not found, cannot determine GPU"
         fi
+
+        # MacOS does not have a `timeout`, but has `gtimeout` in coreutils; alias if present
+        if ! command -v gtimeout &> /dev/null
+            then
+                echo "missing gtimeout (`brew install coreutils`)"
+                exit
+            fi
+        alias timeout=gtimeout
     fi
 
     # Enable Debug in func tests with debug level 1

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -40,7 +40,7 @@ init_config() {
         # MacOS does not have a `timeout`, but has `gtimeout` in coreutils; alias if present
         if ! command -v gtimeout &> /dev/null
             then
-                echo "missing gtimeout (`brew install coreutils`)"
+                echo "missing gtimeout (\`brew install coreutils\`)"
                 exit
             fi
         alias timeout=gtimeout


### PR DESCRIPTION
The functional test script requires `timeout`, which is available as `gtimeout` from `coreutils` on MacOS. Adds an alias from `timeout` to `gtimeout` if MacOS is detected, or prints error message with install instructions if `gtimeout` is not present.
