### PR TITLE
fix: Set default K for RAG to 3

### DIFF
--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -88,7 +88,7 @@ class _InstructlabDefaults:
     GRANITE_EMBEDDING_MODEL_NAME = "ibm-granite/granite-embedding-125m-english"
     DOCUMENT_STORE_NAME = "embeddings.db"
     DOCUMENT_STORE_COLLECTION_NAME = "ilab"
-    RETRIEVER_TOP_K = 20
+    RETRIEVER_TOP_K = 3
     MERLINITE_GGUF_MODEL_NAME = "merlinite-7b-lab-Q4_K_M.gguf"
     MISTRAL_GGUF_MODEL_NAME = "mistral-7b-instruct-v0.2.Q4_K_M.gguf"
     MODEL_REPO = "instructlab/granite-7b-lab"

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -258,8 +258,8 @@ rag:
   # Retrieval configuration parameters for RAG
   retriever:
     # The maximum number of documents to retrieve.
-    # Default: 20
-    top_k: 20
+    # Default: 3
+    top_k: 3
 # Serve configuration section.
 serve:
   # Serving backend to use to host the model.


### PR DESCRIPTION
We've found the following issue with RAG in InstructLab:

- By default, the RAG runtime requests 20 search results (configurable via `--retriever-top-k` parameter with default 20).
- Then it puts all of those search results into a single message in the chat session history
- Then if the chat session history is too large to fit into the context window of the generator model, the chat system discards messages from the chat context (oldest to latest) until the chat session history fits into the context window.

However, in practice 20 results is often bigger than the context window of the generator model.   So the effect is that we throw out *all* search results for all queries -- effectively disabling RAG completely (and also obliterating the rest of the chat context which all came before the search results).

In the future, I think we need to be smarter about not flooding the chat session history with too much content.  For now though, just setting the value to 3 provides a work-around that seems like it works out OK with the default models.  The problem could still arise even with 3 search results if the user overrides the default embedding model and replaces it with one that handles very large chunks of text, especially if the response model is one that has a very small context window.  For now, having a default that works with the default models is a lot better than the alternative.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
