### PR TITLE
feat: DK-Bench ilab implementation

### DIFF
--- a/.github/workflows/e2e-nvidia-l40s-x8.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x8.yml
@@ -228,6 +228,7 @@ jobs:
       - name: Run e2e test
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           . venv/bin/activate
           ./scripts/e2e-ci.sh -x

--- a/.spellcheck-en-custom.txt
+++ b/.spellcheck-en-custom.txt
@@ -35,6 +35,8 @@ datasets
 deepspeed
 dev
 ditaa
+DK
+DK-Bench
 DKMS
 dr
 Dropdown
@@ -103,6 +105,7 @@ NVidia
 OCI
 oneMKL
 OOM
+OpenAI
 orchestrator
 ots
 parallelized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - llama-cpp-python has been bumped to 0.3.2. This allows for serving of Granite 3.0 GGUF Models. With this change, some previous handling of context window size has been modified to work with the 0.3.z releases of llama-cpp-python.
 - `ilab train --pipeline=simple` no longer supports Intel Gaudi (`hpu`) devices. Simple training on Gaudi was experimental and limited to a single device.
+- The results of MT-Bench and MT-Bench-Branch are now stored in `$XDG_DATA_HOME/eval/{mt_bench,mt_bench_branch}` respectively. Previously the results for both benchmarks were stored in `$XDG_DATA_HOME/eval`. `ilab config init` must be run to initialize the new evaluation results directories.
+- `system_prompt` variable and `dk_bench` section have been added to the `evaluate` section of the configuration file. `ilab config init` should be run to initialize these new sections in the config file.
 
 ### Features
 
@@ -14,6 +16,7 @@
 - `ilab data generate` now stores generated data from each run in individually dated directories.
 - `ilab data list` now organizes tables per dated run, and outputs a more detailed table that describes which model generated which dataset.
 - `ilab model train` and `ilab model test` now search for training data in per-run directories in addition to the top-level directory, maintaining backwards compatibility with old datasets.
+- `ilab model evaluate` now has support for DK-Bench (Domain Knowledge Bench). DK-Bench takes in a set of questions and reference answers provided from a user, gets responses from a model to those questions, and then uses a judge model to grade the response to each question on a 1-5 scale compared to the reference answer. The highest possible score for each question is a 5 (fully accurate, and completely aligned with the reference) and the lowest is a 1 (entirely incorrect, and irrelevant). To run the benchmark the environment variable OPENAI_API_KEY must be set. The judge model for DK-Bench is `gpt-4o` and any judge model provided for DK-Bench must be the name of an OpenAI model.
 
 ## v0.22
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -51,6 +51,11 @@ script.
 | `x`  | Run the e2e workflow for the x-large t-shirt size of hardware |
 | `p`  | Preserve the E2E_TEST_DIR for debugging |
 
+> [!NOTE]
+> The DK-Bench evaluation requires OPENAI_API_KEY to be set before running in `e2e-ci.sh`.
+> This environment variable is set in the CI. Local users of `e2e-ci.sh` will find that the script will exit with a warning if that environment variable is not set.
+> If a user of the script does not have an OPENAI_API_KEY and wishes to run `e2e-ci.sh` without running DK-Bench they can set OPENAI_API_KEY='NO_API_KEY'.
+
 You can specify the following flags to test various features of `ilab` with the
 `e2e-custom.sh` script.
 

