### PR TITLE
github: reduce amount of time for issue to be marked stale

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -33,17 +33,17 @@ jobs:
         with:
           stale-issue-label: 'stale'
           stale-issue-message: >
-            This issue has been automatically marked as stale because it has not had activity within 90 days.
+            This issue has been automatically marked as stale because it has not had activity within 60 days.
             It will be automatically closed if no further activity occurs within 30 days.
           close-issue-message: >
             This issue has been automatically closed due to inactivity. Please feel free to reopen if you feel it is still relevant!
-          days-before-issue-stale: 90
+          days-before-issue-stale: 60
           days-before-issue-close: 30
           stale-pr-label: 'stale'
           stale-pr-message: >
-            This pull request has been automatically marked as stale because it has not had activity within 90 days.
+            This pull request has been automatically marked as stale because it has not had activity within 60 days.
             It will be automatically closed if no further activity occurs within 30 days.
           close-pr-message: >
             This pull request has been automatically closed due to inactivity. Please feel free to reopen if you intend to continue working on it!
-          days-before-pr-stale: 90
+          days-before-pr-stale: 60
           days-before-pr-close: 30


### PR DESCRIPTION
currently it takes 90 days for an issue to be marked as stale and another 30 for it to be autoclosed

this commit reduces to a 60/30 cadence

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
