### PR TITLE
fix: apt-get update before installing packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,13 @@ jobs:
       - name: Free disk space
         uses: ./.github/actions/free-disk-space
 
+      # Always apt-get update before installing any extra packages
+      # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners
+      - name: Update apt index
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: |
+          sudo apt-get update
+
       - name: Install the expect package
         if: startsWith(matrix.platform, 'ubuntu')
         run: |


### PR DESCRIPTION
See the Note at
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners . We should always run an `apt-get update` to update the package index before attempting installs to prevent package installation failures.

Resolves #3073

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