--- a/scripts/e2e-ci.sh
+++ b/scripts/e2e-ci.sh
@@ -377,6 +377,19 @@ test_evaluate() {
 
     model_path=${TRAINED_MODEL_PATH}
     base_model_path="${CACHE_HOME}/instructlab/models/${GRANITE_7B_MODEL}"
+    dk_bench_output_formats="csv,xlsx,jsonl"
+
+    step Running DK Bench where trained model generates responses
+    ilab model evaluate \
+        --model "${model_path}" \
+        --benchmark dk_bench \
+        --input-questions "${SCRIPTDIR}/test-data/dk-bench-questions.jsonl" \
+        --output-file-formats "${dk_bench_output_formats}"
+
+    step Running DK Bench with responses already provided
+    ilab model evaluate \
+        --benchmark dk_bench \
+        --input-questions "${SCRIPTDIR}/test-data/dk-bench-questions-with-responses.jsonl" \
 
     export INSTRUCTLAB_EVAL_MMLU_MIN_TASKS=true
     export HF_DATASETS_TRUST_REMOTE_CODE=true

--- a/scripts/test-data/dk-bench-questions-with-responses.jsonl
+++ b/scripts/test-data/dk-bench-questions-with-responses.jsonl
@@ -1,0 +1,10 @@
+{"user_input": "What is the capital of the United States of America?", "reference": "The capital of the United States of America is Washington, D.C.", "response": "The capital is New York City."}
+{"user_input": "What is the capital of France?", "reference": "The capital of France is Paris.", "response": "The capital of France is Paris"}
+{"user_input": "What is the capital of Mexico?", "reference": "The capital of Mexico is Mexico City.", "response": "The capital of Mexico is Mexico City."}
+{"user_input": "What is the capital of Japan?", "reference": "The capital of Japan is Tokyo.", "response": "The capital of Japan is Okinawa."}
+{"user_input": "What is the capital of India?", "reference": "The capital of India is New Delhi.", "response": "The capital of India is New Delhi."}
+{"user_input": "What is the capital of Argentina?", "reference": "The capital of Argentina is Buenos Aires.", "response": "The capital of Argentina is Buenos Aires."}
+{"user_input": "What is the capital of China?", "reference": "The capital of China is Beijing.", "response": "The capital of China is Beijing."}
+{"user_input": "What is the capital of Germany?", "reference": "The capital of Germany is Berlin.", "response": "The capital of Germany is Berlin."}
+{"user_input": "What is the capital of Russia?", "reference": "The capital of Russia is Moscow.", "response": "The capital of Russia is Paris."}
+{"user_input": "What is the capital of Chile?", "reference": "The capital of Chile is Santiago", "response": "The capital of Chile is Buenos Aires."}

--- a/scripts/test-data/dk-bench-questions.jsonl
+++ b/scripts/test-data/dk-bench-questions.jsonl
@@ -1,0 +1,10 @@
+{"user_input": "What is the capital of the United States of America?", "reference": "The capital of the United States of America is Washington, D.C."}
+{"user_input": "What is the capital of France?", "reference": "The capital of France is Paris."}
+{"user_input": "What is the capital of Mexico?", "reference": "The capital of Mexico is Mexico City."}
+{"user_input": "What is the capital of Japan?", "reference": "The capital of Japan is Tokyo."}
+{"user_input": "What is the capital of India?", "reference": "The capital of India is New Delhi."}
+{"user_input": "What is the capital of Canada?", "reference": "The capital of Canada is Toronto."}
+{"user_input": "What is the capital of India?", "reference": "The capital of India is Mumbai."}
+{"user_input": "What is the capital of Germany?", "reference": "The capital of Germany is Paris."}
+{"user_input": "What is the capital of Mexico?", "reference": "The capital of Mexico is Cancun."}
+{"user_input": "What is the capital of the United States of America?", "reference": "The capital of the United States of America is New York City"}

--- a/scripts/test-data/profile-l4-x1.yaml
+++ b/scripts/test-data/profile-l4-x1.yaml
@@ -19,6 +19,15 @@ evaluate:
   # Taxonomy branch containing custom skills/knowledge that should be used for evaluation runs
   branch: null
   # Number of GPUs to use for running evaluation
+  dk_bench:
+    # File with questions and reference answers used for evaluation during DK-Bench.
+    input_questions: null
+    # Judge model for DK-Bench.
+    judge_model: gpt-4o
+    # Directory where DK-Bench evaluation results are stored.
+    output_dir: ~/.local/share/instructlab/internal/eval_data/dk_bench
+    # Comma-separated list of file formats for results of the DK-Bench evaluation.
+    output_file_formats: jsonl
   gpus: 1
   # MMLU benchmarking settings
   mmlu:
@@ -39,12 +48,25 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:
     # Path to where base taxonomy is stored
     taxonomy_path: ~/.local/share/instructlab/taxonomy
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/instructlab/granite-7b-lab
+    # Directory where evaluation results are stored
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench_branch
+  # System prompt for model getting responses during DK-Bench.
+  system_prompt: You are an advanced AI assistant designed to provide precise and
+    accurate information. Your primary goal is to answer queries with the most up-to-date
+    and factual information available. Focus on delivering clear, concise, and correct
+    responses. If you're uncertain about any aspect of the query, state your level
+    of confidence and provide the most accurate information you can. Your responses
+    should prioritize accuracy over all other considerations.
+  # Temperature for model getting responses during DK-Bench.
+  temperature: 0.0
 general:
   debug_level: 0
   log_level: DEBUG

--- a/scripts/test-data/profile-l40s-x4.yaml
+++ b/scripts/test-data/profile-l40s-x4.yaml
@@ -19,6 +19,15 @@ evaluate:
   # Taxonomy branch containing custom skills/knowledge that should be used for evaluation runs
   branch: null
   # Number of GPUs to use for running evaluation
+  dk_bench:
+    # File with questions and reference answers used for evaluation during DK-Bench.
+    input_questions: null
+    # Judge model for DK-Bench.
+    judge_model: gpt-4o
+    # Directory where DK-Bench evaluation results are stored.
+    output_dir: ~/.local/share/instructlab/internal/eval_data/dk_bench
+    # Comma-separated list of file formats for results of the DK-Bench evaluation.
+    output_file_formats: jsonl
   gpus: 4
   # MMLU benchmarking settings
   mmlu:
@@ -39,12 +48,25 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
+    # Directory where evaluation results are stored
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench_branch
     # Path to where base taxonomy is stored
     taxonomy_path: ~/.local/share/instructlab/taxonomy
+  # System prompt for model getting responses during DK-Bench.
+  system_prompt: You are an advanced AI assistant designed to provide precise and
+    accurate information. Your primary goal is to answer queries with the most up-to-date
+    and factual information available. Focus on delivering clear, concise, and correct
+    responses. If you're uncertain about any aspect of the query, state your level
+    of confidence and provide the most accurate information you can. Your responses
+    should prioritize accuracy over all other considerations.
+  # Temperature for model getting responses during DK-Bench.
+  temperature: 0.0
 general:
   debug_level: 0
   log_level: INFO

--- a/scripts/test-data/profile-l40s-x8.yaml
+++ b/scripts/test-data/profile-l40s-x8.yaml
@@ -20,6 +20,16 @@ evaluate:
   branch: null
   # Number of GPUs to use for running evaluation
   gpus: 8
+  # DK-Bench settings
+  dk_bench:
+    # File with questions and reference answers used for evaluation during DK-Bench.
+    input_questions: null
+    # Judge model for DK-Bench.
+    judge_model: gpt-4o
+    # Directory where DK-Bench evaluation results are stored.
+    output_dir: ~/.local/share/instructlab/internal/eval_data/dk_bench
+    # Comma-separated list of file formats for results of the DK-Bench evaluation.
+    output_file_formats: jsonl
   # MMLU benchmarking settings
   mmlu:
     # batch size for evaluation.
@@ -39,12 +49,25 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
+    # Directory where evaluation results are stored
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench_branch
     # Path to where base taxonomy is stored
     taxonomy_path: ~/.local/share/instructlab/taxonomy
+  # System prompt for model getting responses during DK-Bench.
+  system_prompt: You are an advanced AI assistant designed to provide precise and
+    accurate information. Your primary goal is to answer queries with the most up-to-date
+    and factual information available. Focus on delivering clear, concise, and correct
+    responses. If you're uncertain about any aspect of the query, state your level
+    of confidence and provide the most accurate information you can. Your responses
+    should prioritize accuracy over all other considerations.
+  # Temperature for model getting responses during DK-Bench.
+  temperature: 0.0
 general:
   debug_level: 0
   log_level: INFO

--- a/src/instructlab/cli/model/evaluate.py
+++ b/src/instructlab/cli/model/evaluate.py
@@ -35,15 +35,13 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--judge-model",
+    default=None,
     type=click.STRING,
-    cls=clickext.ConfigOption,
-    config_sections="mt_bench",
 )
 @click.option(
     "--output-dir",
+    default=None,
     type=click.Path(),
-    cls=clickext.ConfigOption,
-    config_sections="mt_bench",
 )
 @click.option(
     "--max-workers",
@@ -140,6 +138,28 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     help="Skip launching the server and evaluate directly with the HuggingFace model. This option supports mmlu and mmlu_branch benchmarks.",
 )
