### PR TITLE
chore: Remove the deprecated `seed_file` from config

### DIFF
--- a/scripts/test-data/profile-l4-x1.yaml
+++ b/scripts/test-data/profile-l4-x1.yaml
@@ -83,7 +83,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/scripts/test-data/profile-l40s-x4.yaml
+++ b/scripts/test-data/profile-l40s-x4.yaml
@@ -81,7 +81,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/scripts/test-data/profile-l40s-x8.yaml
+++ b/scripts/test-data/profile-l40s-x8.yaml
@@ -82,7 +82,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/scripts/test-data/profile-t4-x1.yaml
+++ b/scripts/test-data/profile-t4-x1.yaml
@@ -25,7 +25,6 @@ generate:
   pipeline: simple
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -394,13 +394,6 @@ class _generate(BaseModel):
         default_factory=lambda: DEFAULTS.DATASETS_DIR,
         description="Directory where generated datasets are stored.",
     )
-    # TODO: remove this? It's not used anywhere, was removed by 19b9f4794f79ef81578c00c901bac3ee9db8c046
-    # related issue: https://github.com/instructlab/instructlab/issues/2261
-    seed_file: StrictStr = Field(
-        description="Path to seed file to be used for generation.",
-        default_factory=lambda: DEFAULTS.SEED_FILE,
-        deprecated=True,
-    )
 
 
 class _mmlu(BaseModel):

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -220,10 +220,6 @@ class _InstructlabDefaults:
         return path.join(self.INTERNAL_DIR, "prompt.txt")
 
     @property
-    def SEED_FILE(self) -> str:
-        return path.join(self.INTERNAL_DIR, "seed_tasks.json")
-
-    @property
     def EVAL_DATA_DIR(self) -> str:
         return path.join(self.INTERNAL_DIR, "eval_data")
 

--- a/src/instructlab/profiles/intel/gaudi/gaudi_3.yaml
+++ b/src/instructlab/profiles/intel/gaudi/gaudi_3.yaml
@@ -59,7 +59,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/src/instructlab/profiles/nvidia/a100/a100_x2.yaml
+++ b/src/instructlab/profiles/nvidia/a100/a100_x2.yaml
@@ -59,7 +59,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/src/instructlab/profiles/nvidia/a100/a100_x4.yaml
+++ b/src/instructlab/profiles/nvidia/a100/a100_x4.yaml
@@ -59,7 +59,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/src/instructlab/profiles/nvidia/a100/a100_x8.yaml
+++ b/src/instructlab/profiles/nvidia/a100/a100_x8.yaml
@@ -59,7 +59,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/src/instructlab/profiles/nvidia/h100/h100_x2.yaml
+++ b/src/instructlab/profiles/nvidia/h100/h100_x2.yaml
@@ -59,7 +59,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/src/instructlab/profiles/nvidia/h100/h100_x4.yaml
+++ b/src/instructlab/profiles/nvidia/h100/h100_x4.yaml
@@ -59,7 +59,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/src/instructlab/profiles/nvidia/h100/h100_x8.yaml
+++ b/src/instructlab/profiles/nvidia/h100/h100_x8.yaml
@@ -59,7 +59,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/src/instructlab/profiles/nvidia/l4/l4_x8.yaml
+++ b/src/instructlab/profiles/nvidia/l4/l4_x8.yaml
@@ -59,7 +59,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/src/instructlab/profiles/nvidia/l40s/l40s_x4.yaml
+++ b/src/instructlab/profiles/nvidia/l40s/l40s_x4.yaml
@@ -59,7 +59,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/src/instructlab/profiles/nvidia/l40s/l40s_x8.yaml
+++ b/src/instructlab/profiles/nvidia/l40s/l40s_x8.yaml
@@ -59,7 +59,6 @@ generate:
   pipeline: full
   # The total number of instructions to be generated
   sdg_scale_factor: 30
-  seed_file: ~/.local/share/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against
   taxonomy_base: empty
   # Directory where taxonomy is stored and accessed from

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,7 +27,6 @@ class TestConfig:
         # redefine defaults here instead of relyin on those in configuration.DEFAULTS
         # to catch any errors if we are doing things incorrectly over there
         package_name = "instructlab"
-        internal_dirname = "internal"
         cache_dir = os.path.join(xdg_cache_home(), package_name)
         data_dir = os.path.join(xdg_data_home(), package_name)
         default_chat_model = f"{cache_dir}/models/granite-7b-lab-Q4_K_M.gguf"
@@ -72,9 +71,6 @@ class TestConfig:
         assert cfg.generate.sdg_scale_factor == 30
         assert cfg.generate.chunk_word_count == 1000
         assert cfg.generate.output_dir == f"{data_dir}/datasets"
-        assert (
-            cfg.generate.seed_file == f"{data_dir}/{internal_dirname}/seed_tasks.json"
-        )
 
         assert cfg.serve is not None
         assert cfg.serve.model_path == default_chat_model

--- a/tests/testdata/default_config.yaml
+++ b/tests/testdata/default_config.yaml
@@ -160,10 +160,6 @@ generate:
   # The total number of instructions to be generated.
   # Default: 30
   sdg_scale_factor: 30
-  # Path to seed file to be used for generation.
-  # Default: /data/instructlab/internal/seed_tasks.json
-  # Deprecated
-  seed_file: /data/instructlab/internal/seed_tasks.json
   # Branch of taxonomy used to calculate diff against.
   # Default: origin/main
   taxonomy_base: origin/main


### PR DESCRIPTION
This entirely removes the deprecated `seed_file` option from the configuration. It hasn't actually been used by anything in SDG for multiple releases.

**Issue resolved by this Pull Request:**
Resolves #2261


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
