### PR TITLE
Bump minimum version of SDG to 0.7.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ httpx>=0.25.0
 instructlab-eval>=0.5.1
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.4.2
-instructlab-sdg>=0.7.0
+instructlab-sdg>=0.7.2
 instructlab-training>=0.7.0
 llama_cpp_python[server]==0.3.6
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'


### PR DESCRIPTION
SDG created a new bugfix release. It is important enough that we want all instructlab users to consume it.