### PR TITLE
Set names for served models

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,10 @@ For detailed documentation on the InstructLab LLMs and their functions, see the 
 
    📋 If multiple `ilab` clients try to connect to the same InstructLab server at the same time, the 1st will connect to the server while the others will start their own temporary server. This will require additional resources on the host machine.
 
+   Model will be available under both long form absolute path, and a shorthand name.
+
+   The model server will behave in the same way as the backend chosen for execution, either Llama.cpp or vllm.
+
 #### Serving other models
 
 - You can serve a non-default model (e.g. Mixtral-8x7B-Instruct-v0.1) with the following example command:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -277,7 +277,7 @@ def test_ilab_llama_cpp_args(
 def test_build_vllm_cmd_with_defaults(tmp_path: pathlib.Path):
     host = "localhost"
     port = 8080
-    model_path = pathlib.Path("/path/to/model")
+    model_path = tmp_path / "model"
     model_family = ""
     chat_template = tmp_path / "chat_template.jinja2"
     chat_template.touch()
@@ -296,6 +296,9 @@ def test_build_vllm_cmd_with_defaults(tmp_path: pathlib.Path):
         str(chat_template),
         "--distributed-executor-backend",
         "mp",
+        "--served-model-name",
+        str(model_path),
+        "model",
     ]
     cmd, _ = build_vllm_cmd(
         host, port, model_family, model_path, str(chat_template), vllm_args
@@ -306,7 +309,7 @@ def test_build_vllm_cmd_with_defaults(tmp_path: pathlib.Path):
 def test_build_vllm_cmd_with_args_provided(tmp_path: pathlib.Path):
     host = "localhost"
     port = 8080
-    model_path = pathlib.Path("/path/to/model")
+    model_path = tmp_path / "model"
     model_family = ""
     chat_template = tmp_path / "chat_template.jinja2"
     chat_template.touch()
@@ -325,6 +328,9 @@ def test_build_vllm_cmd_with_args_provided(tmp_path: pathlib.Path):
         host,
         "--chat-template",
         str(chat_template),
+        "--served-model-name",
+        str(model_path),
+        "model",
     ] + vllm_args
 
     cmd, _ = build_vllm_cmd(
@@ -360,6 +366,10 @@ def test_build_vllm_cmd_with_bnb_quant(tmp_path: pathlib.Path):
         "--enforce-eager",
         "--distributed-executor-backend",
         "mp",
+        "--served-model-name",
+        str(model_path),
+        "model",
+        "test_build_vllm_cmd_with_bnb_q0/model",
     ]
     create_safetensors_or_bin_model_files(model_path, "safetensors", True)
     cmd, _ = build_vllm_cmd(


### PR DESCRIPTION
Served models can now be accessed using short names derived from their path, not just their absolute path.

This feature is supported by the VLLM backend, as a `--served-model-name` argument for `vllm serve` command.[1]
The model served will remain the same, but will appear as two models if the vllm server `v1/models` endpoint is queried. For example:

```
curl  http://0.0.0.0:8000/v1/models | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   998  100   998    0     0   812k      0 --:--:-- --:--:-- --:--:--  974k
{
  "object": "list",
  "data": [
    {
      "id": "supercoolmodel/yeah",
      "object": "model",
      "created": 1737722890,
      "owned_by": "vllm",
      "root": "ibm-granite/granite-3.1-8b-instruct",
      "parent": null,
      "max_model_len": 8096,
      "permission": [
        {
          "id": "modelperm-4e50f43ff7ab4e7596a74e053fd340d9",
          "object": "model_permission",
          "created": 1737722890,
          "allow_create_engine": false,
          "allow_sampling": true,
          "allow_logprobs": true,
          "allow_search_indices": false,
          "allow_view": true,
          "allow_fine_tuning": false,
          "organization": "*",
          "group": null,
          "is_blocking": false
        }
      ]
    },
    {
      "id": "ibm-granite/granite-3.1-8b-instruct",
      "object": "model",
      "created": 1737722890,
      "owned_by": "vllm",
      "root": "ibm-granite/granite-3.1-8b-instruct",
      "parent": null,
      "max_model_len": 8096,
      "permission": [
        {
          "id": "modelperm-b9d36978a6254c80b39aaff438fbdb0d",
          "object": "model_permission",
          "created": 1737722890,
          "allow_create_engine": false,
          "allow_sampling": true,
          "allow_logprobs": true,
          "allow_search_indices": false,
          "allow_view": true,
          "allow_fine_tuning": false,
          "organization": "*",
          "group": null,
          "is_blocking": false
        }
      ]
    }
  ]
}
```

With this change, the user will be able to call our API using not only the long absolute path to a model, but also using shorter name, composed of last two components of the path. 

The existing behavior, that is API calls using absolute path to the model, will be maintained.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Functional tests have been added, if necessary.
- [x] E2E Workflow tests have been added, if necessary.

[1] https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#vllm-serve