### PR TITLE
fix: Only require HF_TOKEN when actually needed

### DIFF
--- a/src/instructlab/model/download.py
+++ b/src/instructlab/model/download.py
@@ -13,6 +13,7 @@ import subprocess
 from huggingface_hub import hf_hub_download, list_repo_files
 from huggingface_hub import logging as hf_logging
 from huggingface_hub import snapshot_download
+from huggingface_hub.errors import GatedRepoError
 
 # First Party
 from instructlab.configuration import DEFAULTS
@@ -77,13 +78,6 @@ class HFDownloader(ModelDownloader):
             f"Downloading model from Hugging Face:\n{DEFAULT_INDENT}Model: {self.repository}@{self.release}\n{DEFAULT_INDENT}Destination: {self.download_dest}"
         )
 
-        if self.hf_token is None and "instructlab" not in self.repository:
-            raise ValueError(
-                """HF_TOKEN var needs to be set in your environment to download HF Model.
-                Alternatively, the token can be passed with --hf-token flag.
-                The HF Token is used to authenticate your identity to the Hugging Face Hub."""
-            )
-
         try:
             if self.log_level is not None:
                 hf_logging.set_verbosity(self.log_level)
@@ -93,6 +87,12 @@ class HFDownloader(ModelDownloader):
             else:
                 self.download_gguf()
 
+        except GatedRepoError as exc:
+            raise ValueError(
+                """The HF_TOKEN environment variable needs to be set in your environment to download this Hugging Face Model.
+                Alternatively, the token can be passed with --hf-token flag.
+                The Hugging Face token is used to authenticate your identity to the Hugging Face Hub."""
+            ) from exc
         except Exception as exc:
             raise RuntimeError(
                 f"\nDownloading model failed with the following Hugging Face Hub error:\n{DEFAULT_INDENT}{exc}"

--- a/tests/test_lab_download.py
+++ b/tests/test_lab_download.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 # Third Party
 from click.testing import CliRunner
+from huggingface_hub.errors import GatedRepoError
 from huggingface_hub.utils import HfHubHTTPError
 import pytest
 
@@ -24,20 +25,25 @@ class TestLabDownload:
             ("any/any", "", None, True),
         ],
     )
+    @patch("instructlab.model.download.list_repo_files")
     def test_downloader_handles_token(
         self,
+        mock_list_repo_files,
         repo: str,
         provided_token: str,
         expected_token: Union[str, bool, None],
         expect_failure: bool,
     ):
+        if expect_failure:
+            mock_list_repo_files.side_effect = GatedRepoError("invalid token")
+
         downloader = HFDownloader(
             repository=repo,
             hf_token=provided_token,
             release="",
             download_dest=Path(""),
             filename="",
-            log_level="",
+            log_level="INFO",
         )
 
         assert downloader.hf_token == expected_token


### PR DESCRIPTION
Instead of assuming everything that doesn't have "instructlab" in it needs a HuggingFace access token, we actually try to download whatever model they have and only warn them to set a token if they really need one.

Resolves #3075

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] Unit tests have been added, if necessary.
