### PR TITLE
fix: Skipping docs with same ID by default

### DIFF
--- a/src/instructlab/rag/haystack/component_factory.py
+++ b/src/instructlab/rag/haystack/component_factory.py
@@ -10,6 +10,7 @@ from haystack.components.embedders import (  # type: ignore
 from haystack.components.retrievers import InMemoryEmbeddingRetriever  # type: ignore
 from haystack.components.writers import DocumentWriter  # type: ignore
 from haystack.document_stores.in_memory import InMemoryDocumentStore  # type: ignore
+from haystack.document_stores.types import DuplicatePolicy  # type: ignore
 
 # First Party
 from instructlab.rag.haystack.components.document_splitter import (
@@ -27,7 +28,8 @@ def create_document_writer(
             document_store_uri=document_store_uri,
             document_store_collection_name=document_store_collection_name,
             drop_old=True,
-        )
+        ),
+        policy=DuplicatePolicy.SKIP,
     )
 
 


### PR DESCRIPTION
With in-memory implementation of document store, the document ID is generated by hashing the document content (of each chunk). Because of that, if two chunks have the same content, the duplicate ID issue is raised.

This fix overrides the embeddings in the document store every time this happens. 
Note: we could also use the `OVERWRITE` option, which should provide the same result in terms of store content, but we assume that this would have worst performance since it puts unneeded data in the document store.

**Issue resolved by this Pull Request:**
Resolves #3062 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
