### PR TITLE
feat: split ilab config init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ issues = "https://github.com/instructlab/instructlab/issues"
 
 [project.entry-points."instructlab.command.config"]
 "edit" = "instructlab.config.edit:edit"
-"init" = "instructlab.config.init:init"
+"init" = "instructlab.cli.config.init:init"
 "show" = "instructlab.config.show:show"
 
 [project.entry-points."instructlab.command.data"]

--- a/src/instructlab/cli/config/init.py
+++ b/src/instructlab/cli/config/init.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from os import listdir
+from os.path import dirname, exists
+import logging
+import pathlib
+import typing
+
+# Third Party
+from git import GitError, Repo
+import click
+
+# First Party
+from instructlab import clickext, utils
+from instructlab.config.init import initialize_config
+from instructlab.configuration import (
+    DEFAULTS,
+    Config,
+    configs_exist,
+    ensure_storage_directories_exist,
+    get_default_config,
+    profiles_exist,
+    read_config,
+    write_config,
+)
+from instructlab.defaults import DEFAULT_INDENT
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option(
+    "--interactive/--non-interactive",
+    default=True,
+    show_default=True,
+    help="Initialize the environment assuming defaults.",
+)
+@click.option(
+    "--model-path",
+    type=click.Path(),
+    default=lambda: DEFAULTS.DEFAULT_CHAT_MODEL,
+    show_default="The instructlab data files location per the user's system.",
+    help="Path to the model used during generation.",
+)
+@click.option(
+    "--taxonomy-base",
+    default=DEFAULTS.TAXONOMY_BASE,
+    show_default=True,
+    help="Base git-ref to use when listing/generating new taxonomy.",
+)
+@click.option(
+    "--taxonomy-path",
+    type=click.Path(),
+    default=lambda: DEFAULTS.TAXONOMY_DIR,
+    show_default="The instructlab data files location per the user's system.",
+    help="Path to where the taxonomy should be cloned.",
+)
+@click.option(
+    "--repository",
+    default=DEFAULTS.TAXONOMY_REPO,
+    show_default=True,
+    help="Taxonomy repository location.",
+)
+@click.option(
+    "--min-taxonomy",
+    is_flag=True,
+    help="Shallow clone the taxonomy repository with minimum size. "
+    "Please do not use this option if you are planning to contribute back "
+    "using the same taxonomy repository. ",
+)
+@click.option(
+    "--profile",
+    type=click.Path(),
+    default=None,
+    help="Overwrite the default values in the generated config.yaml by passing in an existing configuration yaml.",
+)
+@click.option(
+    "--config",
+    "config_file",
+    type=click.Path(),
+    default=None,
+    envvar=DEFAULTS.ILAB_GLOBAL_CONFIG,
+    show_default=True,
+    help="Path to a configuration file.",
+)
+@clickext.display_params
+@click.pass_context
+def init(
+    ctx,
+    interactive,
+    model_path: str,
+    taxonomy_path,
+    taxonomy_base,
+    repository,
+    min_taxonomy,
+    profile,
+    config_file,
+):
+    """Initializes environment for InstructLab"""
+    param_source = ctx.get_parameter_source("config_file")
+    fresh_install = ensure_storage_directories_exist()
+    overwrite_profile = False
+    if interactive:
+        overwrite_profile = check_if_configs_exist(fresh_install)
+    model_path, taxonomy_path, cfg = get_params(
+        param_source,
+        interactive,
+        repository,
+        min_taxonomy,
+        model_path,
+        taxonomy_path,
+        config_file,
+    )
+    # auto-detect and write config
+    new_cfg, arch_family_processors, is_default_config = initialize_config(
+        cfg=cfg,
+        profile=profile,
+        overwrite_profile=overwrite_profile,
+        fresh_install=fresh_install,
+        write_to_disk=False,
+    )
+    if is_default_config and interactive:
+        # if auto detection didn't work, just continue prompting as usual!
+        key = prompt_user_to_choose_vendors(arch_family_processors)
+
+        if key is not None:
+            for i, arch_family_processor in enumerate(
+                arch_family_processors[key], start=1
+            ):
+                click.echo(
+                    f"[{i}] {' '.join(map(str, arch_family_processor[0])).upper()}"
+                )
+            # pass the specific manufacturer specific list of tuples containing config names
+            new_cfg = prompt_user_to_choose_profile(arch_family_processors[key])
+    if new_cfg is not None:
+        cfg = new_cfg
+    # we should not override all paths with the serve model if special ENV vars exist
+    if param_source != click.core.ParameterSource.ENVIRONMENT:
+        cfg.chat.model = model_path
+        cfg.serve.model_path = model_path
+        cfg.evaluate.model = model_path
+        cfg.generate.taxonomy_base = taxonomy_base
+        cfg.generate.taxonomy_path = taxonomy_path
+        cfg.evaluate.mt_bench_branch.taxonomy_path = taxonomy_path
+    write_config(cfg=cfg)
+    # this means auto-detect failed so we didn't print anything
+    if is_default_config:
+        utils.print_init_success()
+
+
+# prompt_user_to_choose_vendors asks the user which hardware vendor best matches their system
+def prompt_user_to_choose_vendors(
+    arch_family_processors: dict[str, list[tuple[list[str], str]]],
+) -> str | None:
+    """
+    prompt_user_to_choose_vendors asks the user which hardware vendor best matches their system
+    """
+    key = None
+    click.echo(
+        click.style(
+            "Please choose a system profile.\nProfiles set hardware-specific defaults for all commands and sections of the configuration.",
+            fg="green",
+        )
+    )
+    # print info like APPLE, AMD, INTEL and have them select
+    click.echo(
+        click.style(
+            "First, please select the hardware vendor your system falls into",
+            bg="blue",
+            fg="white",
+        )
+    )
+    click.echo("[0] NO SYSTEM PROFILE")
+    keys = list(arch_family_processors.keys())
+    for idx, k in enumerate(keys, 1):
+        click.echo(f"[{idx}] {k.upper()}")
+
+    system_profile_selection = click.prompt(
+        "Enter the number of your choice",
+        type=click.IntRange(0, len(keys)),
+        default=0,
+    )
+    if 1 <= system_profile_selection <= len(keys):
+        key = keys[system_profile_selection - 1]
+        click.echo(f"You selected: {key.upper()}")
+        click.echo(
+            click.style(
+                "Next, please select the specific hardware configuration that most closely matches your system.",
+                bg="blue",
+                fg="white",
+            )
+        )
+        click.echo("[0] NO SYSTEM PROFILE")
+    elif system_profile_selection == 0:
+        click.echo(
+            "No profile selected - ilab will use generic code defaults - these may not be optimized for your system."
+        )
+    return key
+
+
+# prompt_user_to_choose_profile asks the user to choose which specific profile for the hardware vendor best matches their system
+def prompt_user_to_choose_profile(arch_family_processors) -> Config | None:
+    """
+    prompt_user_to_choose_profile asks the user to choose which specific profile for the hardware vendor best matches their system
+    """
+    cfg = None
+    system_profile_selection = click.prompt(
+        "Enter the number of your choice [hit enter for hardware defaults]",
+        type=click.IntRange(0, len(arch_family_processors)),
+        default=0,
+    )
+    # the file is SYSTEM_PROFILE_DIR/arch_family_processors[key][selection-1]
+    if 1 <= system_profile_selection <= len(arch_family_processors):
+        file = arch_family_processors[system_profile_selection - 1][1]
+        click.secho(f"You selected: {file}", fg="green")
+        cfg = read_config(file)
+    elif system_profile_selection == 0:
+        click.echo(
+            "No profile selected - ilab will use generic code defaults - these may not be optimized for your system."
+        )
+    return cfg
+
+
+def check_if_configs_exist(fresh_install) -> bool:
+    if configs_exist():
+        click.echo(
+            f"Existing config file was found in:\n{DEFAULT_INDENT}{DEFAULTS.CONFIG_FILE}"
+        )
+        overwrite = click.confirm("Do you still want to continue?")
+        if not overwrite:
+            raise click.exceptions.Exit(0)
+    if profiles_exist(fresh_install=fresh_install):
+        return click.confirm(
+            f"\nExisting system profiles were found in:\n{DEFAULT_INDENT}{DEFAULTS.SYSTEM_PROFILE_DIR}\nDo you want to restore these profiles to the default values?"
+        )
+    # default behavior should be do NOT overwrite files that could have just been created
+    return False
+
+
+def get_params_from_env(
+    obj: typing.Optional[typing.Any],
+) -> typing.Tuple[str, str, Config]:
+    if obj is None or not hasattr(obj, "config"):
+        raise ValueError("obj must not be None and must have a 'config' attribute")
+    return (
+        obj.config.generate.taxonomy_path,
+        obj.config.generate.taxonomy_base,
+        obj.config,
+    )
+
+
+def get_params(
+    param_source: click.core.ParameterSource,
+    interactive: bool,
+    repository: str,
+    min_taxonomy: bool,
+    model_path: str,
+    taxonomy_path: pathlib.Path,
+    config: pathlib.Path | None,
+) -> typing.Tuple[str, pathlib.Path, Config]:
+    cfg = get_default_config()
+    if config is not None:
+        cfg = read_config(config)
+    clone_taxonomy_repo = True
+    if interactive:
+        guide_text = "  This guide will help you to setup your environment"
+        separator = utils.get_separator(guide_text)
+        click.echo(
+            f"\n{separator}\n         Welcome to the InstructLab CLI\n{guide_text}\n{separator}\n"
+        )
+        click.echo(
+            "Please provide the following values to initiate the "
+            "environment [press 'Enter' for default options when prompted]"
+        )
+        if param_source != click.core.ParameterSource.ENVIRONMENT:
+            taxonomy_path = utils.expand_path(
+                click.prompt("Path to taxonomy repo", default=taxonomy_path)
+            )
+
+    try:
+        taxonomy_contents = listdir(taxonomy_path)
+    except FileNotFoundError:
+        taxonomy_contents = []
+    if taxonomy_contents:
+        clone_taxonomy_repo = False
+    elif interactive and param_source != click.core.ParameterSource.ENVIRONMENT:
+        click.echo(f"`{taxonomy_path}` seems to not exist or is empty.")
+        clone_taxonomy_repo = click.confirm(
+            f"Should I clone {repository} for you?",
+            default=True,
+        )
+
+    # clone taxonomy repo if it needs to be cloned
+    if clone_taxonomy_repo:
+        click.echo(f"Cloning {repository}...")
+        clone_depth = False if not min_taxonomy else 1
+        try:
+            Repo.clone_from(
+                repository,
+                taxonomy_path,
+                branch="main",
+                recurse_submodules=True,
+                depth=clone_depth,
+            )
+        except GitError as exc:
+            click.secho(f"Failed to clone taxonomy repo: {exc}", fg="red")
+            click.secho(f"Please make sure to manually run `git clone {repository}`")
+            raise click.exceptions.Exit(1)
+
+    # check if models dir exists, and if so ask for which model to use
+    models_dir = dirname(model_path)
+    if (
+        interactive
+        and exists(models_dir)
+        and param_source != click.core.ParameterSource.ENVIRONMENT
+    ):
+        model_path = utils.expand_path(
+            click.prompt("Path to your model", default=model_path)
+        )
+
+    return model_path, taxonomy_path, cfg

