### PR TITLE
Fix import of read_config in debug-llama

### DIFF
--- a/containers/bin/debug-llama
+++ b/containers/bin/debug-llama
@@ -33,7 +33,7 @@ def main(argv=None):
 
     if args.model is None:
         # First Party
-        from instructlab.config import read_config
+        from instructlab.configuration import read_config
 
         try:
             cfg = read_config()


### PR DESCRIPTION
Function **_read_config()_** has been moved from **_instructlab.config_** to **_instructlab.configuration_** module.

Fix below problem with import of read_config() function which simply has been moved to different place.

```
(instructlab-02-cuda) ai@box ~/s/instructlab (main)> ./containers/bin/debug-llama
llama_cpp version: 0.3.6
llama supports gpu offload: False
n_gpu_layers: -1 (gpu)
Traceback (most recent call last):
  File "/home/ai/src/instructlab/./containers/bin/debug-llama", line 74, in <module>
    main()
  File "/home/ai/src/instructlab/./containers/bin/debug-llama", line 36, in main
    from instructlab.config import read_config
ImportError: cannot import name 'read_config' from 'instructlab.config' (/home/ai/venv/instructlab-02-cuda/lib64/python3.11/site-packages/instructlab/config/__init__.py
```