### PR TITLE
ci: install `git-core` package instead of `git`

### DIFF
--- a/.github/actions/detect-exposed-secrets/exposed_secrets_detection/tests/test_data/git_workflow_automatic_trigger.yaml
+++ b/.github/actions/detect-exposed-secrets/exposed_secrets_detection/tests/test_data/git_workflow_automatic_trigger.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git-core python3.11 python3.11-devel
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/actions/detect-exposed-secrets/exposed_secrets_detection/tests/test_data/git_workflow_automatic_trigger_with_top_level_env_secrets.yaml
+++ b/.github/actions/detect-exposed-secrets/exposed_secrets_detection/tests/test_data/git_workflow_automatic_trigger_with_top_level_env_secrets.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git-core python3.11 python3.11-devel
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/actions/detect-exposed-secrets/exposed_secrets_detection/tests/test_data/git_workflow_invalid_yaml.yml
+++ b/.github/actions/detect-exposed-secrets/exposed_secrets_detection/tests/test_data/git_workflow_invalid_yaml.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git-core python3.11 python3.11-devel
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/actions/detect-exposed-secrets/exposed_secrets_detection/tests/test_data/git_workflow_manual_trigger.yml
+++ b/.github/actions/detect-exposed-secrets/exposed_secrets_detection/tests/test_data/git_workflow_manual_trigger.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git-core python3.11 python3.11-devel
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/actions/detect-exposed-secrets/exposed_secrets_detection/tests/test_data/git_workflow_missing_triggers.yml
+++ b/.github/actions/detect-exposed-secrets/exposed_secrets_detection/tests/test_data/git_workflow_missing_triggers.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git-core python3.11 python3.11-devel
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/e2e-aws-custom.yml
+++ b/.github/workflows/e2e-aws-custom.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Install Packages
         run: |
           cat /etc/os-release
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git-core python3.11 python3.11-devel
 
       - name: Install ilab
         run: |

--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           cat /etc/os-release
           mkdir -p /home/tmp
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git-core python3.11 python3.11-devel
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           cat /etc/os-release
           mkdir -p /home/tmp
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git-core python3.11 python3.11-devel
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/e2e-nvidia-l40s-x8.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x8.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           cat /etc/os-release
           mkdir -p /home/tmp
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git-core python3.11 python3.11-devel
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           cat /etc/os-release
           mkdir -p /home/tmp
-          sudo dnf install -y gcc gcc-c++ make git python3.11 python3.11-devel
+          sudo dnf install -y gcc gcc-c++ make git-core python3.11 python3.11-devel
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For an overview of the full workflow, see the [workflow diagram](./docs/workflow
 - When installing on Fedora Linux, install C++, Python 3.10 or 3.11, and other necessary tools by running the following command:
 
    ```shell
-   sudo dnf install gcc gcc-c++ make git python3.11 python3.11-devel
+   sudo dnf install gcc gcc-c++ make git-core python3.11 python3.11-devel
    ```
 
    Some Python version management tools that build Python (instead of using a pre-built binary) may not by default build libraries implemented in C, and CPython when installing a Python version. This can result in the following error when running the `ilab data generate` command: `ModuleNotFoundError: No module named '_lzma'`. This can be resolved by building CPython during the Python installation with the `--enable-framework`. For example for `pyenv` on MacOS: `PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.x`. You may need to recreate your virtual environment after reinstalling Python.

--- a/scripts/infra/cloud-instance.sh
+++ b/scripts/infra/cloud-instance.sh
@@ -309,7 +309,7 @@ wait_ssh_listen() {
 }
 
 setup_rh_devenv() {
-    "${BASH_SOURCE[0]}" "$CLOUD_TYPE" ssh -n "$INSTANCE_NAME" sudo dnf install git gcc make python3.11 python3.11-devel -y
+    "${BASH_SOURCE[0]}" "$CLOUD_TYPE" ssh -n "$INSTANCE_NAME" sudo dnf install git-core gcc make python3.11 python3.11-devel -y
     "${BASH_SOURCE[0]}" "$CLOUD_TYPE" ssh -n "$INSTANCE_NAME" "sudo dnf install g++ -y || sudo dnf install gcc-c++"
     "${BASH_SOURCE[0]}" "$CLOUD_TYPE" ssh -n "$INSTANCE_NAME" "if [ ! -d instructlab.git ]; then git clone --bare https://github.com/instructlab/instructlab.git && git clone instructlab.git && pushd instructlab && git remote add syncrepo ../instructlab.git && git remote add upstream https://github.com/instructlab/instructlab.git; fi"
     "${BASH_SOURCE[0]}" "$CLOUD_TYPE" ssh -n "$INSTANCE_NAME" "pushd instructlab && python3.11 -m venv --upgrade-deps venv"

--- a/scripts/infra/local-setup.sh
+++ b/scripts/infra/local-setup.sh
@@ -30,7 +30,7 @@ rh__ensure_aws_system_pkgs() {
     # shellcheck source=/dev/null
     source /etc/os-release
     if [[ "$ID" == "fedora" ]] || [[ "$ID_LIKE" =~ "fedora" ]]; then
-        PKG_LIST=(git aws)
+        PKG_LIST=(git-core aws)
         if "$ADDN_PKGS"; then
             PKG_LIST+=(gcc python-devel python-virtualenv krb5-devel openldap-devel)
         fi

--- a/scripts/infra/nvidia-setup.sh
+++ b/scripts/infra/nvidia-setup.sh
@@ -49,7 +49,7 @@ WantedBy=multi-user.target
 FILEEOF
 
 rm -rf yum-packaging-precompiled-kmod
-dnf install libicu podman skopeo git rpm-build make openssl elfutils-libelf-devel python3.11 python3.11-devel -y
+dnf install libicu podman skopeo git-core rpm-build make openssl elfutils-libelf-devel python3.11 python3.11-devel -y
 if [ -z "${KERNEL_VERSION}" ]; then
       KERNELS=$(rpm -q --qf="%{BUILDTIME} %{VERSION}-%{RELEASE}\n" kernel-core | sort -n)
       KERNEL_COUNT=$(echo "${KERNELS}" | wc -l)


### PR DESCRIPTION
`git` is a package that pulls in Perl, and we only need `git-core` for the basic Git client.

Resolves #3139 