+@click.option(
+    "--input-questions",
+    type=click.STRING,
+    cls=clickext.ConfigOption,
+    config_sections="dk_bench",
+)
+@click.option(
+    "--output-file-formats",
+    type=click.STRING,
+    cls=clickext.ConfigOption,
+    config_sections="dk_bench",
+)
+@click.option(
+    "--system-prompt",
+    type=click.STRING,
+    cls=clickext.ConfigOption,
+)
+@click.option(
+    "--temperature",
+    type=click.FloatRange(min=0.0, max=1.0),
+    cls=clickext.ConfigOption,
+)
 @click.pass_context
 @clickext.display_params
 def evaluate(
@@ -166,6 +186,10 @@ def evaluate(
     tls_client_passwd,  # pylint: disable=unused-argument
     enable_serving_output,
     skip_server: bool,
+    input_questions,
+    output_file_formats,
+    system_prompt,
+    temperature,
 ) -> None:
     """Evaluates a trained model"""
     try:
@@ -193,6 +217,10 @@ def evaluate(
             tls_client_passwd,
             enable_serving_output,
             skip_server,
+            input_questions,
+            output_file_formats,
+            system_prompt,
+            temperature,
         )
     except Exception as e:
         logger.error(f"An error occurred during evaluation: {str(e)}")

--- a/src/instructlab/cli/model/evaluate.py
+++ b/src/instructlab/cli/model/evaluate.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=ungrouped-imports
 # Standard
+from typing import Tuple
 import logging
 
 # Third Party
@@ -13,6 +14,47 @@ from instructlab.model.backends import backends
 from instructlab.model.evaluate import Benchmark, evaluate_model
 
 logger = logging.getLogger(__name__)
+
+
+def set_benchmark_specific_vars(
+    ctx: click.Context,
+    benchmark: Benchmark,
+    judge_model: str | None,
+    output_dir: str | None,
+) -> Tuple[str | None, str | None]:
+    """
+    Ensure judge_model and output_dir are not None before call into
+    evaluate_data(). If either is, ensure defaults are set correctly depending
+    on benchmark being run.
+
+    Args:
+        ctx (click.Context):   Click context containing of the config defaults
+        benchmark (Benchmark): Name of benchmark being run
+        judge_model (str):     Judge model for benchmark given by CLI input.
+        output_dir (str):      CLI input for directory that evalauation
+                               artifacts to go into.
+    Returns:
+        judge_model (str):     Judge model for benchmark
+        output_dir (str):      Benchmark specific directory for output to go
+                               into.
+    """
+    if benchmark == Benchmark.MT_BENCH:
+        if judge_model is None:
+            judge_model = ctx.obj.config.evaluate.mt_bench.judge_model
+        if output_dir is None:
+            output_dir = ctx.obj.config.evaluate.mt_bench.output_dir
+    elif benchmark == Benchmark.MT_BENCH_BRANCH:
+        if judge_model is None:
+            judge_model = ctx.obj.config.evaluate.mt_bench_branch.judge_model
+        if output_dir is None:
+            output_dir = ctx.obj.config.evaluate.mt_bench_branch.output_dir
+    elif benchmark == Benchmark.DK_BENCH:
+        if judge_model is None:
+            judge_model = ctx.obj.config.evaluate.dk_bench.judge_model
+        if output_dir is None:
+            output_dir = ctx.obj.config.evaluate.dk_bench.output_dir
+
+    return judge_model, output_dir
 
 
 @click.command()
@@ -180,10 +222,10 @@ def evaluate(
     merge_system_user_message,
     backend,
     judge_backend,
-    tls_insecure,  # pylint: disable=unused-argument
-    tls_client_cert,  # pylint: disable=unused-argument
-    tls_client_key,  # pylint: disable=unused-argument
-    tls_client_passwd,  # pylint: disable=unused-argument
+    tls_insecure,
+    tls_client_cert,
+    tls_client_key,
+    tls_client_passwd,
     enable_serving_output,
     skip_server: bool,
     input_questions,
@@ -193,8 +235,12 @@ def evaluate(
 ) -> None:
     """Evaluates a trained model"""
     try:
+        judge_model, output_dir = set_benchmark_specific_vars(
+            ctx, benchmark, judge_model, output_dir
+        )
+
         evaluate_model(
-            ctx,
+            ctx.obj.config.serve,
             model,
             base_model,
             benchmark,
@@ -217,10 +263,10 @@ def evaluate(
             tls_client_passwd,
             enable_serving_output,
             skip_server,
-            input_questions,
-            output_file_formats,
-            system_prompt,
-            temperature,
+            input_questions=input_questions,
+            output_file_formats=output_file_formats,
+            system_prompt=system_prompt,
+            temperature=temperature,
         )
     except Exception as e:
         logger.error(f"An error occurred during evaluation: {str(e)}")

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -416,29 +416,60 @@ class _mmlu(BaseModel):
     )
 
 
+class _dkbench(BaseModel):
+    """Class describing configuration of DK-Bench evaluation benchmark."""
+
+    judge_model: str = Field(
+        default_factory=lambda: DEFAULTS.JUDGE_MODEL_DK,
+        description="Judge model for DK-Bench.",
+    )
+    input_questions: Optional[str] = Field(
+        default=None,
+        description="File with questions and reference answers used for evaluation during DK-Bench. The file must be valid a '.jsonl' file with the fields 'user_input' and 'reference' in each entry",
+    )
+    output_file_formats: str = Field(
+        default_factory=lambda: DEFAULTS.DK_BENCH_OUTPUT_FILE_FORMAT,
+        description="Comma-separated list of file formats for results of the DK-Bench evaluation. Ex: 'csv,jsonl'. Valid options in the list are csv, jsonl, and xlsx. If this option is not provided the results are written as a .jsonl file",
+    )
+    output_dir: str = Field(
+        default_factory=lambda: DEFAULTS.DK_BENCH_DATA_DIR,
+        description="Directory where DK-Bench evaluation results are stored.",
+    )
+
+
 class _mtbench(BaseModel):
     """Class describing configuration of MTBench evaluation benchmark."""
 
     judge_model: str = Field(
         default_factory=lambda: DEFAULTS.JUDGE_MODEL_MT,
-        description="Judge model for mt_bench and mt_bench_branch.",
-    )
-    output_dir: str = Field(
-        default_factory=lambda: DEFAULTS.EVAL_DATA_DIR,
-        description="Directory where evaluation results are stored.",
+        description="Judge model for MT-Bench.",
     )
     max_workers: str | int = Field(
         default="auto",
         description="Number of workers to use for evaluation with mt_bench or mt_bench_branch. Must be a positive integer or 'auto'.",
+    )
+    output_dir: str = Field(
+        default_factory=lambda: DEFAULTS.MT_BENCH_DATA_DIR,
+        description="Directory where MT-Bench evaluation results are stored.",
     )
 
 
 class _mtbenchbranch(BaseModel):
     """Class describing configuration of MTBenchBranch evaluation benchmark."""
 
+    judge_model: str = Field(
+        # MT-Bench-Branch uses the same default judge model as MT-Bench
+        default_factory=lambda: DEFAULTS.JUDGE_MODEL_MT,
+        description="Judge model for MT-Bench-Branch.",
+    )
+
     taxonomy_path: str = Field(
         default_factory=lambda: DEFAULTS.TAXONOMY_DIR,
         description="Path to where base taxonomy is stored.",
+    )
+    output_dir: str = Field(
+        default_factory=lambda: DEFAULTS.MT_BENCH_BRANCH_DATA_DIR,
+        description="Directory where MT-Bench-Branch evaluation results are stored.",
     )
 
 
@@ -469,6 +500,10 @@ class _evaluate(BaseModel):
         description="Taxonomy branch containing custom skills/knowledge that should be used for evaluation runs.",
     )
     base_branch: Optional[str] = Field(default=None, description="Base taxonomy branch")
+    dk_bench: _dkbench = Field(
+        default_factory=_dkbench,
+        description="Settings to run DK-Bench against a file of user created questions, reference answers, and responses. If responses are not provided they are generated from a model",
+    )
     gpus: Optional[int] = Field(
         default=None, description="Number of GPUs to use for running evaluation."
     )
@@ -487,6 +522,16 @@ class _evaluate(BaseModel):
     mt_bench_branch: _mtbenchbranch = Field(
         default_factory=_mtbenchbranch,
         description="Settings to run MT-Bench against a branch of taxonomy containing custom skills/knowledge used for training",
+    )
+    system_prompt: Optional[str] = Field(
+        default=None,
+        description="System prompt for model getting responses during DK-Bench.",
+    )
+    temperature: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Temperature for model getting responses during DK-Bench. Temperature controls the randomness of the model's responses. Lower values make the output more deterministic, while higher values produce more random results.",
     )
 
 
