### PR TITLE
Update to differentiate between Granite model versions

### DIFF
--- a/src/instructlab/common.py
+++ b/src/instructlab/common.py
@@ -7,10 +7,12 @@ CLI_HELPER_SYS_PROMPT = "You are an expert for command line interface and know a
 class SupportedModelArchitectures:
     LLAMA = "llama"
     GRANITE = "granite"
+    GRANITE3_128K = "granite-3.1"
 
 
 # These system prompts are specific to granite models developed by Red Hat and IBM Research
 SYSTEM_PROMPTS = {
     SupportedModelArchitectures.LLAMA: "I am, Red Hat® Instruct Model based on Granite 7B, an AI language model developed by Red Hat and IBM Research, based on the Granite-7b-base language model. My primary function is to be a chat assistant.",
     SupportedModelArchitectures.GRANITE: "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.0-8b-base model. My primary role is to serve as a chat assistant.",
+    SupportedModelArchitectures.GRANITE3_128K: "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.1-8b-instruct model. My primary role is to serve as a chat assistant.",
 }

--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -948,6 +948,10 @@ def get_model_arch(model_path: pathlib.Path) -> str:
         try:
             model_cfg = get_config_file_from_model(model_path, "config.json")
             model_arch = model_cfg["model_type"]
+            max_position_embeddings = model_cfg["max_position_embeddings"]
+            if model_arch == "granite" and max_position_embeddings >= 131072:
+                model_arch = "granite-3.1"
+                return model_arch
         except Exception as e:
             logger.debug(
                 f"Unable to get model architecture from config for model: {model_path}: {e}. Falling back to default value"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -200,11 +200,44 @@ def test_get_sysprompt():
         == "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.0-8b-base model. My primary role is to serve as a chat assistant."
     )
 
+    arch = "granite-3.1"
+    assert (
+        utils.get_sysprompt(arch)
+        == "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.1-8b-instruct model. My primary role is to serve as a chat assistant."
+    )
+
     arch = "random"
     assert (
         utils.get_sysprompt(arch)
         == "I am an advanced AI language model designed to assist you with a wide range of tasks and provide helpful, clear, and accurate responses. My primary role is to serve as a chat assistant, engaging in natural, conversational dialogue, answering questions, generating ideas, and offering support across various topics."
     )
+
+
+def test_get_model_arch_granite():
+    mock_path = pathlib.Path("/path/to/mock/granite/model")
+    mock_config = {
+        "model_type": "granite",
+        "max_position_embeddings": 32768,  # Less than 131072
+    }
+
+    with (
+        patch("instructlab.utils.is_model_safetensors", return_value=True),
+        patch("instructlab.utils.get_config_file_from_model", return_value=mock_config),
+    ):
+        result = utils.get_model_arch(mock_path)
+        assert result == "granite"
+
+
+def test_get_model_arch_granite_3_1():
+    mock_path = pathlib.Path("/path/to/mock/granite-3.1/model")
+    mock_config = {"model_type": "granite", "max_position_embeddings": 131072}
+
+    with (
+        patch("instructlab.utils.is_model_safetensors", return_value=True),
+        patch("instructlab.utils.get_config_file_from_model", return_value=mock_config),
+    ):
+        result = utils.get_model_arch(mock_path)
+        assert result == "granite-3.1"
 
 
 def test_get_model_template_from_tokenizer(tmp_path: pathlib.Path):


### PR DESCRIPTION
Modifies system prompt application logic for 'granite' model_type. Adds support for distinguishing between Granite 3.0 and 3.1 models and ensures correct system prompt is applied based on specific Granite version.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
