### PR TITLE
fix: Update vLLM to 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Update NVIDIA CUDA to version 12.8, in order to support NVIDIA Blackwell GPUs.
-- Update vLLM to version 0.6.6.post1. As a requirement for this new vLLM version, PyTorch is updated to 2.5.1
+- Update vLLM to version 0.7.2. As a requirement for this new vLLM version, PyTorch is updated to 2.5.1
 - Use vLLM wheel from PyPI for NVIDIA CUDA to speed up installation of InstructLab.
 - `ilab model chat` now has `--no-decoration` option to display chat responses without decoration.
 - A new command `ilab model remove` has been introduced so users can now remove the model via `ilab` CLI.

--- a/requirements-vllm-cuda.txt
+++ b/requirements-vllm-cuda.txt
@@ -2,4 +2,4 @@
 # Dependencies for installing vLLM on CUDA
 
 # vLLM only supports Linux platform (including WSL)
-vllm==0.6.6.post1 ; sys_platform == 'linux' and platform_machine == 'x86_64'
+vllm==0.7.2 ; sys_platform == 'linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
vLLM 0.6.6.post1 has an important CVE:
[CVE-2025-24357](https://nvd.nist.gov/vuln/detail/CVE-2025-24357). The fix is available is vLLM 0.7.0 or higher.