### PR TITLE
ci: label `scripts/infra` files as CI/CD

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -169,6 +169,7 @@ pull_request_rules:
       - files=.github/mergify.yml
       - files~=^\.github/(actions|workflows)/
       - files=scripts/ruff.sh
+      - files=scripts/infra/
       - files=.pre-commit-config.yaml
       - files=.pylintrc
       - files~=^\.spellcheck[^/]+$


### PR DESCRIPTION
The files in [`scripts/infra`](https://github.com/instructlab/instructlab/tree/main/scripts/infra) are relevant to CI/CD. Make PRs easier to discover for people who work on CI/CD.

With this change, my recent PR https://github.com/instructlab/instructlab/pull/3186 would get the [CI/CD label](https://github.com/instructlab/instructlab/pulls?q=is%3Aopen+is%3Apr+label%3ACI%2FCD).