### PR TITLE
fix: Add fallback logic to select a new AZ if AWS has insufficient capacity for our desired XL e2e instance

### DIFF
--- a/.github/workflows/e2e-nvidia-l40s-x8.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x8.yml
@@ -18,9 +18,11 @@ env:
 jobs:
   start-xlarge-ec2-runner:
     runs-on: ubuntu-latest
+    env:
+      INSTANCE_TYPE: "g6e.48xlarge"
     outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+      label: ${{ steps.selected-availability-zone.outputs.label }}
+      ec2-instance-id: ${{ steps.selected-availability-zone.outputs.ec2-instance-id }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -39,14 +41,39 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      - name: Start EC2 runner
-        id: start-ec2-runner
+      # Attempt to launch the EC2 runner on us-east-2a. If it fails to launch due to insufficient capacity
+      # for this instance, we will continue and try another availability zone within this region.
+      - name: Attempt to start EC2 runner on us-east-2a
+        id: start-ec2-runner-us-east-2a
         uses: machulav/ec2-github-runner@fcfb31a5760dad1314a64a0e172b78ec6fc8a17e # v2.3.6
+        continue-on-error: true
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           ec2-image-id: ${{ vars.AWS_EC2_AMI }}
-          ec2-instance-type: g6e.48xlarge
+          ec2-instance-type: ${{ env.INSTANCE_TYPE }}
+          subnet-id: subnet-02d230cffd9385bd4
+          security-group-id: sg-06300447c4a5fbef3
+          iam-role-name: instructlab-ci-runner
+          aws-resource-tags: >
+            [
+              {"Key": "Name", "Value": "instructlab-ci-github-xlarge-runner"},
+              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
+              {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
+              {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
+            ]
+
+      # Fallback in case of failure
+      - name: Attempt to start EC2 runner on us-east-2b (if us-east-2a failed)
+        if: steps.start-ec2-runner-us-east-2a.outcome == 'failure'
+        id: start-ec2-runner-us-east-2b
+        uses: machulav/ec2-github-runner@fcfb31a5760dad1314a64a0e172b78ec6fc8a17e # v2.3.6
+        continue-on-error: true
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          ec2-image-id: ${{ vars.AWS_EC2_AMI }}
+          ec2-instance-type: ${{ env.INSTANCE_TYPE }}
           subnet-id: subnet-024298cefa3bedd61
           security-group-id: sg-06300447c4a5fbef3
           iam-role-name: instructlab-ci-runner
@@ -57,6 +84,44 @@ jobs:
               {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
               {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
             ]
+
+      # Only try us-east-2c if the previous two availability zones had no availability, but
+      # do not continue if we see a failure here. Assume we've exhausted all options at that
+      # point in time.
+      - name: Attempt to start EC2 runner on us-east-2c (if us-east-2b failed)
+        if: steps.start-ec2-runner-us-east-2b.outcome == 'failure'
+        id: start-ec2-runner-us-east-2c
+        uses: machulav/ec2-github-runner@fcfb31a5760dad1314a64a0e172b78ec6fc8a17e # v2.3.6
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          ec2-image-id: ${{ vars.AWS_EC2_AMI }}
+          ec2-instance-type: ${{ env.INSTANCE_TYPE }}
+          subnet-id: subnet-04701a08396b2ed01
+          security-group-id: sg-06300447c4a5fbef3
+          iam-role-name: instructlab-ci-runner
+          aws-resource-tags: >
+            [
+              {"Key": "Name", "Value": "instructlab-ci-github-xlarge-runner"},
+              {"Key": "GitHubRepository", "Value": "${{ github.repository }}"},
+              {"Key": "GitHubRef", "Value": "${{ github.ref }}"},
+              {"Key": "GitHubPR", "Value": "${{ github.event.number }}"}
+            ]
+
+      - name: Determine EC2 availability zone used
+        id: selected-availability-zone
+        run: |
+          # shellcheck disable=SC2086 # False positive error from shellcheck about word splitting/gobbling
+          if [ "${{ steps.start-ec2-runner-us-east-2a.outcome }}" = "success" ]; then
+            echo "label=${{ steps.start-ec2-runner-us-east-2a.outputs.label }}" >> $GITHUB_OUTPUT
+            echo "ec2-instance-id=${{ steps.start-ec2-runner-us-east-2a.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.start-ec2-runner-us-east-2b.outcome }}" = "success" ]; then
+            echo "label=${{ steps.start-ec2-runner-us-east-2b.outputs.label }}" >> $GITHUB_OUTPUT
+            echo "ec2-instance-id=${{ steps.start-ec2-runner-us-east-2b.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.start-ec2-runner-us-east-2c.outcome }}" = "success" ]; then
+            echo "label=${{ steps.start-ec2-runner-us-east-2c.outputs.label }}" >> $GITHUB_OUTPUT
+            echo "ec2-instance-id=${{ steps.start-ec2-runner-us-east-2c.outputs.ec2-instance-id }}" >> $GITHUB_OUTPUT
+          fi
 
   e2e-xlarge-test:
     needs:


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #2974

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.

This workflow update enables us to fall back on a different AWS availability zone when provisioning an EC2 instance fails due to insufficient capacity in a specific availability zone. See example of this PR working as intended:

<img width="1285" alt="Screenshot 2025-01-23 at 10 37 06 AM" src="https://github.com/user-attachments/assets/3a67b535-8657-406c-90a9-9c67fec686ec" />

Logs: https://github.com/instructlab/instructlab/actions/runs/12933687455/job/36072889297
