### PR TITLE
feat: Remove hpu (Gaudi) support from simple training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking Changes
 
 - llama-cpp-python has been bumped to 0.3.2. This allows for serving of Granite 3.0 GGUF Models. With this change, some previous handling of context window size has been modified to work with the 0.3.z releases of llama-cpp-python.
+- `ilab train --pipeline=simple` no longer supports Intel Gaudi (`hpu`) devices. Simple training on Gaudi was experimental and limited to a single device.
 
 ### Features
 

--- a/docs/habana-gaudi.md
+++ b/docs/habana-gaudi.md
@@ -10,7 +10,6 @@
 - Intel Gaudi 2 device
 - [Habana Labs](https://docs.habana.ai/en/latest/index.html) software stack (tested with 1.18.0)
 - software from Habana Vault for [RHEL](https://vault.habana.ai/ui/native/rhel) and [PyTorch](https://vault.habana.ai/ui/native/gaudi-pt-modules)
-- software [HabanaAI GitHub](https://github.com/HabanaAI/) org like [optimum-habana](https://github.com/HabanaAI/optimum-habana-fork) fork
 
 ## System preparation
 
@@ -126,8 +125,6 @@ Validate installation:
 ## Habana Lab's PyTorch stack
 
 Habana Labs comes with a modified fork of PyTorch that is build with Intel's oneAPI Math Kernel Library (oneMKL). The actual HPU bindings and helpers are provided by the `habana_framework` package. Imports of `habana_framework` sub-packages register `hpu` device support, `torch.hpu` module, and `dynamo` backends.
-
-The [`SFTTrainer`](https://huggingface.co/docs/trl/sft_trainer) from `trl` does not work with Habana stack. Instead the `GaudiSFTTrainer` from [optimum-habana](https://huggingface.co/docs/optimum/habana/index) is needed. The version on PyPI is currently broken, but the HabanaAI [optimum-habana-fork](https://github.com/HabanaAI/optimum-habana-fork) works.
 
 ## Install and run InstructLab with Intel Gaudi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,6 @@ module = [
   "instructlab_quantize",
   "instructlab.training",
   "mlx.*",
-  "optimum.habana.*",
   "ruamel",
   "sentencepiece",
   "trl",

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ toml>=0.10.2
 # Default version. Can be overridden in extra requirements
 torch>=2.3.0,<2.6.0
 tqdm>=4.66.2
-# 'optimum' for Intel Gaudi needs transformers <4.44.0,>=4.43.0
 transformers>=4.41.2
 trl>=0.12.2
 wandb>=0.16.4

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -1,15 +1,12 @@
 # Dependencies for Intel Gaudi / Habana Labs HPU devices
 #
 
-# Habana Labs 1.18.0 has 2.4.0a0+git74cd574 pre-release
-torch>=2.4.0a0,<2.5.0
 # Habana Labs frameworks
 habana-torch-plugin>=1.18.0
 habana_gpu_migration>=1.18.0
 # additional Habana Labs packages (installed, but not used)
 #habana-media-loader
 #habana-pyhlml
-#habana_quantization_toolkit
 #habana-torch-dataloader
 
 # Extra dependencies for Intel Gaudi cards

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -1,8 +1,6 @@
 # Dependencies for Intel Gaudi / Habana Labs HPU devices
 #
 
-optimum>=1.21.0
-optimum-habana>=1.13.2
 # Habana Labs 1.18.0 has 2.4.0a0+git74cd574 pre-release
 torch>=2.4.0a0,<2.5.0
 # Habana Labs frameworks


### PR DESCRIPTION
Intel Gaudi support for simple training was very experimental and limited. It was never properly tested and flagged as experimental from the beginning. The design of the simple training code also did not allow for multi-device training. Typical Gaudi servers have 4 or 8 devices.

The removal of Gaudi support makes it possible to remove dependency on `optimum` and `optimum-habana` packages. The packages have upper version limits for packages like `trl`.

Fixes: #2963

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
