### PR TITLE
fix: rename model used in default granite-3.1 system prompt

### DIFF
--- a/src/instructlab/common.py
+++ b/src/instructlab/common.py
@@ -14,5 +14,5 @@ class SupportedModelArchitectures:
 SYSTEM_PROMPTS = {
     SupportedModelArchitectures.LLAMA: "I am, Red Hat® Instruct Model based on Granite 7B, an AI language model developed by Red Hat and IBM Research, based on the Granite-7b-base language model. My primary function is to be a chat assistant.",
     SupportedModelArchitectures.GRANITE: "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.0-8b-base model. My primary role is to serve as a chat assistant.",
-    SupportedModelArchitectures.GRANITE3_128K: "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.1-8b-instruct model. My primary role is to serve as a chat assistant.",
+    SupportedModelArchitectures.GRANITE3_128K: "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.1-8b-base model. My primary role is to serve as a chat assistant.",
 }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -203,7 +203,7 @@ def test_get_sysprompt():
     arch = "granite-3.1"
     assert (
         utils.get_sysprompt(arch)
-        == "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.1-8b-instruct model. My primary role is to serve as a chat assistant."
+        == "I am a Red Hat® Instruct Model, an AI language model developed by Red Hat and IBM Research based on the granite-3.1-8b-base model. My primary role is to serve as a chat assistant."
     )
 
     arch = "random"


### PR DESCRIPTION
The LAB models that will be used in our pipeline will be based on top of granite-3.1-8b-base, not granite-3.1-8b-instruct. 

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
