### PR TITLE
fix: test_lab_download mocks list_repo_files

### DIFF
--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -73,7 +73,7 @@ class TestLabDownload:
 
     @patch(
         "instructlab.model.download.OCIDownloader.download",
-        MagicMock(side_effect=HfHubHTTPError("Could not reach hugging face server")),
+        MagicMock(side_effect=HfHubHTTPError("Could not reach server")),
     )
     def test_oci_download_repository_error(self, cli_runner: CliRunner):
         result = cli_runner.invoke(
@@ -86,4 +86,4 @@ class TestLabDownload:
             ],
         )
         assert result.exit_code == 1
-        assert "Could not reach hugging face server" in result.output
+        assert "Could not reach server" in result.output


### PR DESCRIPTION
We're seeing test_lab_download failing to connect to HF, presumably due to stricter checking of authentication.  It was already using a mock to to the downloading but not to do the listing of files.  So I added mocks for that too.

**Issue resolved by this Pull Request:**
Resolves #3066 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
