### PR TITLE
mergify: remove old `ruff.sh` reference

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -168,7 +168,6 @@ pull_request_rules:
     - or:
       - files=.github/mergify.yml
       - files~=^\.github/(actions|workflows)/
-      - files=scripts/ruff.sh
       - files=scripts/infra/
       - files=.pre-commit-config.yaml
       - files=.pylintrc


### PR DESCRIPTION
PR https://github.com/instructlab/instructlab/pull/1526 moved this to a `tox` target.