### PR TITLE
ci: run yamllint on all files

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -83,7 +83,7 @@ runs:
           sudo dnf clean all
           rm -rf /var/cache/dnf*
         else
-          echo "Unrecognized OS '${os_id}'. Skipping large package cleanup, as this logic has not been implemented for ${os_id}."
+          echo "Skipping large package cleanup for OS '${os_id}' (not implemented)."
         fi
       shell: bash
     - name: Free Disk Space MacOS

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,6 +1,8 @@
 pull_request_rules:
 - name: auto-merge
-  description: automatic merge for main with >= 2 approved reviews, all requested reviews have given feedback, not held, and CI is successful
+  description: >
+    automatic merge for main with >= 2 approved reviews,
+    all requested reviews have given feedback, not held, and CI is successful
   conditions:
     - "#approved-reviews-by>=2"
     - "#review-requested=0"
@@ -235,9 +237,10 @@ pull_request_rules:
       add:
         - needs-rebase
     comment:
-      message: |
-       This pull request has merge conflicts that must be resolved before it can be
-       merged. @{{author}} please rebase it. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
+      message: >
+       This pull request has merge conflicts that must be resolved before it
+       can be merged. @{{author}} please rebase it.
+       https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
 
 - name: remove 'needs-rebase' label when conflict is resolved
   conditions:

--- a/.github/workflows/e2e-aws-custom.yml
+++ b/.github/workflows/e2e-aws-custom.yml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# yamllint disable rule:line-length
 
 name: E2E (Custom)
 

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# yamllint disable rule:line-length
 
 name: E2E (NVIDIA L40S x4)
 

--- a/.github/workflows/e2e-nvidia-l40s-x8.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x8.yml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# yamllint disable rule:line-length
 
 name: E2E (NVIDIA L40S x8)
 

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -36,7 +36,8 @@ jobs:
             This issue has been automatically marked as stale because it has not had activity within 60 days.
             It will be automatically closed if no further activity occurs within 30 days.
           close-issue-message: >
-            This issue has been automatically closed due to inactivity. Please feel free to reopen if you feel it is still relevant!
+            This issue has been automatically closed due to inactivity.
+            Please feel free to reopen if you feel it is still relevant!
           days-before-issue-stale: 60
           days-before-issue-close: 30
           stale-pr-label: 'stale'
@@ -44,7 +45,8 @@ jobs:
             This pull request has been automatically marked as stale because it has not had activity within 60 days.
             It will be automatically closed if no further activity occurs within 30 days.
           close-pr-message: >
-            This pull request has been automatically closed due to inactivity. Please feel free to reopen if you intend to continue working on it!
+            This pull request has been automatically closed due to inactivity.
+            Please feel free to reopen if you intend to continue working on it!
           days-before-pr-stale: 60
           days-before-pr-close: 30
           operations-per-run: 300

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# yamllint disable rule:line-length
 
 name: Status Checks Reusable Workflow
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# yamllint disable rule:line-length
 
 name: Test
 

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -9,3 +9,7 @@ rules:
     max: 120
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: false
+    ignore:
+      # tests/test_lab_diff.py expects to fail on this file.
+      # All other basic yamllint runs should skip this file.
+      - /tests/testdata/invalid_yaml.yaml

--- a/tox.ini
+++ b/tox.ini
@@ -112,8 +112,7 @@ skipsdist = true
 deps =
   yamllint>=1.35.1
 commands =
-  yamllint scripts/test-data/compositional_skills
-  yamllint scripts/test-data/knowledge
+  yamllint .
 
 [testenv:spellcheck]
 description = spell check (needs 'aspell' command)


### PR DESCRIPTION
Prior to this change, `tox yamllint` only linted certain files under `test-data`. Expand this to lint all files in the tree.

Some YAML files are more readable with lines greater than 120 characters. For these files, I've inserted per-file magic override comments. These files get copy-pasted a bit, so I've included the comments within each file.

Resolves #3041
