### PR TITLE
feat(infra): add cloud-instance list command; ignore shutting-down instances

### DIFF
--- a/scripts/infra/cloud-instance.sh
+++ b/scripts/infra/cloud-instance.sh
@@ -64,7 +64,7 @@ _get_instances() {
     aws ec2 describe-instances \
         --filters "Name=tag:Name,Values=$INSTANCE_NAME" \
         --region "$EC2_REGION" \
-        --query 'Reservations[*].Instances[?State.Name!=`terminated`].InstanceId' \
+        --query 'Reservations[*].Instances[?State.Name!=`terminated` && State.Name!=`shutting-down`].InstanceId' \
         --output text
 }
 


### PR DESCRIPTION
Some improvements to the `cloud-instance.sh` script:

- **feat(infra): add cloud-instance.sh list command**
- **feat(infra): ignore shutting-down machines when calculating aws ids**

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