--- a/src/instructlab/config/init.py
+++ b/src/instructlab/config/init.py
@@ -1,26 +1,17 @@
-# SPDX-License-Identifier: Apache-2.0
-
 # Standard
 from math import floor
-from os import listdir
-from os.path import dirname, exists
 import logging
 import os
-import pathlib
-import shutil
-import typing
-
-# Third Party
-from git import GitError, Repo
-import click
 
 # First Party
-from instructlab import clickext, utils
+from instructlab import utils
 from instructlab.configuration import (
     DEFAULTS,
     Config,
+    configs_exist,
     ensure_storage_directories_exist,
     get_default_config,
+    profiles_exist,
     read_config,
     recreate_system_profiles,
     write_config,
@@ -31,198 +22,130 @@ from instructlab.utils import convert_bytes_to_proper_mag
 logger = logging.getLogger(__name__)
 
 
-@click.command()
-@click.option(
-    "--interactive/--non-interactive",
-    default=True,
-    show_default=True,
-    help="Initialize the environment assuming defaults.",
-)
-@click.option(
-    "--model-path",
-    type=click.Path(),
-    default=lambda: DEFAULTS.DEFAULT_CHAT_MODEL,
-    show_default="The instructlab data files location per the user's system.",
-    help="Path to the model used during generation.",
-)
-@click.option(
-    "--taxonomy-base",
-    default=DEFAULTS.TAXONOMY_BASE,
-    show_default=True,
-    help="Base git-ref to use when listing/generating new taxonomy.",
-)
-@click.option(
-    "--taxonomy-path",
-    type=click.Path(),
-    default=lambda: DEFAULTS.TAXONOMY_DIR,
-    show_default="The instructlab data files location per the user's system.",
-    help="Path to where the taxonomy should be cloned.",
-)
-@click.option(
-    "--repository",
-    default=DEFAULTS.TAXONOMY_REPO,
-    show_default=True,
-    help="Taxonomy repository location.",
-)
-@click.option(
-    "--min-taxonomy",
-    is_flag=True,
-    help="Shallow clone the taxonomy repository with minimum size. "
-    "Please do not use this option if you are planning to contribute back "
-    "using the same taxonomy repository. ",
-)
-@click.option(
-    "--profile",
-    type=click.Path(),
-    default=None,
-    help="Overwrite the default values in the generated config.yaml by passing in an existing configuration yaml.",
-)
-@click.option(
-    "--config",
-    "config_file",
-    type=click.Path(),
-    default=None,
-    envvar=DEFAULTS.ILAB_GLOBAL_CONFIG,
-    show_default=True,
-    help="Path to a configuration file.",
-)
-@clickext.display_params
-@click.pass_context
-def init(
-    ctx,
-    interactive,
-    model_path: str,
-    taxonomy_path,
-    taxonomy_base,
-    repository,
-    min_taxonomy,
-    profile,
-    config_file,
-):
-    """Initializes environment for InstructLab"""
-    fresh_install = ensure_storage_directories_exist()
-    param_source = ctx.get_parameter_source("config_file")
-    overwrite_profile = False
-    if interactive:
-        overwrite_profile = check_if_configs_exist(fresh_install)
-    model_path, taxonomy_path, cfg = get_params(
-        param_source,
-        interactive,
-        repository,
-        min_taxonomy,
-        model_path,
-        taxonomy_path,
-        config_file,
+def initialize_config(
+    cfg: Config | None = None,
+    profile: os.PathLike | None = None,
+    overwrite_profile: bool = False,
+    fresh_install: bool = False,
+    write_to_disk: bool = True,
+) -> tuple[Config | None, dict[str, list[tuple[list[str], str]]], bool]:
+    """
+    initialize_config is a standalone way to get an auto-detected InstructLab configuration file
+    This will check your hardware and automatically select a profile for you. If none match, the default
+    configuration will be returned.
+
+    This function optionally takes some arguments if being called by the CLI. Leaving all of these blank will assume you want a fresh config.
+
+
+    The return values are a Config object, a list of the parsed profiles on disk, and a bool indicating if we selected a profile.
+    Most of these return values are used in the CLI.
+
+    Args:
+      cfg: Config | None
+      profile: Path | None
+      overwrite_profile: bool
+      fresh_install: bool
+      write_to_disk: bool
+
+    Returns:
+       cfg: Config
+       arch_family_processors: dict[str, list[tuple[list[str], str]]]
+       is_default_config: bool
+
+    """
+    cfg = get_default_config() if cfg is None else cfg
+    is_default_config = True
+    arch_family_processors: dict[str, list[tuple[list[str], str]]] = {}
+    fresh_install = fresh_install or ensure_storage_directories_exist()
+    overwrite_profiles = (
+        overwrite_profile or configs_exist() or profiles_exist(fresh_install)
     )
-    if overwrite_profile:
-        click.echo(
+    if overwrite_profiles:
+        logger.info(
             f"\nGenerating config file and profiles:\n{DEFAULT_INDENT}{DEFAULTS.CONFIG_FILE}\n{DEFAULT_INDENT}{DEFAULTS.SYSTEM_PROFILE_DIR}\n"
         )
         recreate_system_profiles(overwrite=True)
     else:
-        click.echo(
-            f"\nGenerating config file:\n{DEFAULT_INDENT}{DEFAULTS.CONFIG_FILE}\n"
-        )
+        print(f"\nGenerating config file:\n{DEFAULT_INDENT}{DEFAULTS.CONFIG_FILE}\n")
     if profile is not None:
         cfg = read_config(profile)
-    elif interactive:
-        new_cfg = hw_auto_detect()
+        is_default_config = False
+    else:
+        new_cfg, arch_family_processors = hw_auto_detect()
         if new_cfg is not None:
+            is_default_config = False
             cfg = new_cfg
-    # we should not override all paths with the serve model if special ENV vars exist
-    if param_source != click.core.ParameterSource.ENVIRONMENT:
-        cfg.chat.model = model_path
-        cfg.serve.model_path = model_path
-        cfg.evaluate.model = model_path
-        cfg.generate.taxonomy_base = taxonomy_base
-        cfg.generate.taxonomy_path = taxonomy_path
-        cfg.evaluate.mt_bench_branch.taxonomy_path = taxonomy_path
-    write_config(cfg)
+    if write_to_disk:
+        write_config(cfg)
 
-    ready_text = "  You're ready to start using `ilab`. Enjoy!"
-    separator = get_separator(ready_text)
-    click.secho(
-        f"\n{separator}\n{DEFAULT_INDENT}Initialization completed successfully!\n{ready_text}\n{separator}",
-        fg="green",
-    )
+    if not is_default_config:
+        utils.print_init_success()
+    return cfg, arch_family_processors, is_default_config
 
 
-# prompt_user_to_choose_vendors asks the user which hardware vendor best matches their system
-def prompt_user_to_choose_vendors(
-    arch_family_processors: dict[str, list[tuple[list[str], str]]],
-) -> str | None:
+def get_chip_name() -> str:
     """
-    prompt_user_to_choose_vendors asks the user which hardware vendor best matches their system
+    get_chip_name returns the name of the processor on the system (Linux or Mac for now).
     """
-    key = None
-    click.echo(
-        click.style(
-            "Please choose a system profile.\nProfiles set hardware-specific defaults for all commands and sections of the configuration.",
-            fg="green",
-        )
-    )
-    # print info like APPLE, AMD, INTEL and have them select
-    click.echo(
-        click.style(
-            "First, please select the hardware vendor your system falls into",
-            bg="blue",
-            fg="white",
-        )
-    )
-    click.echo("[0] NO SYSTEM PROFILE")
-    keys = list(arch_family_processors.keys())
-    for idx, k in enumerate(keys, 1):
-        click.echo(f"[{idx}] {k.upper()}")
+    # Standard
+    import platform
+    import subprocess
 
-    system_profile_selection = click.prompt(
-        "Enter the number of your choice",
-        type=click.IntRange(0, len(keys)),
-        default=0,
-    )
-    if 1 <= system_profile_selection <= len(keys):
-        key = keys[system_profile_selection - 1]
-        click.echo(f"You selected: {key.upper()}")
-        click.echo(
-            click.style(
-                "Next, please select the specific hardware configuration that most closely matches your system.",
-                bg="blue",
-                fg="white",
+    system = platform.system()
+
+    if system == "Darwin":  # macOS
+        try:
+            # macOS: Use system_profiler for detailed hardware info
+            result = subprocess.run(
+                ["system_profiler", "SPHardwareDataType"],
+                capture_output=True,
+                text=True,
+                check=True,
             )
-        )
-        click.echo("[0] NO SYSTEM PROFILE")
-    elif system_profile_selection == 0:
-        click.echo(
-            "No profile selected - ilab will use generic code defaults - these may not be optimized for your system."
-        )
-    return key
+            for line in result.stdout.splitlines():
+                if "Chip" in line or "Processor Name" in line:
+                    return line.split(":")[-1].strip().lower()
+        except subprocess.CalledProcessError:
+            return "Unsupported"
 
+    elif system == "Linux":  # Linux
+        try:
+            # Linux: Read /proc/cpuinfo for CPU model information
+            with open("/proc/cpuinfo", "r", encoding="utf-8") as f:
+                for line in f:
+                    if "model name" in line:
+                        cpu_name = line.split(":")[-1].strip().lower().split(" ")[0]
+                        cpu_name = f"{cpu_name} cpu"
+                        if "intel" in cpu_name:
+                            # intel returns intel(r)
+                            cpu_name = "intel cpu"
+        except FileNotFoundError:
+            return "Unsupported"
 
-# prompt_user_to_choose_profile asks the user to choose which specific profile for the hardware vendor best matches their system
-def prompt_user_to_choose_profile(arch_family_processors) -> Config | None:
-    """
-    prompt_user_to_choose_profile asks the user to choose which specific profile for the hardware vendor best matches their system
-    """
-    cfg = None
-    system_profile_selection = click.prompt(
-        "Enter the number of your choice [hit enter for hardware defaults]",
-        type=click.IntRange(0, len(arch_family_processors)),
-        default=0,
+    logger.warning(
+        "ilab is only officially supported on Linux and MacOS with M-Series Chips"
     )
-    # the file is SYSTEM_PROFILE_DIR/arch_family_processors[key][selection-1]
-    if 1 <= system_profile_selection <= len(arch_family_processors):
-        file = arch_family_processors[system_profile_selection - 1][1]
-        click.secho(f"You selected: {file}", fg="green")
-        cfg = read_config(file)
-    elif system_profile_selection == 0:
-        click.echo(
-            "No profile selected - ilab will use generic code defaults - these may not be optimized for your system."
-        )
-    return cfg
+    return "Unsupported"
 
 
-def walk_and_print_system_profiles(
+# hw_auto_detect looks at a user's GPUs or CPU configuration and chooses the system profile which matches your system
+def hw_auto_detect() -> tuple[Config | None, dict[str, list[tuple[list[str], str]]]]:
+    """
+    hw_auto_detect looks at a user's GPUs or CPU configuration and chooses the system profile which matches your system
+    """
+
+    (
+        chip_name,
+        vram,
+        gpus,
+    ) = get_gpu_or_cpu()
+
+    return walk_and_choose_system_profile(vram, gpus, chip_name)
+
+
+def walk_and_choose_system_profile(
     vram: int, gpus: int, chip_name: str
-) -> Config | None:
+) -> tuple[Config | None, dict[str, list[tuple[list[str], str]]]]:
     """
     walk_and_print_system_profiles prints interactive prompts asking the user to choose
     their hardware vendor and system profile. If a profile is auto detected to match the
@@ -294,25 +217,12 @@ def walk_and_print_system_profiles(
     if cfg is not None:
         if "a100" in chip_name and vram == 320 and gpus == 8:
             cfg.train.max_batch_len = 10000
-        chosen_profile = click.style(
-            " ".join(full_chip_name).upper(),
-            bg="blue",
-            fg="white",
+        processor = " ".join(full_chip_name).upper()
+        print(
+            f"We have detected the {processor} profile as an exact match for your system."
         )
-        click.secho(
-            f"We have detected the {chosen_profile} profile as an exact match for your system."
-        )
-        return cfg
 
-    # if auto detection didn't work, just continue prompting as usual!
-    key = prompt_user_to_choose_vendors(arch_family_processors)
-
-    if key is not None:
-        for i, arch_family_processor in enumerate(arch_family_processors[key], start=1):
-            click.echo(f"[{i}] {' '.join(map(str, arch_family_processor[0])).upper()}")
-        # pass the specific manufacturer specific list of tuples containing config names
-        cfg = prompt_user_to_choose_profile(arch_family_processors[key])
-    return cfg
+    return cfg, arch_family_processors
 
 
 def is_hpu_available() -> bool:
@@ -346,7 +256,7 @@ def get_gpu_or_cpu() -> tuple[str, int, int]:
     no_rocm_or_hpu = torch.version.hip is None and not is_hpu_available()
     # try nvidia
     if torch.cuda.is_available() and no_rocm_or_hpu:
-        click.echo("Detecting hardware...")
+        logger.info("Detecting hardware...")
         gpus = torch.cuda.device_count()
         for i in range(gpus):
             chip_name, vram = utils.get_cuda_device_properties(i)
@@ -367,174 +277,3 @@ def get_gpu_or_cpu() -> tuple[str, int, int]:
         vram,
         gpus,
     )
-
-
-# hw_auto_detect looks at a user's GPUs or CPU configuration and chooses the system profile which matches your system
-def hw_auto_detect() -> Config | None:
-    """
-    hw_auto_detect looks at a user's GPUs or CPU configuration and chooses the system profile which matches your system
-    """
-
-    (
-        chip_name,
-        vram,
-        gpus,
-    ) = get_gpu_or_cpu()
-
-    return walk_and_print_system_profiles(vram, gpus, chip_name)
-
-
-def check_if_configs_exist(fresh_install) -> bool:
-    if exists(DEFAULTS.CONFIG_FILE):
-        click.echo(
-            f"Existing config file was found in:\n{DEFAULT_INDENT}{DEFAULTS.CONFIG_FILE}"
-        )
-        overwrite = click.confirm("Do you still want to continue?")
-        if not overwrite:
-            raise click.exceptions.Exit(0)
-    if exists(DEFAULTS.SYSTEM_PROFILE_DIR) and not fresh_install:
-        return click.confirm(
-            f"\nExisting system profiles were found in:\n{DEFAULT_INDENT}{DEFAULTS.SYSTEM_PROFILE_DIR}\nDo you want to restore these profiles to the default values?"
-        )
-    # default behavior should be do NOT overwrite files that could have just been created
-    return False
-
-
-def get_params_from_env(
-    obj: typing.Optional[typing.Any],
-) -> typing.Tuple[str, str, Config]:
-    if obj is None or not hasattr(obj, "config"):
-        raise ValueError("obj must not be None and must have a 'config' attribute")
-    return (
-        obj.config.generate.taxonomy_path,
-        obj.config.generate.taxonomy_base,
-        obj.config,
-    )
-
-
-def get_params(
-    param_source: click.core.ParameterSource,
-    interactive: bool,
-    repository: str,
-    min_taxonomy: bool,
-    model_path: str,
-    taxonomy_path: pathlib.Path,
-    config: pathlib.Path | None,
-) -> typing.Tuple[str, pathlib.Path, Config]:
-    cfg = get_default_config()
-    if config is not None:
-        cfg = read_config(config)
-    clone_taxonomy_repo = True
-    if interactive:
-        guide_text = "  This guide will help you to setup your environment"
-        separator = get_separator(guide_text)
-        click.echo(
-            f"\n{separator}\n         Welcome to the InstructLab CLI\n{guide_text}\n{separator}\n"
-        )
-        click.echo(
-            "Please provide the following values to initiate the "
-            "environment [press 'Enter' for default options when prompted]"
-        )
-        if param_source != click.core.ParameterSource.ENVIRONMENT:
-            taxonomy_path = utils.expand_path(
-                click.prompt("Path to taxonomy repo", default=taxonomy_path)
-            )
-
-    try:
-        taxonomy_contents = listdir(taxonomy_path)
-    except FileNotFoundError:
-        taxonomy_contents = []
-    if taxonomy_contents:
-        clone_taxonomy_repo = False
-    elif interactive and param_source != click.core.ParameterSource.ENVIRONMENT:
-        click.echo(f"`{taxonomy_path}` seems to not exist or is empty.")
-        clone_taxonomy_repo = click.confirm(
-            f"Should I clone {repository} for you?",
-            default=True,
-        )
-
-    # clone taxonomy repo if it needs to be cloned
-    if clone_taxonomy_repo:
-        click.echo(f"Cloning {repository}...")
-        clone_depth = False if not min_taxonomy else 1
-        try:
-            Repo.clone_from(
-                repository,
-                taxonomy_path,
-                branch="main",
-                recurse_submodules=True,
-                depth=clone_depth,
-            )
-        except GitError as exc:
-            click.secho(f"Failed to clone taxonomy repo: {exc}", fg="red")
-            click.secho(f"Please make sure to manually run `git clone {repository}`")
-            raise click.exceptions.Exit(1)
-
-    # check if models dir exists, and if so ask for which model to use
-    models_dir = dirname(model_path)
-    if (
-        interactive
-        and exists(models_dir)
-        and param_source != click.core.ParameterSource.ENVIRONMENT
-    ):
-        model_path = utils.expand_path(
-            click.prompt("Path to your model", default=model_path)
-        )
-
-    return model_path, taxonomy_path, cfg
-
-
-def get_separator(text: str) -> str:
-    text_length = len(text)
-    try:
-        terminal_width = shutil.get_terminal_size().columns
-    except Exception:  # pylint: disable=broad-exception-caught
-        # Exception can occur in non-interactive scenarios where no terminal is associated with the process
-        terminal_width = text_length
-    separator_length = min(text_length, terminal_width)
-    return "-" * separator_length
-
-
-def get_chip_name() -> str:
-    """
-    get_chip_name returns the name of the processor on the system (Linux or Mac for now).
-    """
-    # Standard
-    import platform
-    import subprocess
-
-    system = platform.system()
-
-    if system == "Darwin":  # macOS
-        try:
-            # macOS: Use system_profiler for detailed hardware info
-            result = subprocess.run(
-                ["system_profiler", "SPHardwareDataType"],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            for line in result.stdout.splitlines():
-                if "Chip" in line or "Processor Name" in line:
-                    return line.split(":")[-1].strip().lower()
-        except subprocess.CalledProcessError:
-            return "Unsupported"
-
-    elif system == "Linux":  # Linux
-        try:
-            # Linux: Read /proc/cpuinfo for CPU model information
-            with open("/proc/cpuinfo", "r", encoding="utf-8") as f:
-                for line in f:
-                    if "model name" in line:
-                        cpu_name = line.split(":")[-1].strip().lower().split(" ")[0]
-                        cpu_name = f"{cpu_name} cpu"
-                        if "intel" in cpu_name:
-                            # intel returns intel(r)
-                            cpu_name = "intel cpu"
-        except FileNotFoundError:
-            return "Unsupported"
-
-    logger.warning(
-        "ilab is only officially supported on Linux and MacOS with M-Series Chips"
-    )
-    return "Unsupported"

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -1568,3 +1568,11 @@ def storage_dirs_exist() -> bool:
         DEFAULTS.LOGS_DIR,
     ]
     return all(os.path.exists(dirpath) for dirpath in dirs_to_check)
+
+
+def profiles_exist(fresh_install) -> bool:
+    return os.path.exists(DEFAULTS.SYSTEM_PROFILE_DIR) and not fresh_install
+
+
+def configs_exist() -> bool:
+    return os.path.exists(DEFAULTS.CONFIG_FILE)

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -1079,3 +1079,34 @@ def get_cuda_device_properties(gpu_num: int) -> tuple[str, int]:
     properties = torch.cuda.get_device_properties(gpu_num)
     chip_name = properties.name.lower()
     return chip_name, int(properties.total_memory)
+
+
+def get_separator(text: str) -> str:
+    """
+    get_seeparator takes an input string and formats it according to the system's terminal
+
+    Args:
+        text (str): the input string to process
+    Returns
+        str: a string containing the proper amount of dashes according to the separator length
+    """
+    text_length = len(text)
+    try:
+        terminal_width = shutil.get_terminal_size().columns
+    except Exception:  # pylint: disable=broad-exception-caught
+        # Exception can occur in non-interactive scenarios where no terminal is associated with the process
+        terminal_width = text_length
+    separator_length = min(text_length, terminal_width)
+    return "-" * separator_length
+
+
+def print_init_success():
+    """
+    print_init_success is a helper function to tell the user their system is ready, and they can start using ilab.
+    This is used in both the CLI and the config initialization package. A user can use either path independently to initialize a config.
+    """
+    ready_text = "  You're ready to start using `ilab`. Enjoy!"
+    separator = get_separator(ready_text)
+    print(
+        f"\n{separator}\n{DEFAULT_INDENT}Initialization completed successfully!\n{ready_text}\n{separator}",
+    )

--- a/tests/test_lab_init.py
+++ b/tests/test_lab_init.py
@@ -208,7 +208,7 @@ class TestLabInit:
     # of your module, so you should use `my_module.Y`` to patch.
     # When using `import X`, you should use `X.Y` to patch.
     # https://docs.python.org/3/library/unittest.mock.html#where-to-patch?
-    @patch("instructlab.config.init.Repo.clone_from")
+    @patch("instructlab.cli.config.init.Repo.clone_from")
     def test_init_noninteractive(self, mock_clone_from, cli_runner: CliRunner):
         result = cli_runner.invoke(lab.ilab, ["config", "init", "--non-interactive"])
         assert result.exit_code == 0
@@ -216,7 +216,7 @@ class TestLabInit:
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         mock_clone_from.assert_called_once()
 
-    @patch("instructlab.config.init.Repo.clone_from")
+    @patch("instructlab.cli.config.init.Repo.clone_from")
     def test_init_interactive(self, mock_clone_from, cli_runner: CliRunner):
         result = cli_runner.invoke(lab.ilab, ["config", "init"], input="\nn")
         assert result.exit_code == 0
@@ -225,7 +225,7 @@ class TestLabInit:
         mock_clone_from.assert_not_called()
 
     @patch(
-        "instructlab.config.init.Repo.clone_from",
+        "instructlab.cli.config.init.Repo.clone_from",
         MagicMock(side_effect=GitError("Authentication failed")),
     )
     def test_init_interactive_git_error(self, cli_runner: CliRunner):
@@ -234,14 +234,14 @@ class TestLabInit:
         assert "Failed to clone taxonomy repo: Authentication failed" in result.output
         assert "manually run" in result.output
 
-    @patch("instructlab.config.init.Repo.clone_from")
+    @patch("instructlab.cli.config.init.Repo.clone_from")
     def test_init_interactive_clone(self, mock_clone_from, cli_runner: CliRunner):
         result = cli_runner.invoke(lab.ilab, ["config", "init"], input="y\n\ny")
         assert result.exit_code == 0
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         mock_clone_from.assert_called_once()
 
-    @patch("instructlab.config.init.Repo.clone_from")
+    @patch("instructlab.cli.config.init.Repo.clone_from")
     def test_init_interactive_default_clone(
         self, mock_clone_from, cli_runner: CliRunner
     ):
@@ -250,7 +250,7 @@ class TestLabInit:
         assert "config.yaml" in os.listdir(DEFAULTS._config_dir)
         mock_clone_from.assert_called_once()
 
-    @patch("instructlab.config.init.Repo.clone_from")
+    @patch("instructlab.cli.config.init.Repo.clone_from")
     def test_init_interactive_with_preexisting_nonempty_taxonomy(
         self, mock_clone_from, cli_runner: CliRunner
     ):


### PR DESCRIPTION
split `ilab config init` into two packages `src/instructlab/cli/config/init.py` and `src/instructlab/config/init.py`

`initialize_config` is the new method in the `config/init.py` package and acts as a standalone way to initialize an instructlab config file via python.

This method needs to take a few arguments since it can be "driven" from the CLI or via someone calling the method manually. Most args are meant to be passed via the CLI and can left blank

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
