### PR TITLE
infra: fix cloud-instance ec2 wait loop

### DIFF
--- a/scripts/infra/cloud-instance.sh
+++ b/scripts/infra/cloud-instance.sh
@@ -34,7 +34,7 @@ ec2__launch() {
         echo "Failed to launch instance"
         exit 1
     else
-        local i=0
+        local i=1
         echo "Waiting for instance to be in the 'running' state..."
         while [[ $i -lt $MAX_ITERS ]]; do
             local state


### PR DESCRIPTION
Prior to this change, `./cloud-instance.sh ec2 launch` would fail to print information about the host it was launching.

Bash with `set -e` will bail out on `(( $i++ ))` when `$i` is zero. Start `i` on `1` to avoid this. This also clarifies that this is the "first" logical time the script has polled `describe-instances` before sleeping.

**Issue resolved by this Pull Request:**
Resolves #3185 