@@ -1275,6 +1320,9 @@ def ensure_storage_directories_exist() -> bool:
         DEFAULTS.OCI_DIR,
         DEFAULTS.DATASETS_DIR,
         DEFAULTS.EVAL_DATA_DIR,
+        DEFAULTS.MT_BENCH_DATA_DIR,
+        DEFAULTS.MT_BENCH_BRANCH_DATA_DIR,
+        DEFAULTS.DK_BENCH_DATA_DIR,
         DEFAULTS.INTERNAL_DIR,
         DEFAULTS.MODELS_DIR,
         DEFAULTS.TAXONOMY_DIR,
@@ -1558,6 +1606,9 @@ def storage_dirs_exist() -> bool:
         DEFAULTS.OCI_DIR,
         DEFAULTS.DATASETS_DIR,
         DEFAULTS.EVAL_DATA_DIR,
+        DEFAULTS.MT_BENCH_DATA_DIR,
+        DEFAULTS.MT_BENCH_BRANCH_DATA_DIR,
+        DEFAULTS.DK_BENCH_DATA_DIR,
         DEFAULTS.INTERNAL_DIR,
         DEFAULTS.MODELS_DIR,
         DEFAULTS.TAXONOMY_DIR,

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -93,6 +93,8 @@ class _InstructlabDefaults:
     MISTRAL_GGUF_MODEL_NAME = "mistral-7b-instruct-v0.2.Q4_K_M.gguf"
     MODEL_REPO = "instructlab/granite-7b-lab"
     JUDGE_MODEL_MT = "prometheus-eval/prometheus-8x7b-v2.0"
+    JUDGE_MODEL_DK = "gpt-4o"
+    DK_BENCH_OUTPUT_FILE_FORMAT = "jsonl"
     TAXONOMY_REPO = "https://github.com/instructlab/taxonomy.git"
     TAXONOMY_BASE = "origin/main"
     MAX_CONTEXT_SIZE = 4096
@@ -224,6 +226,18 @@ class _InstructlabDefaults:
     @property
     def EVAL_DATA_DIR(self) -> str:
         return path.join(self.INTERNAL_DIR, "eval_data")
+
+    @property
+    def MT_BENCH_DATA_DIR(self) -> str:
+        return path.join(self.EVAL_DATA_DIR, "mt_bench")
+
+    @property
+    def MT_BENCH_BRANCH_DATA_DIR(self) -> str:
+        return path.join(self.EVAL_DATA_DIR, "mt_bench_branch")
+
+    @property
+    def DK_BENCH_DATA_DIR(self) -> str:
+        return path.join(self.EVAL_DATA_DIR, "dk_bench")
 
     @property
     def SYSTEM_PROFILE_DIR(self) -> str:

