### PR TITLE
Setting mock console size to 80 cols

### DIFF
--- a/tests/test_model_chat.py
+++ b/tests/test_model_chat.py
@@ -81,7 +81,7 @@ def test_list_contexts_and_decoration():
     with contextlib.suppress(KeyboardInterrupt):
         chatbot.start_prompt(logger=None)
 
-    console = Console(force_terminal=False)
+    console = Console(force_terminal=False, width=80)
     with console.capture() as capture:
         console.print(mock_sys_print_output.output)
 


### PR DESCRIPTION
`Console` takes a terminal width from environment by default. This would cause the test to fail, as the expected output is formatted to fit in 80 column terminal.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Functional tests have been added, if necessary.
- [x] E2E Workflow tests have been added, if necessary.
