### PR TITLE
feat(init): use pathlib.Path in Click options

### DIFF
--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -155,7 +155,8 @@ class _chat(BaseModel):
     # model configuration
     model_config = ConfigDict(extra="ignore")
     model: str = Field(
-        default_factory=lambda: DEFAULTS.DEFAULT_CHAT_MODEL,
+        # @TODO: Switch to pathlib.Path once 'chat' subcommand options have been updated
+        default_factory=lambda: str(DEFAULTS.DEFAULT_CHAT_MODEL),
         description="Model to be used for chatting with.",
     )
     # additional fields with defaults
@@ -260,7 +261,8 @@ class _serve(BaseModel):
         description="llama-cpp serving settings.",
     )
     model_path: StrictStr = Field(
-        default_factory=lambda: DEFAULTS.DEFAULT_CHAT_MODEL,
+        # @TODO: Switch to pathlib.Path once 'serve' subcommand options have been updated
+        default_factory=lambda: str(DEFAULTS.DEFAULT_CHAT_MODEL),
         description="Directory where model to be served is stored.",
     )
     # additional fields with defaults
@@ -298,7 +300,8 @@ class _convert(BaseModel):
         description="Directory where converted documents are stored.",
     )
     taxonomy_path: StrictStr = Field(
-        default_factory=lambda: DEFAULTS.TAXONOMY_DIR,
+        # @TODO: Switch to pathlib.Path once 'rag' subcommand options have been updated
+        default_factory=lambda: str(DEFAULTS.TAXONOMY_DIR),
         description="Directory where taxonomy is stored and accessed from.",
     )
     taxonomy_base: StrictStr = Field(
@@ -357,7 +360,8 @@ class _generate(BaseModel):
         description="Teacher model that will be used to synthetically generate training data.",
     )
     taxonomy_path: StrictStr = Field(
-        default_factory=lambda: DEFAULTS.TAXONOMY_DIR,
+        # @TODO: Switch to pathlib.Path once 'generate' subcommand options have been updated
+        default_factory=lambda: str(DEFAULTS.TAXONOMY_DIR),
         description="Directory where taxonomy is stored and accessed from.",
     )
     taxonomy_base: StrictStr = Field(
@@ -461,7 +465,8 @@ class _mtbenchbranch(BaseModel):
     )
 
     taxonomy_path: str = Field(
-        default_factory=lambda: DEFAULTS.TAXONOMY_DIR,
+        # @TODO: Switch to pathlib.Path once 'evaluate' subcommand options have been updated
+        default_factory=lambda: str(DEFAULTS.TAXONOMY_DIR),
         description="Path to where base taxonomy is stored.",
     )
     output_dir: str = Field(
@@ -1159,7 +1164,9 @@ def get_dict(cfg: Config) -> dict[str, typing.Any]:
     return cfg.model_dump()
 
 
-def write_config(cfg: Config, config_file: typing.Optional[str] = None) -> None:
+def write_config(
+    cfg: Config, config_file: typing.Optional[pathlib.Path] = None
+) -> None:
     """Writes configuration to a disk"""
     config_file = DEFAULTS.CONFIG_FILE if config_file is None else config_file
     write_config_to_yaml(cfg, config_file)
@@ -1295,7 +1302,7 @@ def set_comment(
     )
 
 
-def write_config_to_yaml(cfg: Config, file_path: str):
+def write_config_to_yaml(cfg: Config, file_path: pathlib.Path):
     """
     Write a Pydantic model to a YAML file with comments derived from field descriptions.
 
@@ -1490,7 +1497,7 @@ def init(
 ) -> None:
     config_obj: Config
     error_msg: str | None = None
-    if config_file == "DEFAULT":
+    if str(config_file) == "DEFAULT":
         # if user passed --config DEFAULT we should ensure all proper dirs are created
         ensure_storage_directories_exist()
         config_obj = get_default_config()

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -167,8 +167,8 @@ class _InstructlabDefaults:
         return path.join(self._data_dir, STORAGE_DIR_NAMES.CONVERTED_DOCUMENTS)
 
     @property
-    def CONFIG_FILE(self) -> str:
-        return path.join(self._config_dir, CONFIG_FILENAME)
+    def CONFIG_FILE(self) -> pathlib.Path:
+        return pathlib.Path(self._config_dir) / CONFIG_FILENAME
 
     @property
     def CONFIG_FILE_LOCK(self) -> str:
@@ -179,8 +179,8 @@ class _InstructlabDefaults:
         return path.join(self._cache_home, STORAGE_DIR_NAMES.MODELS)
 
     @property
-    def DEFAULT_CHAT_MODEL(self) -> str:
-        return path.join(self.MODELS_DIR, self.GRANITE_GGUF_MODEL_NAME)
+    def DEFAULT_CHAT_MODEL(self) -> pathlib.Path:
+        return pathlib.Path(self.MODELS_DIR) / self.GRANITE_GGUF_MODEL_NAME
 
     @property
     def DEFAULT_EMBEDDING_MODEL(self) -> str:
@@ -199,8 +199,8 @@ class _InstructlabDefaults:
         return path.join(self.MODELS_DIR, self.JUDGE_MODEL_MT)
 
     @property
-    def TAXONOMY_DIR(self) -> str:
-        return path.join(self._data_dir, STORAGE_DIR_NAMES.TAXONOMY)
+    def TAXONOMY_DIR(self) -> pathlib.Path:
+        return pathlib.Path(self._data_dir) / STORAGE_DIR_NAMES.TAXONOMY
 
     @property
     def CHATLOGS_DIR(self) -> str:

--- a/src/instructlab/lab.py
+++ b/src/instructlab/lab.py
@@ -4,6 +4,7 @@
 
 # Standard
 import multiprocessing
+import pathlib
 
 # Third Party
 import click
@@ -25,10 +26,11 @@ multiprocessing.set_start_method(cfg.DEFAULTS.MULTIPROCESSING_START_METHOD, forc
 @click.option(
     "--config",
     "config_file",
-    type=click.Path(),
+    type=click.Path(path_type=pathlib.Path),
     default=cfg.DEFAULTS.CONFIG_FILE,
     show_default=True,
     help="Path to a configuration file.",
+    required=True,
 )
 @click.option(
     "-v",
@@ -42,7 +44,7 @@ multiprocessing.set_start_method(cfg.DEFAULTS.MULTIPROCESSING_START_METHOD, forc
 @click.version_option(package_name="instructlab")
 @click.pass_context
 # pylint: disable=redefined-outer-name
-def ilab(ctx, config_file, debug_level: int = 0):
+def ilab(ctx, config_file: pathlib.Path, debug_level: int = 0):
     """CLI for interacting with InstructLab.
 
     If this is your first time running ilab, it's best to start with `ilab config init` to create the environment.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -101,7 +101,8 @@ class TestConfig:
         assert cfg.generate.model == DEFAULTS.DEFAULT_TEACHER_MODEL
 
         assert cfg.serve is not None
-        assert cfg.serve.model_path == DEFAULTS.DEFAULT_CHAT_MODEL
+        # @TODO: Switch to pathlib.Path once 'serve' subcommand options have been updated
+        assert cfg.serve.model_path == str(DEFAULTS.DEFAULT_CHAT_MODEL)
 
         assert cfg.train is not None
         assert cfg.train.model_path == "instructlab/granite-7b-lab"
@@ -374,11 +375,11 @@ def test_compare_default_config_testdata(
 ):
     assert config.DEFAULTS.CHECKPOINTS_DIR == "/data/instructlab/checkpoints"
     saved_file = testdata_path / "default_config.yaml"
-    current_file = os.path.join(config.DEFAULTS._config_dir, "current_config.yaml")
+    current_file = pathlib.Path(config.DEFAULTS._config_dir) / "current_config.yaml"
 
     current_cfg = config.get_default_config()
     # roundtrip to verify serialization and de-serialization
-    config.write_config(current_cfg, str(current_file))
+    config.write_config(current_cfg, current_file)
     with open(file=current_file, encoding="utf-8") as yamlfile:
         current_content = yaml.safe_load(yamlfile)
 


### PR DESCRIPTION
Standardize path handling in the `init` command by replacing `str` with `pathlib.Path` in all relevant Click options

- Ensure consistency in path representations within the CLI
- Update default values to use `pathlib.Path` where applicable
- Add type annotations to relevant functions
- Explicitly set the `required` parameter based on whether an option has a default value

Resolves #1594 (partially)

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
