### PR TITLE
fix: Temporarily reduce the number of epochs from 7 to 6

### DIFF
--- a/scripts/test-data/profile-l40s-x8.yaml
+++ b/scripts/test-data/profile-l40s-x8.yaml
@@ -119,15 +119,15 @@ train:
   max_batch_len: 30000
   max_seq_len: 4096
   model_path: ~/.cache/instructlab/models/instructlab/granite-7b-lab
-  num_epochs: 7
+  num_epochs: 6
   save_samples: 1000
   is_padding_free: true
   nproc_per_node: 8
   phased_phase1_effective_batch_size: 32
-  phased_phase1_num_epochs: 7
+  phased_phase1_num_epochs: 6
   phased_phase1_samples_per_save: 0
   phased_phase2_effective_batch_size: 32
-  phased_phase2_num_epochs: 7
+  phased_phase2_num_epochs: 6
   phased_phase2_samples_per_save: 0
   distributed_backend: fsdp
   pipeline: accelerated


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


**Issue resolved by this Pull Request:**
Resolves #3000


<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.

## Purpose

This PR temporarily reduces the number of training epochs in our XL e2e job from 7 to 6 in an attempt to have the job complete in under 6 hours. We need the job to complete in under 6 hours because GitHub has set a limitation that prevents its runners from persisting longer than 6 hours. See linked issue for more details.