--- a/src/instructlab/model/dk_bench_utils.py
+++ b/src/instructlab/model/dk_bench_utils.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# pylint: disable=ungrouped-imports
+# Standard
+from datetime import datetime
+from typing import List
+import enum
+import logging
+import os
+import pathlib
+import statistics as stats
+
+# Third Party
+from instructlab.eval.mt_bench_common import (
+    get_openai_client as get_local_openai_client,
+)
+from instructlab.eval.ragas import ModelConfig, RagasEvaluator
+from openai import OpenAI, OpenAIError
+from openpyxl import load_workbook  # type: ignore
+from openpyxl.styles import Border, Font, Side  # type: ignore
+from ragas.evaluation import EvaluationResult  # type: ignore
+import click
+import pandas as pd
+
+# First Party
+from instructlab import client_utils
+
+# Local
+from .evaluate import get_model_name as get_local_model_name
+from .evaluate import launch_server, validate_model
+
+logger = logging.getLogger(__name__)
+
+
+class IOFileType(enum.Enum):
+    CSV = "csv"
+    JSONL = "jsonl"
+    XLSX = "xlsx"
+
+
+def validate_input_questions(input_questions: pathlib.Path) -> None:
+    """
+    Ensure input questions file exists, is not a directory
+    and is a '.jsonl' file.
+    Args:
+        input_questions (Path): The path to the input questions .jsonl file
+    Returns:
+        None
+    """
+    if not input_questions.exists():
+        raise ValueError(
+            f"Input questions file {input_questions} does not exist",
+        )
+
+    if input_questions.is_dir():
+        raise ValueError(
+            f"Input questions file {input_questions} is a directory",
+        )
+
+    # need to make sure input questions is a jsonl file
+    if input_questions.suffix.lstrip(".") != IOFileType.JSONL.value:
+        raise ValueError(
+            f"Invalid file type: {input_questions}. Expected a '.jsonl' file."
+        )
+
+
+def validate_output_file_formats(file_formats: List[str]) -> None:
+    """
+    Validates that file formats passed in for the file containing scores and
+    responses is a valid output format. Valid file formats are one of:
+    jsonl, xlsx, or csv.
+    Args:
+        file_formats (List[str]): A list of all of the file format strings
+                                  passed in by the user.
+    Returns:
+        None
+    """
+    for file_format in file_formats:
+        if not any(file_format == item.value for item in IOFileType):
+            raise ValueError(
+                f"File format {file_format} is not a valid output format. Format must be one of csv, xlsx, jsonl"
+            )
+
+
+def create_results_file_name(
+    file_format: str, output_dir: str, timestamp: str, model_name: str
+) -> str:
+    """
+    Validates that file formats passed in for the file containing scores and
+    responses is a valid output format. Valid file formats are one of:
+    jsonl, xlsx, or csv.
+
+    This function assumes output_dir is already created and is a directory.
+    Args:
+        file_formats (str): The file format for the output file. One of "csv",
+                            "xlsx", "jsonl".
+        output_dir (str):   Output directory for results and  scores file
+        timestamp (str):    timestamp in .iso format that is part of the
+                            name of the output file.
+        model_name (str):   Name of model to be used in the name of the output
+                            file.
+    Returns:
+        str: The file name containing the scores and model responses
+    """
+    if file_format not in [
+        IOFileType.CSV.value,
+        IOFileType.JSONL.value,
+        IOFileType.XLSX.value,
+    ]:
+        raise ValueError("File format is not one of: csv, xlsx, jsonl")
+
+    # remove any trailing slashes from user provided output_dir
+    output_dir = os.path.normpath(output_dir)
+
+    # make directory for models results
+    model_results_dir = f"{output_dir}/{model_name}"
+    os.makedirs(model_results_dir, exist_ok=True)
+
+    return f"{model_results_dir}/results_{timestamp}.{file_format}"
+
+
+def print_results(
+    result: EvaluationResult, results_files: List[str], model_name: str
+) -> None:
+    """
+    Prints a scoring report for DK-Bench
+    Args:
+        result (Evaluation):       ragas EvaluationResult to parse for scores
+                                   to each question.
+        results_files (List[str]): List of files with scores and responses
+        model_name (str):          Name of model that generated responses for
+                                   DK-Bench to evaluate againist reference answer.
+    Returns:
+        None
+    """
+    print("\n")
+    print("# DK-BENCH REPORT")
+    print(f"\n## MODEL: {model_name}\n")
+    total_score = 0
+    for i, score in enumerate(result.scores):
+        print(f"Question #{i+1}:     {score['domain_specific_rubrics']}/5")
+        total_score += score["domain_specific_rubrics"]
+
+    average = total_score / len(result.scores)
+    print("----------------------------")
+    print(f"Average Score:   {average:.2f}/5")
+    print(f"Total Score:     {total_score}/{len(result.scores)*5}\n")
+
+    print("Responses and scores written to:")
+    for file in results_files:
+        print(f"{file}")
+    print("\n")
+
+
+def create_excel_results_file(excel_file: str, result: EvaluationResult) -> None:
+    """
+    Writes an excel file based on the result of an evaluation.
+    The excel files has two sheets. The first is a summary sheet
+    with a table of individual question scores, average, total score and median.
+
+    The second sheet has the score, the question (user_input), reference,
+    response, model name, and evaluation run, similar to the contents of the
+    .jsonl and .csv files.
+
+    Args:
+        result (Evaluation):    ragas EvaluationResult to parse for scores
+                                for summary sheet and questions, references,
+                                and responses sheet.
+        excel_file (str):       Name of excel file to be created the summary
+                                and dataset sheets.
+    Returns:
+        None
+    """
+    scores = [score["domain_specific_rubrics"] for score in result.scores]
+    question_indices = [f"Q{i + 1}" for i in range(len(scores))]
+
+    col1 = ["Average", "Total Score", "Median", "Question"] + question_indices
+    col2 = [stats.mean(scores), sum(scores), stats.median(scores), "Score"] + scores
+
+    summary_data = {
+        "Metric": col1,
+        "Value": col2,
+    }
+
+    summary_df = pd.DataFrame(summary_data)
+
+    response_df = result.dataset.to_pandas()
+    response_df["scores"] = scores
+
+    with pd.ExcelWriter(excel_file, engine="openpyxl") as writer:
+        # df with contents similar to those in the .jsonl and .csv output files
+        response_df.to_excel(writer, sheet_name="dataset", index=False)
+        summary_df.to_excel(writer, sheet_name="Summary", index=False)
+
+    # Add a visual separation for row 5 on the summary sheet before question number and scores are output.
+    wb = load_workbook(excel_file)
+    summary_sheet = wb["Summary"]
+    for cell in summary_sheet[5]:  # Row 5 (Question, Score)
+        cell.font = Font(bold=True)
+        cell.border = Border(
+            left=Side(style="thin"),
+            right=Side(style="thin"),
+            top=Side(style="thin"),
+            bottom=Side(style="thin"),
+        )
+
+    wb.save(excel_file)
+
+
+def write_results(
+    result: EvaluationResult, file_formats: List[str], output_dir: str, model_name: str
+) -> List[str]:
+    """
+    Writes results files for DK-Bench for each file format provided.
+    Files have the name {output_dir}/responses-{model_name}-{timestamp}.{file_type}"
+
+    Each of the entries in a file has the following fields:
+    {model_name, scores, evaluation_run, user_input, response, reference}
+
+    The list of file formats can be assumed to be valid.
+
+    Args:
+        result (Evaluation):      ragas EvaluationResult to parse for scores
+                                  for summary sheet and questions, references,
+                                  and responses sheet.
+        file_formats (List[str]): List of file formats of files to write results to.
+        output_dir (str):         Directory for results to be written out to
+        model_name (str):         Model name to be used in the results file name.
+    Returns:
+        List[str]:                A list of strings that are the file names of the files
+                                  with responses and scores for DK-Bench
+    """
+    response_df = result.dataset.to_pandas()
+    response_df["model_name"] = model_name
+
+    scores = [score["domain_specific_rubrics"] for score in result.scores]
+    response_df["scores"] = scores
+
+    timestamp = datetime.now().isoformat()
+    response_df["timestamp"] = f"{timestamp}"
+
+    results_files = []
+    for fmt in file_formats:
+        results_file = create_results_file_name(fmt, output_dir, timestamp, model_name)
+
+        if IOFileType.JSONL.value == fmt:
+            response_df.to_json(f"{results_file}", orient="records", lines=True)
+        elif IOFileType.CSV.value == fmt:
+            response_df.to_csv(f"{results_file}", index=False)
+        elif IOFileType.XLSX.value == fmt:
+            create_excel_results_file(results_file, result)
+
+        results_files.append(results_file)
+        logger.debug("DK-Bench responses and results written to %s", results_file)
+
+    return results_files
+
+
+def is_judge_model_name_valid(judge_model_name: str, api_key: str) -> bool:
+    """
+    Verifies whether or not the judge model provided is the name of a valid
+    OpenAI model to use for the judge in DK-Bench evaluation.
+
+    Args:
+        judge_model_name (str):   Name of the judge model to check validity of.
+        api_key (str):            OpenAI API key.
+    Returns:
+        bool:                     Whether or not the judge_model_name is a valid
+                                  OpenAI model name.
+    """
+    try:
+        client = OpenAI(
+            base_url="https://api.openai.com/v1/",
+            api_key=api_key,
+        )
+        models = client.models.list()
+    except OpenAIError as exc:
+        raise client_utils.ClientException(f"Connection Error {exc}") from exc
+
+    return any(judge_model_name == model.id for model in models.data)
+
+
+def run_dk_bench(
+    ctx: click.Context,
+    model: str,
+    max_workers: str | int | None,
+    gpus: int | None,
+    backend: str | None,
+    enable_serving_output: bool,
+    input_questions: str,
+    system_prompt: str,
+    temperature: float,
+    judge_model_name: str,
+) -> tuple[EvaluationResult, str]:
+    """
+    Wrapper for running one iteration of DK-Bench evaluation.
+
+    Args:
+        serve_config (_serve):           Name of the judge model to check validity of.
+        tls_insecure (bool):             TLS is secure bool for launch_server
+        tls_client_cert (str):           TLS client cert for launch_server
+        tls_client_key (str):            TLS client key for launch_server
+        tls_client_passwd (str):         TLS client password for launch_server
+        model (str):                     Model to generate responses for
+                                         evaluation.
+        max_workers (str | int | None):  Max workers
+        gpus (int | None):               Number of gpus to use when serving
+                                         with vLLM.
+        backend (str | None):            Serving backend for local model
+        enable_serving_output (bool):    Whether to dump full vLLM output
+                                         into foreground.
+        input_questions (str):           Path to file with input questions
+                                         and references.
+        system_prompt (str):             System prompt for model generating
+                                         responses.
+        temperature (float):             Chat temperature for generating
+                                         responses.
+        judge_model_name (str):          OpenAI Judge model name.
+    Returns:
+        result (Evaluation):             ragas EvaluationResult to parse for
+                                         scores for summary sheet and questions,
+                                         references, and responses sheet.
+        model_name (str):                Model name of model responses were collected
+                                         from.
+    """
+    if "OPENAI_API_KEY" not in os.environ:
+        raise EnvironmentError(
+            "Environment variable 'OPENAI_API_KEY' must be set to run the Judge model in DK-Bench."
+        )
+    judge_openai_api_key = os.environ["OPENAI_API_KEY"]
+
+    if not is_judge_model_name_valid(judge_model_name, judge_openai_api_key):
+        raise ValueError("Judge model name must be a valid OpenAI GPT model")
+
+    # RagasEvaluator.run() expects a Path of a .jsonl file
+    input_questions_path = pathlib.Path(input_questions).resolve()
+    validate_input_questions(input_questions_path)
+
+    try:
+        test_df = pd.read_json(input_questions_path, orient="records", lines=True)
+        if "response" in test_df.columns:
+            logger.info(
+                "Input file %s already contains responses for evaluation. Responses from %s will not be collected for this file.",
+                input_questions_path,
+                model,
+            )
+            get_responses_from_model = False
+        else:
+            get_responses_from_model = True
+
+    except Exception as exc:
+        raise ValueError(
+            f"Contents of {input_questions_path} cannot be loaded as JSON. Please ensure it is a valid '.jsonl' file."
+        ) from exc
+
+    evaluator = RagasEvaluator()
+    if get_responses_from_model:
+        logger.debug(
+            "Input file needs responses for evaluation. Getting responses from user configured model %s.",
+            model,
+        )
+        server = None
+        validate_model(model)
+        try:
+            logger.debug("Model being evaluated in DK-Bench is local")
+            model_name = get_local_model_name(model)
+            server, api_base, _ = launch_server(
+                eval_serve=ctx.obj.config.serve,
+                tls_client_cert=ctx.params["tls_client_cert"],
+                tls_client_key=ctx.params["tls_client_key"],
+                tls_client_passwd=ctx.params["tls_client_passwd"],
+                tls_insecure=ctx.params["tls_insecure"],
+                model=model,
+                model_name=model_name,
+                max_workers=max_workers,
+                gpus=gpus,
+                backend=backend,
+                enable_serving_output=enable_serving_output,
+            )
+            openai_client = get_local_openai_client(
+                model_api_base=api_base, api_key=None
+            )
+            model_config = ModelConfig(
+                model_name=model_name,
+                temperature=temperature,
+                system_prompt=system_prompt,
+            )
+            result = evaluator.run(
+                dataset=input_questions_path,
+                student_model=model_config,
+                student_openai_client=openai_client,
+                judge_model_name=judge_model_name,
+                judge_openai_api_key=judge_openai_api_key,
+            )
+
+        finally:
+            if server is not None:
+                server.shutdown()
+    # evaluation on just a dataset with responses already provided
+    else:
+        result = evaluator.run(
+            dataset=input_questions_path,
+            judge_model_name=judge_model_name,
+            judge_openai_api_key=judge_openai_api_key,
+        )
+        model_name = "no-model-provided"
+
+    return result, model_name

