### PR TITLE
Use prebuilt vLLM for NVIDIA CUDA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update NVIDIA CUDA to version 12.8, in order to support NVIDIA Blackwell GPUs.
 - Update vLLM to version 0.6.6.post1. As a requirement for this new vLLM version, PyTorch is updated to 2.5.1
+- Use vLLM wheel from PyPI for NVIDIA CUDA to speed up installation of InstructLab.
 - `ilab model chat` now has `--no-decoration` option to display chat responses without decoration.
 - A new command `ilab model remove` has been introduced so users can now remove the model via `ilab` CLI.
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
    source venv/bin/activate
    pip cache remove llama_cpp_python
    CMAKE_ARGS="-DGGML_CUDA=on -DGGML_NATIVE=off" pip install 'instructlab[cuda]'
-   pip install vllm@git+https://github.com/opendatahub-io/vllm@v0.6.2
+   pip install -r requirements-vllm-cuda.txt
    ```
 
 4. From your `venv` environment, verify `ilab` is installed correctly, by running the `ilab` command.
@@ -510,7 +510,7 @@ For detailed documentation on the InstructLab LLMs and their functions, see the 
    If it is not, please run:
 
    ```shell
-   pip install vllm@git+https://github.com/opendatahub-io/vllm@v0.6.2
+   pip install -r requirements-vllm-cuda.txt
    ```
 
    Then you can serve a Safetensors model:

--- a/containers/cuda/Containerfile
+++ b/containers/cuda/Containerfile
@@ -179,6 +179,7 @@ ENV C_INCLUDE_PATH="${INTEL_MKL_HOME}/include:${C_INCLUDE_PATH}"
 ENV CPLUS_INCLUDE_PATH="${INTEL_MKL_HOME}/include:${CPLUS_INCLUDE_PATH}"
 ENV CMAKE_INCLUDE_PATH="${INTEL_MKL_HOME}/include:${CMAKE_INCLUDE_PATH}"
 
+COPY requirements-vllm-cuda.txt requirements-vllm-cuda.txt
 RUN source ${VIRTUAL_ENV}/bin/activate \
     && if [ "${INSTRUCTLAB_VERSION}" != "" ] ; then \
         INSTRUCTLAB_PKG="${INSTRUCTLAB_PKG}==${INSTRUCTLAB_VERSION}" ; \
@@ -186,7 +187,8 @@ RUN source ${VIRTUAL_ENV}/bin/activate \
     && pip install torch psutil \
     && pip install flash_attn --no-build-isolation \
     && pip install "${INSTRUCTLAB_PKG}" -C cmake.args="-DGGML_CUDA=on" -C cmake.args="-DGGML_NATIVE=off" \
-    && pip install vllm@git+https://github.com/opendatahub-io/vllm@v0.6.2
+    && pip install -r requirements-vllm-cuda.txt \
+    && rm requirements-vllm-cuda.txt
 
 ENV TORCH_HOME="${VIRTUAL_ENV}/lib64/${PYTHON}/site-packages/torch"
 ENV PYTORCH_HOME="${VIRTUAL_ENV}/lib64/${PYTHON}/site-packages/torch"

--- a/requirements-vllm-cuda.txt
+++ b/requirements-vllm-cuda.txt
@@ -2,4 +2,4 @@
 # Dependencies for installing vLLM on CUDA
 
 # vLLM only supports Linux platform (including WSL)
-vllm @git+https://github.com/opendatahub-io/vllm@v0.6.6.post1 ; sys_platform == 'linux' and platform_machine == 'x86_64'
+vllm==0.6.6.post1 ; sys_platform == 'linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
We have seen timeouts in the CI jobs because vLLM build takes too much time. Building vLLM is only done because we use the Open Data Hub fork of vLLM. However, the main difference between ODH fork and upstream vLLM is the Dockerfile for UBI, which is not used in InstructLab.

This change modifies the requirements to use the prebuilt vLLM wheel from PyPI, so that we don't build vLLM from source. This should speed up the CI jobs in general.

Fixes #3111.

Signed-off-by: Fabien Dupont <fdupont@redhat.com>