### PR TITLE
tests: Fix failure on python without _uuid module

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -52,11 +52,16 @@ def vllm_setup_test(runner, args, mock_popen, *_mock_args):
     if result.exit_code != 0:
         print(result.output)
 
-    assert len(mock_popen.call_args_list) == 1 or (
-        "Retrying (1/1)" in result.output and len(mock_popen.call_args_list) == 2
+    vllm_calls = [
+        call
+        for call in mock_popen.call_args_list
+        if "vllm.entrypoints.openai.api_server" in call.kwargs.get("args", [])
+    ]
+    assert len(vllm_calls) == 1 or (
+        "Retrying (1/1)" in result.output and len(vllm_calls) == 2
     )
 
-    return mock_popen.call_args_list[0][1]["args"]
+    return vllm_calls[0][1]["args"]
 
 
 def assert_tps(args, tps):


### PR DESCRIPTION
On these pythons, uuid module will fall back to a platform specific
method to extract a safe uuid. It usually means a call to an external
utility like `ip` or `ifconfig` (to derive a UUID from the machine MAC
address):

https://github.com/python/cpython/blob/379ab856f59423c570333403a7d5d72f3ea82d52/Lib/uuid.py#L641

Because of that, the Popen mock catches a spurious `ip` call, which
makes the later check fail because the observed number of calls is off
by 1. (The `uuid.uuid1()` that triggers it in the test suite comes from
process management layer.)

One example of python build with _uuid module is linux nixpkgs cpython.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
