### PR TITLE
ci: Don't require secrets in medium e2e test

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -137,9 +137,6 @@ jobs:
           df -h
 
       - name: Run e2e test
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           . venv/bin/activate
           ./scripts/e2e-ci.sh -m

--- a/scripts/e2e-ci.sh
+++ b/scripts/e2e-ci.sh
@@ -138,7 +138,7 @@ test_download() {
         ilab model download --repository ${GRANITE_7B_MODEL}
     elif [ "$MEDIUM" -eq 1 ]; then
         step Downloading the mistral-7b-instruct GGUF model as the teacher model for SDG
-        ilab model download --repository ${MISTRAL_GGUF_REPO} --filename ${MISTRAL_GGUF_MODEL} --hf-token "${HF_TOKEN}"
+        ilab model download --repository ${MISTRAL_GGUF_REPO} --filename ${MISTRAL_GGUF_MODEL}
         step Downloading granite-7b-lab model to train and as the judge model for evaluation
         ilab model download --repository ${GRANITE_7B_MODEL}
     elif [ "$LARGE" -eq 1 ] || [ "$XLARGE" -eq 1 ]; then
@@ -379,17 +379,19 @@ test_evaluate() {
     base_model_path="${CACHE_HOME}/instructlab/models/${GRANITE_7B_MODEL}"
     dk_bench_output_formats="csv,xlsx,jsonl"
 
-    step Running DK Bench where trained model generates responses
-    ilab model evaluate \
-        --model "${model_path}" \
-        --benchmark dk_bench \
-        --input-questions "${SCRIPTDIR}/test-data/dk-bench-questions.jsonl" \
-        --output-file-formats "${dk_bench_output_formats}"
+    if [ "$LARGE" -eq 1 ]; then
+        step Running DK Bench where trained model generates responses
+        ilab model evaluate \
+            --model "${model_path}" \
+            --benchmark dk_bench \
+            --input-questions "${SCRIPTDIR}/test-data/dk-bench-questions.jsonl" \
+            --output-file-formats "${dk_bench_output_formats}"
 
-    step Running DK Bench with responses already provided
-    ilab model evaluate \
-        --benchmark dk_bench \
-        --input-questions "${SCRIPTDIR}/test-data/dk-bench-questions-with-responses.jsonl" \
+        step Running DK Bench with responses already provided
+        ilab model evaluate \
+            --benchmark dk_bench \
+            --input-questions "${SCRIPTDIR}/test-data/dk-bench-questions-with-responses.jsonl"
+    fi
 
     export INSTRUCTLAB_EVAL_MMLU_MIN_TASKS=true
     export HF_DATASETS_TRUST_REMOTE_CODE=true


### PR DESCRIPTION
This removes the need to have any secrets in the medium e2e test itself, simplifying the setup across repos as multiple repositories run this job and it's tedious to have to sync those secrets in multiple places.

Note that the workflow itself still uses secrets to spin up the EC2 runners, but the actual e2e test job no longer uses any secrets.