### PR TITLE
[Draft]: Allow config_sections to refer to a leaf field in clickext module

### DIFF
--- a/src/instructlab/clickext.py
+++ b/src/instructlab/clickext.py
@@ -224,7 +224,10 @@ class ConfigOption(click.Option):
             # we need to overwrite the value
             for secname in self.config_sections:
                 section = section.get(secname, {})
-            value = section.get(self.name)
+            if isinstance(section, dict):
+                value = section.get(self.name)
+            else:
+                value = section
         # fix parameter source for config section that are mis-reported
         # as DEFAULT source instead of DEFAULT_MAP source.
         if (
@@ -240,7 +243,7 @@ class ConfigOption(click.Option):
             assert isinstance(section, dict)
             for secname in self.config_sections:
                 section = section.get(secname, {})
-            if self.name in section:
+            if not isinstance(section, dict) or self.name in section:
                 source = ParameterSource.DEFAULT_MAP
         return value, source
 
@@ -263,7 +266,10 @@ class ConfigOption(click.Option):
                 section = ctx.default_map
             for secname in self.config_sections:
                 section = section.get(secname, {})
-            value = section.get(self.name)
+            if isinstance(section, dict):
+                value = section.get(self.name)
+            else:
+                value = section
             if call and callable(value):
                 return value()
             return value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -427,7 +427,14 @@ class Config(BaseModel):
         (Config(), None, ["non_existent_field"], None, None, True),
         (Config(), None, ["nested", "non_existent_field"], None, None, True),
         # Simulate using nested field as the config_class in @click.option
-        (Config(), 'nested', ["nested_field"], "Nested field description", "nested_default", False),
+        (
+            Config(),
+            "nested",
+            ["nested_field"],
+            "Nested field description",
+            "nested_default",
+            False,
+        ),
     ],
 )
 def test_get_default_and_description(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -413,23 +413,33 @@ class Config(BaseModel):
 
 
 @pytest.mark.parametrize(
-    "cfg, config_identifier, expected_description, expected_default_value, expect_error",
+    "cfg, cfg_class, config_identifier, expected_description, expected_default_value, expect_error",
     [
-        (Config(), ["field"], "Field description", "default_value", False),
+        (Config(), None, ["field"], "Field description", "default_value", False),
         (
             Config(),
+            None,
             ["nested", "nested_field"],
             "Nested field description",
             "nested_default",
             False,
         ),
-        (Config(), ["non_existent_field"], None, None, True),
-        (Config(), ["nested", "non_existent_field"], None, None, True),
+        (Config(), None, ["non_existent_field"], None, None, True),
+        (Config(), None, ["nested", "non_existent_field"], None, None, True),
+        # Simulate using nested field as the config_class in @click.option
+        (Config(), 'nested', ["nested_field"], "Nested field description", "nested_default", False),
     ],
 )
 def test_get_default_and_description(
-    cfg, config_identifier, expected_description, expected_default_value, expect_error
+    cfg,
+    cfg_class,
+    config_identifier,
+    expected_description,
+    expected_default_value,
+    expect_error,
 ):
+    if cfg_class is not None:
+        cfg = getattr(cfg, cfg_class)
     if expect_error:
         with pytest.raises(ValueError):
             get_default_and_description(cfg, config_identifier)


### PR DESCRIPTION
This change allows to use an argument name in the click option that is different from the actual field name.
Until now, the `config_sections` value was used to match the parent sections of the target field, but the field name and the argument name had to match exactly.

For example, using the following option configuration we can have an argument called `store_uri`:
```py
@click.option(
    "--document-store-uri",
    "store_uri",
    type=click.STRING,
    cls=clickext.ConfigOption,
    config_class="rag",
    config_sections="document_store.uri",
)
def cmd( ...., store_uri,...):
```
Match a configuration field called `uri`:
```yaml
document_store:
  collection_name: ilab
  uri: embeddings.db
```

This change may be useful to reduce the verbosity of the configuration model (e.g. `document_store.uri` instead of `document_store.document_store_uri`) and at the same time having consistent argument names in the function (e.g. `document_store_uri`)

More UT may be added to validate this change, even if, tbh, there aren't many tests validating the `clickext` module.

**Issue resolved by this Pull Request:**
Will create an issue if needed

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
