### PR TITLE
refactor: Tighten process registry interface

### DIFF
--- a/src/instructlab/data/generate_data.py
+++ b/src/instructlab/data/generate_data.py
@@ -200,7 +200,7 @@ def create_server_and_generate(
     from instructlab.sdg.utils import GenerateException
 
     # First Party
-    from instructlab.process.process import update_status
+    from instructlab.process.process import complete_process
 
     try:
         logger.info(
@@ -228,12 +228,12 @@ def create_server_and_generate(
         )
     except GenerateException as exc:
         # mark process as errored on registry and set end_time
-        update_status(local_uuid=local_uuid, status=ILAB_PROCESS_STATUS.ERRORED)
+        complete_process(local_uuid=local_uuid, status=ILAB_PROCESS_STATUS.ERRORED)
         raise ValueError(
             f"Generating dataset failed with the following error: {exc}"
         ) from exc
     finally:
         # mark process as done on registry and set end_time
-        update_status(local_uuid=local_uuid, status=ILAB_PROCESS_STATUS.DONE)
+        complete_process(local_uuid=local_uuid, status=ILAB_PROCESS_STATUS.DONE)
         if backend_instance is not None:
             backend_instance.shutdown()

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from os import path
+import pathlib
 
 # Third Party
 from xdg_base_dirs import xdg_cache_home, xdg_config_home, xdg_data_home
@@ -30,23 +31,26 @@ LOG_FORMAT = "%(levelname)s %(asctime)s %(name)s:%(lineno)d: %(message)s"
 RECOMMENDED_SCOPEO_VERSION = "1.9.0"
 
 
+# TODO: make it an enum
 class ILAB_PROCESS_STATUS:
     RUNNING: str = "Running"
     DONE: str = "Done"
     ERRORED: str = "Errored"
 
 
+# TODO: make it an enum
 class ILAB_PROCESS_MODES:
     DETACHED: str = "detached"
     ATTACHED: str = "attached"
 
 
+# TODO: make it an enum
 class ILAB_PROCESS_TYPES:
     DATA_GENERATION: str = "Generation"
-
     TRAINING: str = "Training"
 
 
+# TODO: make it an enum
 class STORAGE_DIR_NAMES:
     ILAB = "instructlab"
     DATASETS = "datasets"
@@ -284,12 +288,8 @@ class _InstructlabDefaults:
         return path.join(self.TRAIN_PROFILE_DIR, "L4_x8.yaml")
 
     @property
-    def PROCESS_REGISTRY_FILE(self) -> str:
-        return path.join(self.INTERNAL_DIR, "process_registry.json")
-
-    @property
-    def PROCESS_REGISTRY_LOCK_FILE(self) -> str:
-        return path.join(self.INTERNAL_DIR, "process_registry.json.lock")
+    def PROCESS_REGISTRY_FILE(self) -> pathlib.Path:
+        return pathlib.Path(self.INTERNAL_DIR) / "process_registry.json"
 
 
 DEFAULTS = _InstructlabDefaults()

--- a/tests/process/test_process.py
+++ b/tests/process/test_process.py
@@ -1,0 +1,104 @@
+# Standard
+from datetime import datetime
+
+# First Party
+from instructlab.defaults import ILAB_PROCESS_STATUS
+from instructlab.process import process
+
+
+class TestProcessRegistry:
+    @staticmethod
+    def _get_registry(home):
+        return process.ProcessRegistry(filepath=home / "process_registry.json").load()
+
+    def test_add_update_remove(self, tmp_path_home):
+        reg = self._get_registry(tmp_path_home)
+        assert not reg.processes
+
+        # Add a process
+        uuid_ = "fake-uuid"
+        pid = 100
+        children = [101, 102]
+        type_ = "TestType"
+        log_file = tmp_path_home / "test.log"
+        now = datetime.now()
+        status = ILAB_PROCESS_STATUS.RUNNING
+
+        reg.add(
+            uuid_,
+            process.Process(
+                pid=pid,
+                log_path=log_file,
+                ptype=type_,
+                children=children[:],
+                start_time=now,
+                status=status,
+            ),
+        )
+
+        # Confirm values are as expected
+        assert len(reg.processes) == 1
+        p = reg.processes[uuid_]
+        assert p.pids == [100, 101, 102]
+        assert p.ptype == type_
+        assert p.log_path == log_file
+        runtime = p.runtime
+        assert runtime <= datetime.now() - now
+        assert p.status == status
+        assert not p.completed
+        assert not p.started
+
+        # Create log file; this tells the module that the process started
+        log_file.touch()
+        assert not p.completed
+        assert p.started
+
+        # Now complete the process
+        p.complete(ILAB_PROCESS_STATUS.DONE)
+
+        # Confirm update happened
+        p = reg.processes[uuid_]
+        assert p.started
+        assert p.completed
+
+        # Remove the process and confirm it's removed
+        reg.remove(uuid_)
+        assert not reg.processes
+
+    def test_load_persist(self, tmp_path_home):
+        reg = self._get_registry(tmp_path_home)
+        assert not reg.processes
+
+        # Add a process
+        uuid_ = "fake-uuid"
+        pid = 100
+        children = [101, 102]
+        type_ = "TestType"
+        log_file = tmp_path_home / "test.log"
+        now = datetime.now()
+        status = ILAB_PROCESS_STATUS.RUNNING
+
+        reg.add(
+            uuid_,
+            process.Process(
+                pid=pid,
+                log_path=log_file,
+                ptype=type_,
+                children=children[:],
+                start_time=now,
+                status=status,
+            ),
+        )
+
+        # Persist the registry
+        reg.persist()
+
+        # Load a new registry and confirm it's the same
+        new_reg = self._get_registry(tmp_path_home)
+        assert len(new_reg.processes) == 1
+        p = new_reg.processes[uuid_]
+        assert p.pids == [100, 101, 102]
+        assert p.ptype == type_
+        assert p.log_path == log_file
+        assert p._start_time == now
+        assert p.status == status


### PR DESCRIPTION
Make it operate with the callers via Process objects; control external Process and registry modifications; provide a number of consistent verbs (load/persist; add/remove; update).

This also adds some process module specific test cases that do not rely on running the complete click machinery.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
