### PR TITLE
fix(RAG): Fix RAG support for taxonomies with compositional skills

### DIFF
--- a/src/instructlab/rag/taxonomy_utils.py
+++ b/src/instructlab/rag/taxonomy_utils.py
@@ -26,7 +26,11 @@ def lookup_knowledge_files(taxonomy_path, taxonomy_base, temp_dir) -> list[Path]
     )
     knowledge_files: list[Path] = []
     for leaf_node in leaf_nodes.values():
-        knowledge_files.extend(leaf_node[0]["filepaths"])
+        if leaf_node and "filepaths" in leaf_node[0]:
+            # The check for "filepaths" in leaf_node[0] is needed here because skill taxonomy
+            #  nodes don't have filepaths.  This code is trying to get filepaths from the
+            #  knowledge taxonomy nodes, so it should skip over the skill taxonomy nodes.
+            knowledge_files.extend(leaf_node[0]["filepaths"])
 
     grouped_knowledge_files = []
     for knowledge_file in knowledge_files:

--- a/tests/testdata/sample_taxonomy/compositional_skills/howdy/qna.yaml
+++ b/tests/testdata/sample_taxonomy/compositional_skills/howdy/qna.yaml
@@ -1,0 +1,25 @@
+version: 3
+created_by: team1
+task_description: |
+  Sample howdy QNA for unit tests.  Like ../knowledge/hello/qna.yaml except that it is a skill so there is no attached document.
+seed_examples:
+    - question: >
+        Howdy 1?
+      answer: >
+        Howdy
+    - question: >
+        Howdy 2?
+      answer: >
+        Howdy
+    - question: >
+        Howdy 3?
+      answer: >
+        Howdy
+    - question: >
+        Howdy 4?
+      answer: >
+        Howdy
+    - question: >
+        Howdy 5?
+      answer: >
+        Howdy

--- a/tests/testdata/sample_taxonomy/knowledge/hello/qna.yaml
+++ b/tests/testdata/sample_taxonomy/knowledge/hello/qna.yaml
@@ -1,8 +1,8 @@
 version: 3
-domain: CookBook-1
+domain: Hello!
 created_by: team1
 document_outline: |
-  Information about Bibimbap, Bacalao ajoarriero, Kuku, Menemen, Panzanella, and Pad Thai
+  Sample hello world QNA for unit tests
 seed_examples:
   - context: >
      Hello world! A


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

This fixes a bug in RAG convert that causes it to fail on taxonomies that have compositional skills.  The correct behavior is to ignore the compositional skills because they have no documents, but instead this was crashing when it encountered them.  This PR also adds a compositional skill to the sample test taxonomy, which would have let us catch this bug.

**Issue resolved by this Pull Request:**
Resolves #3008

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
