### PR TITLE
infra: remove os version

### DIFF
--- a/scripts/infra/README.md
+++ b/scripts/infra/README.md
@@ -13,11 +13,12 @@ You'll need to setup the respective cloud CLI before using [cloud-instance.sh](c
 - A keypair created within AWS. Config defaults to `whoami` for key name.
 
 ```bash
-# Ensure proper system packages are installed if your local system is Red Hat-based
-# If you are running a different OS you'll need to install these packages manually
-./local-setup.sh rh ensure-aws-system-pkgs
+# Ensure proper system packages are installed. This script supports Red
+# Hat-based systems. If you are running a different OS you'll need to install
+# these packages manually, or update the script for your OS.
+./local-setup.sh ensure-aws-system-pkgs
 # If you are using SAML auth with the AWS CLI, you can install packages for that with the '-s` flag
-./local-setup.sh rh ensure-aws-system-pkgs -s
+./local-setup.sh ensure-aws-system-pkgs -s
 ```
 
 ### IBM


### PR DESCRIPTION
Auto-detect the operating system identifier from `/etc/os-release`, so that users do not need to specify it manually.

The `ibmcloud` setup command applies to both RH and non-RH distros, so we don't need to check the OS there.