### PR TITLE
tests: mock only the sleep from vllm backend module

### DIFF
--- a/src/instructlab/model/backends/vllm.py
+++ b/src/instructlab/model/backends/vllm.py
@@ -37,6 +37,9 @@ from .server import BackendServer, ServerConfig
 
 logger = logging.getLogger(__name__)
 
+# Useful for testing (mocking time.sleep for this module only)
+_sleep = time.sleep
+
 
 class Server(BackendServer):
     def __init__(
@@ -77,7 +80,7 @@ class Server(BackendServer):
 
         try:
             while True:
-                time.sleep(1)
+                _sleep(1)
         except KeyboardInterrupt:
             logger.info("vLLM server terminated by keyboard")
         # pylint: disable=broad-exception-caught
@@ -151,7 +154,7 @@ class Server(BackendServer):
                 shutdown_process(vllm_server_process, 20)
                 # pylint: disable=raise-missing-from
                 raise ServerException(f"vLLM failed to start up in {duration} seconds")
-            time.sleep(2)
+            _sleep(2)
         return (vllm_server_process, temp_api_base)
 
     def run_detached(
@@ -492,7 +495,7 @@ def wait_for_stable_vram(timeout: int):
     supported, stable = wait_for_stable_vram_cuda(timeout)
     if not supported:
         # TODO add support for intel
-        time.sleep(timeout)
+        _sleep(timeout)
         return
     if not stable:
         # Only for debugging since recovery is likely after additional start delay
@@ -581,7 +584,7 @@ def wait_for_stable_vram_cuda(timeout: int) -> Tuple[bool, bool]:
                 return True, False
 
             last_free = free_memory
-            time.sleep(1)
+            _sleep(1)
     finally:
         try:
             torch.cuda.empty_cache()

--- a/tests/test_lab_serve.py
+++ b/tests/test_lab_serve.py
@@ -11,7 +11,7 @@ import pytest
 
 # First Party
 from instructlab.cli.model.serve import warn_for_unsupported_backend_param
-from instructlab.model.backends.vllm import get_max_stable_vram_wait
+from instructlab.model.backends import vllm
 
 # Local
 from . import common
@@ -47,7 +47,7 @@ def vllm_setup_test_with_sleep_raise(runner, args, *_mock_args):
     # We assume that sleep is executed from inside the serve loop; at this
     # point, we are ready to exit from it; we trigger the exit with this side
     # effect, letting the serve function catch it and exit gracefully.
-    with mock.patch("time.sleep", side_effect=Exception("Intended Abort")):
+    with mock.patch.object(vllm, "_sleep", side_effect=Exception("Intended Abort")):
         return common.vllm_setup_test(runner, args)
 
 
@@ -307,10 +307,10 @@ def test_vllm_args_null(cli_runner: CliRunner):
 
 def test_max_stable_vram_wait():
     with mock.patch.dict(os.environ, {"ILAB_MAX_STABLE_VRAM_WAIT": "0"}):
-        wait = get_max_stable_vram_wait(10)
+        wait = vllm.get_max_stable_vram_wait(10)
         assert wait == 0
     with mock.patch.dict(os.environ, clear=True):
-        wait = get_max_stable_vram_wait(10)
+        wait = vllm.get_max_stable_vram_wait(10)
         assert wait == 10
 
 


### PR DESCRIPTION
Though https://github.com/instructlab/instructlab/pull/2984 was a step
in the right direction, in that it isolated the overbroad mocking for
sleep to tests that need the mock-out at all (the serve tests that use
sleep call as indication to exit from the vllm handler), it was not
complete because the mock still applied to all time.sleep calls
happening anywhere, regardless whether the code belongs to vllm.

This new patch introduces a separate module level attribute capturing
the time.sleep used in the vllm backend module. It then mocks only this
new attribute, leaving others intact.

Resolves #2966

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
