### PR TITLE
tests: Validate that unknown field in config are handled gracefully

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -319,6 +319,35 @@ general:
         assert cfg.general.log_level == "DEBUG"
         assert cfg.general.debug_level == 1
 
+    # This test case is useful to guarantee that pydantic model loading never
+    # breaks us whenever we remove a particular field from a model definition.
+    def test_config_with_unknown_field_loaded_successfully(self, tmp_path_home):
+        config_path = tmp_path_home / "config.yaml"
+        with open(config_path, "w", encoding="utf-8") as config_file:
+            # TODO: ideally, we'd generate the section names from actual
+            # models; we could also fill in embedded map fields with garbage
+            # too. This is left for the future.
+            config_file.write(
+                """\
+version: 1.0.0
+chat:
+  unknown-field: unknown-value
+evaluate:
+  unknown-field: unknown-value
+general:
+  unknown-field: unknown-value
+generate:
+  unknown-field: unknown-value
+rag:
+  unknown-field: unknown-value
+serve:
+  unknown-field: unknown-value
+train:
+  unknown-field: unknown-value
+"""
+            )
+        config.read_config(config_path)
+
 
 @pytest.mark.parametrize(
     "log_level,debug_level,root,instructlab,openai_httpx",


### PR DESCRIPTION
This is to make sure we can gracefully load an older config file even
after we drop aw model field. The dropped field is ignored obviously,
but that's to be expected.

Inspired by: https://github.com/instructlab/instructlab/pull/3045

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
