### PR TITLE
fix: Using None for hf_token instead of ""

### DIFF
--- a/src/instructlab/cli/rag/convert.py
+++ b/src/instructlab/cli/rag/convert.py
@@ -56,6 +56,8 @@ def convert(
     input_dir,
     output_dir,
 ):
+    """Pipeline to convert documents from their original format (e.g., PDF) into Docling JSON format for use by ilab rag ingest"""
+
     if not FeatureGating.feature_available(GatedFeatures.RAG):
         click.echo(
             f"This functionality is experimental; set {FeatureGating.env_var_name}"
@@ -63,7 +65,6 @@ def convert(
         )
         return
 
-    """Pipeline to convert documents from their original format (e.g., PDF) into Docling JSON format for use by ilab rag ingest"""
     # Local
     from ...rag.convert import (
         convert_documents_from_folder,

--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -67,7 +67,7 @@ class HFDownloader(ModelDownloader):
             download_dest=download_dest,
         )
         self.filename = filename
-        self.hf_token = hf_token
+        self.hf_token = hf_token or None
 
     def download(self):
         """
@@ -77,7 +77,7 @@ class HFDownloader(ModelDownloader):
             f"Downloading model from Hugging Face:\n{DEFAULT_INDENT}Model: {self.repository}@{self.release}\n{DEFAULT_INDENT}Destination: {self.download_dest}"
         )
 
-        if self.hf_token == "" and "instructlab" not in self.repository:
+        if self.hf_token is None and "instructlab" not in self.repository:
             raise ValueError(
                 """HF_TOKEN var needs to be set in your environment to download HF Model.
                 Alternatively, the token can be passed with --hf-token flag.

--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -1,23 +1,59 @@
 # SPDX-License-Identifier: Apache-2.0
-
 # Standard
+from pathlib import Path
+from typing import Union
 from unittest.mock import MagicMock, patch
 
 # Third Party
 from click.testing import CliRunner
 from huggingface_hub.utils import HfHubHTTPError
+import pytest
 
 # First Party
 from instructlab import lab
+from instructlab.model.download import HFDownloader
 
 
 class TestLabDownload:
+    @pytest.mark.parametrize(
+        "repo,provided_token,expected_token,expect_failure",
+        [
+            ("instructlab/any", "", None, False),
+            ("instructlab/any", "mytoken", "mytoken", False),
+            ("any/any", "mytoken", "mytoken", False),
+            ("any/any", "", None, True),
+        ],
+    )
+    def test_downloader_handles_token(
+        self,
+        repo: str,
+        provided_token: str,
+        expected_token: Union[str, bool, None],
+        expect_failure: bool,
+    ):
+        downloader = HFDownloader(
+            repository=repo,
+            hf_token=provided_token,
+            release="",
+            download_dest=Path(""),
+            filename="",
+            log_level="",
+        )
+
+        assert downloader.hf_token == expected_token
+        if expect_failure:
+            with pytest.raises(ValueError, match="HF_TOKEN"):
+                downloader.download()
+
     # When using `from X import Y` you need to understand that Y becomes part
     # of your module, so you should use `my_module.Y`` to patch.
     # When using `import X`, you should use `X.Y` to patch.
     # https://docs.python.org/3/library/unittest.mock.html#where-to-patch?
     @patch("instructlab.model.download.hf_hub_download")
-    def test_download(self, mock_hf_hub_download, cli_runner: CliRunner):
+    @patch("instructlab.model.download.list_repo_files")
+    def test_download(
+        self, mock_list_repo_files, mock_hf_hub_download, cli_runner: CliRunner
+    ):
         result = cli_runner.invoke(
             lab.ilab,
             [
@@ -30,13 +66,15 @@ class TestLabDownload:
         assert (
             result.exit_code == 0
         ), f"command finished with an unexpected exit code. {result.stdout}"
+        assert mock_list_repo_files.call_count == 3
         assert mock_hf_hub_download.call_count == 3
 
     @patch(
         "instructlab.model.download.hf_hub_download",
         MagicMock(side_effect=HfHubHTTPError("Could not reach hugging face server")),
     )
-    def test_download_error(self, cli_runner: CliRunner):
+    @patch("instructlab.model.download.list_repo_files")
+    def test_download_error(self, mock_list_repo_files, cli_runner: CliRunner):
         result = cli_runner.invoke(
             lab.ilab,
             [
@@ -45,6 +83,7 @@ class TestLabDownload:
                 "download",
             ],
         )
+        assert mock_list_repo_files.call_count == 1
         assert result.exit_code == 1, "command finished with an unexpected exit code"
         assert "Could not reach hugging face server" in result.output
 
@@ -65,6 +104,10 @@ class TestLabDownload:
         assert "model download completed successfully!" in result.output
         assert "Available models (`ilab model list`):" in result.output
 
+    @patch(
+        "instructlab.model.download.OCIDownloader.download",
+        MagicMock(side_effect=HfHubHTTPError("Could not reach server")),
+    )
     def test_oci_download_repository_error(self, cli_runner: CliRunner):
         result = cli_runner.invoke(
             lab.ilab,
@@ -76,7 +119,4 @@ class TestLabDownload:
             ],
         )
         assert result.exit_code == 1
-        assert (
-            "\nInvalid repository supplied:\n    Please specify tag/version 'latest' via --release"
-            in result.output
-        )
+        assert "Could not reach server" in result.output


### PR DESCRIPTION
This is aimed to fix some unexpected issues with model downloads that we faced recently:
```
Repository Not Found for url: https://huggingface.co/instructlab/granite-7b-lab-GGUF/resolve/main/granite-7b-lab-Q4_K_M.gguf.
Please make sure you specified the correct `repo_id` and `repo_type`.
If you are trying to access a private or gated repo, make sure you are authenticated.
Invalid credentials in Authorization header)
```

Changed the logic to initialize `hf_token` according to HF specification:
```py
   token (Union[bool, str, None], optional): 
```

- Instead of `""` we pass `None`.
- Added a parametrized test
- Anticipating changes from #3072 to unblock broken tests
- Including one linting issue in `convert.py` (not clear why it's not blocking other PRs)

**Issue resolved by this Pull Request:**
I'll create an issue if needed

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