--- a/src/instructlab/model/dk_bench_utils.py
+++ b/src/instructlab/model/dk_bench_utils.py
@@ -19,13 +19,13 @@ from openai import OpenAI, OpenAIError
 from openpyxl import load_workbook  # type: ignore
 from openpyxl.styles import Border, Font, Side  # type: ignore
 from ragas.evaluation import EvaluationResult  # type: ignore
-import click
 import pandas as pd
 
 # First Party
 from instructlab import client_utils
 
 # Local
+from ..configuration import _serve
 from .evaluate import get_model_name as get_local_model_name
 from .evaluate import launch_server, validate_model
 
@@ -281,7 +281,11 @@ def is_judge_model_name_valid(judge_model_name: str, api_key: str) -> bool:
 
 
 def run_dk_bench(
-    ctx: click.Context,
+    serve_config: _serve,
+    tls_insecure: bool,
+    tls_client_cert: str,
+    tls_client_key: str,
+    tls_client_passwd: str,
     model: str,
     max_workers: str | int | None,
     gpus: int | None,
@@ -365,11 +369,11 @@ def run_dk_bench(
             logger.debug("Model being evaluated in DK-Bench is local")
             model_name = get_local_model_name(model)
             server, api_base, _ = launch_server(
-                eval_serve=ctx.obj.config.serve,
-                tls_client_cert=ctx.params["tls_client_cert"],
-                tls_client_key=ctx.params["tls_client_key"],
-                tls_client_passwd=ctx.params["tls_client_passwd"],
-                tls_insecure=ctx.params["tls_insecure"],
+                eval_serve=serve_config,
+                tls_insecure=tls_insecure,
+                tls_client_cert=tls_client_cert,
+                tls_client_key=tls_client_key,
+                tls_client_passwd=tls_client_passwd,
                 model=model,
                 model_name=model_name,
                 max_workers=max_workers,

--- a/src/instructlab/profiles/amd/cpu.yaml
+++ b/src/instructlab/profiles/amd/cpu.yaml
@@ -19,10 +19,12 @@ evaluate:
     # Directory where model to be used as judge is stored
     judge_model: ~/.cache/instructlab/models/granite-7b-lab.gguf
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:
+    # Directory where model to be used as judge is stored
+    judge_model: ~/.cache/instructlab/models/granite-7b-lab.gguf
     # Path to where base taxonomy is stored
     taxonomy_path: ~/.local/share/instructlab/taxonomy
 general:

--- a/src/instructlab/profiles/apple/m1/m1_max.yaml
+++ b/src/instructlab/profiles/apple/m1/m1_max.yaml
@@ -34,10 +34,10 @@ evaluate:
   # multi-turn benchmarking settings for skills
   mt_bench:
     # Directory where model to be used as judge is stored
-    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2-0
+    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/apple/m1/m1_ultra.yaml
+++ b/src/instructlab/profiles/apple/m1/m1_ultra.yaml
@@ -34,10 +34,10 @@ evaluate:
   # multi-turn benchmarking settings for skills
   mt_bench:
     # Directory where model to be used as judge is stored
-    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2-0
+    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/apple/m2/m2.yaml
+++ b/src/instructlab/profiles/apple/m2/m2.yaml
@@ -36,10 +36,10 @@ evaluate:
   # multi-turn benchmarking settings for skills
   mt_bench:
     # Directory where model to be used as judge is stored
-    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2-0
+    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/apple/m2/m2_max.yaml
+++ b/src/instructlab/profiles/apple/m2/m2_max.yaml
@@ -34,10 +34,10 @@ evaluate:
   # multi-turn benchmarking settings for skills
   mt_bench:
     # Directory where model to be used as judge is stored
-    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2-0
+    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/apple/m2/m2_pro.yaml
+++ b/src/instructlab/profiles/apple/m2/m2_pro.yaml
@@ -34,10 +34,10 @@ evaluate:
   # multi-turn benchmarking settings for skills
   mt_bench:
     # Directory where model to be used as judge is stored
-    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2-0
+    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/apple/m2/m2_ultra.yaml
+++ b/src/instructlab/profiles/apple/m2/m2_ultra.yaml
@@ -34,10 +34,10 @@ evaluate:
   # multi-turn benchmarking settings for skills
   mt_bench:
     # Directory where model to be used as judge is stored
-    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2-0
+    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/apple/m3/m3.yaml
+++ b/src/instructlab/profiles/apple/m3/m3.yaml
@@ -34,10 +34,10 @@ evaluate:
   # multi-turn benchmarking settings for skills
   mt_bench:
     # Directory where model to be used as judge is stored
-    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2-0
+    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/apple/m3/m3_max.yaml
+++ b/src/instructlab/profiles/apple/m3/m3_max.yaml
@@ -36,10 +36,10 @@ evaluate:
   # multi-turn benchmarking settings for skills
   mt_bench:
     # Directory where model to be used as judge is stored
-    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2-0
+    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/apple/m3/m3_pro.yaml
+++ b/src/instructlab/profiles/apple/m3/m3_pro.yaml
@@ -36,10 +36,10 @@ evaluate:
   # multi-turn benchmarking settings for skills
   mt_bench:
     # Directory where model to be used as judge is stored
-    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2-0
+    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/intel/cpu.yaml
+++ b/src/instructlab/profiles/intel/cpu.yaml
@@ -32,10 +32,10 @@ evaluate:
   # multi-turn benchmarking settings for skills
   mt_bench:
     # Directory where model to be used as judge is stored
-    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2-0
+    judge_model: ~/.cache/instructlab/models/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/intel/gaudi/gaudi_3.yaml
+++ b/src/instructlab/profiles/intel/gaudi/gaudi_3.yaml
@@ -39,7 +39,7 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/nvidia/a100/a100_x2.yaml
+++ b/src/instructlab/profiles/nvidia/a100/a100_x2.yaml
@@ -39,7 +39,7 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/nvidia/a100/a100_x4.yaml
+++ b/src/instructlab/profiles/nvidia/a100/a100_x4.yaml
@@ -39,7 +39,7 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/nvidia/a100/a100_x8.yaml
+++ b/src/instructlab/profiles/nvidia/a100/a100_x8.yaml
@@ -39,7 +39,7 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/nvidia/h100/h100_x2.yaml
+++ b/src/instructlab/profiles/nvidia/h100/h100_x2.yaml
@@ -39,7 +39,7 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/nvidia/h100/h100_x4.yaml
+++ b/src/instructlab/profiles/nvidia/h100/h100_x4.yaml
@@ -39,7 +39,7 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/nvidia/h100/h100_x8.yaml
+++ b/src/instructlab/profiles/nvidia/h100/h100_x8.yaml
@@ -39,7 +39,7 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/nvidia/l4/l4_x8.yaml
+++ b/src/instructlab/profiles/nvidia/l4/l4_x8.yaml
@@ -39,7 +39,7 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/nvidia/l40s/l40s_x4.yaml
+++ b/src/instructlab/profiles/nvidia/l40s/l40s_x4.yaml
@@ -39,7 +39,7 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/src/instructlab/profiles/nvidia/l40s/l40s_x8.yaml
+++ b/src/instructlab/profiles/nvidia/l40s/l40s_x8.yaml
@@ -39,7 +39,7 @@ evaluate:
     judge_model: ~/.cache/instructlab/models/prometheus-eval/prometheus-8x7b-v2.0
     max_workers: auto
     # Directory where evaluation results are stored
-    output_dir: ~/.local/share/instructlab/internal/eval_data
+    output_dir: ~/.local/share/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing
   # custom skills/knowledge used for training
   mt_bench_branch:

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -41,6 +41,26 @@ evaluate:
   # evaluation runs.
   # Default: None
   branch:
+  # Settings to run DK-Bench against a file of user created questions, reference
+  # answers, and responses. If responses are not provided they are generated from a
+  # model
+  dk_bench:
+    # File with questions and reference answers used for evaluation during DK-Bench.
+    # The file must be valid a '.jsonl' file with the fields 'user_input' and
+    # 'reference' in each entry
+    # Default: None
+    input_questions:
+    # Judge model for DK-Bench.
+    # Default: gpt-4o
+    judge_model: gpt-4o
+    # Directory where DK-Bench evaluation results are stored.
+    # Default: /data/instructlab/internal/eval_data/dk_bench
+    output_dir: /data/instructlab/internal/eval_data/dk_bench
+    # Comma-separated list of file formats for results of the DK-Bench evaluation. Ex:
+    # 'csv,jsonl'. Valid options in the list are csv, jsonl, and xlsx. If this option
+    # is not provided the results are written as a .jsonl file
+    # Default: jsonl
+    output_file_formats: jsonl
   # Number of GPUs to use for running evaluation.
   # Default: None
   gpus:
@@ -65,22 +85,36 @@ evaluate:
   model:
   # Multi-turn benchmarking settings for skills.
   mt_bench:
-    # Judge model for mt_bench and mt_bench_branch.
+    # Judge model for MT-Bench.
     # Default: prometheus-eval/prometheus-8x7b-v2.0
     judge_model: prometheus-eval/prometheus-8x7b-v2.0
     # Number of workers to use for evaluation with mt_bench or mt_bench_branch. Must
     # be a positive integer or 'auto'.
     # Default: auto
     max_workers: auto
-    # Directory where evaluation results are stored.
-    # Default: /data/instructlab/internal/eval_data
-    output_dir: /data/instructlab/internal/eval_data
+    # Directory where MT-Bench evaluation results are stored.
+    # Default: /data/instructlab/internal/eval_data/mt_bench
+    output_dir: /data/instructlab/internal/eval_data/mt_bench
   # Settings to run MT-Bench against a branch of taxonomy containing custom
   # skills/knowledge used for training
   mt_bench_branch:
+    # Judge model for MT-Bench-Branch.
+    # Default: prometheus-eval/prometheus-8x7b-v2.0
+    judge_model: prometheus-eval/prometheus-8x7b-v2.0
+    # Directory where MT-Bench-Branch evaluation results are stored.
+    # Default: /data/instructlab/internal/eval_data/mt_bench_branch
+    output_dir: /data/instructlab/internal/eval_data/mt_bench_branch
     # Path to where base taxonomy is stored.
     # Default: /data/instructlab/taxonomy
     taxonomy_path: /data/instructlab/taxonomy
+  # System prompt for model getting responses during DK-Bench.
+  # Default: None
+  system_prompt:
+  # Temperature for model getting responses during DK-Bench. Temperature controls
+  # the randomness of the model's responses. Lower values make the output more
+  # deterministic, while higher values produce more random results.
+  # Default: 0.0
+  temperature: 0.0
 # General configuration section.
 general:
   # Debug level for logging.


### PR DESCRIPTION
This commit adds Domain Knowledge bench (DK-Bench) as an evaluation option as part of
`ilab model evaluate`.

This commit adds the cli flags to enable run the
benchmark.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
