### PR TITLE
Pause the e2e-nvidia-l40s-x8.yml workflow

### DIFF
--- a/.github/workflows/e2e-nvidia-l40s-x8.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x8.yml
@@ -4,8 +4,9 @@
 name: E2E (NVIDIA L40S x8)
 
 on:
-  schedule:
-    - cron: '0 6 * * *' # Runs at 6AM UTC every day
+  #Pausing the schedule until we fix https://github.com/instructlab/instructlab/issues/2999
+  #schedule:
+  #  - cron: '0 6 * * *' # Runs at 6AM UTC every day
   workflow_dispatch:
     inputs:
       pr_or_branch:


### PR DESCRIPTION
Until we fix the underlying root cause for this https://github.com/instructlab/instructlab/issues/2999 and/or add more time if that becomes the inevitable path.

The change in this PR comments the schedule block of the workflow yaml and left a comment to reflect the change. This becomes easier to turn it back on, than removing the schedule block altogether.

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
