### PR TITLE
mypy: Enable pydantic plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ from-first = true
 known-local-folder = ["tuning"]
 
 [tool.mypy]
+plugins = ['pydantic.mypy']
 mypy_path = ["src"]
 packages = ["instructlab", "tests"]
 disable_error_code = []
@@ -227,6 +228,11 @@ module = [
   "transformers",
 ]
 ignore_missing_imports = true
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
 
 [tool.coverage.run]
 branch = false


### PR DESCRIPTION
This may help us avoid some spurious mypy warnings when it gets confused by pydantic magick.

https://docs.pydantic.dev/latest/integrations/mypy/

Noticed when looking at mypy violations under https://github.com/instructlab/instructlab/pull/2977

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
