### PR TITLE
fix: remove duplicate log messages in detached SDG

### DIFF
--- a/src/instructlab/data/generate_data.py
+++ b/src/instructlab/data/generate_data.py
@@ -124,18 +124,20 @@ def create_server_and_generate(
     use_legacy_pretraining_format,
     log_file,
     local_uuid,
+    process_mode,
 ):
     backend_instance = None
     # we need to use the instructlab logger so that the libraries inherit the config we set up.
     logger = logging.getLogger("instructlab")
 
     # First Party
-    from instructlab.defaults import ILAB_PROCESS_STATUS
+    from instructlab.defaults import ILAB_PROCESS_MODES, ILAB_PROCESS_STATUS
     from instructlab.log import add_file_handler_to_logger
 
     # when in a new process, logger configuration does not seem to be promised. Add the file handler pointing to our new log file
     # and also, reenforce the level set on the instructlab logger.
-    add_file_handler_to_logger(log_file=log_file, logger=logger)
+    if process_mode == ILAB_PROCESS_MODES.ATTACHED:
+        add_file_handler_to_logger(log_file=log_file, logger=logger)
     logger.setLevel(log_level)
 
     # Third Party

--- a/src/instructlab/process/process.py
+++ b/src/instructlab/process/process.py
@@ -217,6 +217,7 @@ def add_process(
     start_time_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     kwargs["log_file"] = log_file
     kwargs["local_uuid"] = str(local_uuid)
+    kwargs["process_mode"] = process_mode
     if process_mode == ILAB_PROCESS_MODES.DETACHED:
         assert isinstance(log_file, str)
         cmd = format_command(target=target, extra_imports=extra_imports, **kwargs)


### PR DESCRIPTION
currently, since we add a log file handler and capture the logs from the runnning process when running -dt, there are duplicate log messages. Only add the log file handler if running in attached mode

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
