### PR TITLE
infra: do not reinstall ibmcloud CLI

### DIFF
--- a/scripts/infra/local-setup.sh
+++ b/scripts/infra/local-setup.sh
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 rh__ensure_ibm_system_pkgs() {
+    if command -v ibmcloud &> /dev/null; then
+        echo "ibmcloud CLI is already installed"
+        return
+    fi
     # shellcheck source=/dev/null
     if [ -f /etc/os-release ]; then
         source /etc/os-release


### PR DESCRIPTION
If a developer already has the `ibmcloud` CLI utility present in `$PATH`, print a message and exit rather than re-installing it.