### PR TITLE
chore: bump the training library to 0.8.0 and refactor tokenizer usage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ instructlab-schema>=0.4.2
 instructlab-sdg>=0.7.2
 # XXX(osilkin): we need to pin this version for now while we improve tokenizer logic
 # see: https://github.com/instructlab/training/pull/428
-instructlab-training>=0.7.0,<0.7.1
+instructlab-training>=0.8.0
 llama_cpp_python[server]==0.3.6
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 numpy>=1.26.4,<2.0.0

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,2 +1,2 @@
 # Extra dependencies for NVIDIA CUDA
-instructlab-training[cuda]>=0.7.0,<0.7.1
+instructlab-training[cuda]>=0.8.0

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -10,4 +10,4 @@ habana_gpu_migration>=1.18.0
 #habana-torch-dataloader
 
 # Extra dependencies for Intel Gaudi cards
-instructlab-training[hpu]>=0.7.0,<0.7.1
+instructlab-training[hpu]>=0.8.0

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -1,2 +1,2 @@
 # Extra dependencies for AMD ROCm
-instructlab-training[rocm]>=0.7.0,<0.7.1
+instructlab-training[rocm]>=0.8.0

--- a/src/instructlab/model/full_train.py
+++ b/src/instructlab/model/full_train.py
@@ -173,7 +173,9 @@ def train(train_args, device, optimize_memory):
         )
     )
 
-    model, dataloader = setup_model(train_args, tokenizer, dataset, optimize_memory)
+    model, dataloader = setup_model(
+        train_args, tokenizer, dataset, optimize_memory, packing_max_batch_len, accum
+    )
 
     # Get virtual memory statistics
     memory_info = psutil.virtual_memory()

--- a/src/instructlab/model/full_train.py
+++ b/src/instructlab/model/full_train.py
@@ -20,62 +20,18 @@ from instructlab.utils import is_macos_with_m_chip
 logger = logging.getLogger(__name__)
 
 
-def train(train_args, device, optimize_memory):
-    """
-    train runs a CPU and MacOS optimized version of full fine tuning.
-    Adafactor is the optimizer of choice and the multiprocessing method is set to spawn.
-    Dataloading functions imported from the training library.
-    """
-
+def setup_model(
+    train_args,
+    tokenizer,
+    dataset,
+    optimize_memory: bool,
+    packing_max_batch_len: int,
+    accum: int,
+):
     # pylint: disable=no-name-in-module
     # Third Party
-    from instructlab.training import config
-    from instructlab.training import data_process as dp
-    from instructlab.training import (
-        multipack_sampler,
-        token_dataset,
-        tokenizer_utils,
-        utils,
-    )
+    from instructlab.training import multipack_sampler, utils
     from torch.utils.data import DataLoader
-    import torch
-
-    dp.main(
-        config.DataProcessArgs(
-            data_output_path=train_args.data_output_dir,
-            model_path=train_args.model_path,
-            data_path=train_args.data_path,
-            max_seq_len=train_args.max_seq_len,
-            chat_tmpl_path=train_args.chat_tmpl_path,
-        )
-    )
-
-    # load chat template based on path in the args
-    CHAT_TEMPLATE, SPECIAL_TOKENS = utils.retrieve_chat_template(
-        train_args.chat_tmpl_path
-    )
-    # get the tokenizer for the model
-    tokenizer = tokenizer_utils.setup_tokenizer(
-        train_args.model_path, SPECIAL_TOKENS, CHAT_TEMPLATE
-    )
-
-    # setup the dataset and place it in data.jsonl, this needs to be used for training NOT the jsonl produced by sdg
-    dataset = token_dataset.setup_dataset(
-        os.path.join(train_args.data_output_dir, "data.jsonl"),
-    )
-
-    # based on the length of the dataset, figure out the max batch len
-    packing_max_batch_len, accum = (
-        multipack_sampler.find_packing_max_batch_len_and_grad_accum(
-            num_gpus=1,
-            avg_sample_len=dataset.get_lengths().mean(),
-            effective_batch_size=train_args.effective_batch_size,
-            max_batch_len_per_gpu=train_args.max_batch_len,
-            is_padding=False,
-            dataset=dataset,
-            seed=47,
-        )
-    )
 
     collate_fn = partial(pad_collate_fn, pad_token_id=tokenizer.pad_token_id)
 
@@ -103,8 +59,6 @@ def train(train_args, device, optimize_memory):
     logger.info(
         f"avg_sample_len: {dataset.get_lengths().mean()}\n effective_batch_size: {train_args.effective_batch_size}\n max_batch_len: {train_args.max_batch_len}\n packing_max_batch_len: {packing_max_batch_len} \n grad_accum: {accum}\n  num_batches: {len(dataloader)}\n avg_samples_per_batch: {len(dataset) / len(dataloader)}"
     )
-    # set device based off argument given
-    dev = torch.device(device)
 
     # if the user specified --optimize-memory OR they are on a Mac, set dtype=auto
     torch_dtype = "auto" if (optimize_memory or is_macos_with_m_chip()) else "float32"
@@ -159,11 +113,73 @@ def train(train_args, device, optimize_memory):
         )
         model.config.eos_token_id = tokenizer.eos_token_id
 
+    # ensure the model has any tokens which were added to the tokenizer
+    if tokenizer.pad_token_id is not None and model.config.pad_token_id is None:
+        model.config.pad_token_id = tokenizer.pad_token_id
+    if tokenizer.bos_token_id is not None and model.config.bos_token_id is None:
+        model.config.bos_token_id = tokenizer.bos_token_id
+    if tokenizer.eos_token_id is not None and model.config.eos_token_id is None:
+        model.config.eos_token_id = tokenizer.eos_token_id
+
     model = utils.convert_loss_to_reduce_sum(model)
     model = utils.add_noisy_embeddings(model, noise_alpha=None)
+    return model, dataloader
+
+
+def train(train_args, device, optimize_memory):
+    """
+    train runs a CPU and MacOS optimized version of full fine tuning.
+    Adafactor is the optimizer of choice and the multiprocessing method is set to spawn.
+    Dataloading functions imported from the training library.
+    """
+
+    # pylint: disable=no-name-in-module
+    # Third Party
+    from instructlab.training import config
+    from instructlab.training import data_process as dp
+    from instructlab.training import multipack_sampler, token_dataset, tokenizer_utils
+    import torch
+
+    dp.main(
+        config.DataProcessArgs(
+            data_output_path=train_args.data_output_dir,
+            model_path=train_args.model_path,
+            data_path=train_args.data_path,
+            max_seq_len=train_args.max_seq_len,
+            chat_tmpl_path=train_args.chat_tmpl_path,
+        )
+    )
+
+    # load chat template based on path in the args
+    tokenizer = tokenizer_utils.setup_tokenizer(
+        train_args.model_path, train_args.chat_tmpl_path
+    )
+
+    # setup the dataset and place it in data.jsonl, this needs to be used for training NOT the jsonl produced by sdg
+    dataset = token_dataset.setup_dataset(
+        os.path.join(train_args.data_output_dir, "data.jsonl"),
+    )
+
+    # based on the length of the dataset, figure out the max batch len
+    packing_max_batch_len, accum = (
+        multipack_sampler.find_packing_max_batch_len_and_grad_accum(
+            num_gpus=1,
+            avg_sample_len=dataset.get_lengths().mean(),
+            effective_batch_size=train_args.effective_batch_size,
+            max_batch_len_per_gpu=train_args.max_batch_len,
+            is_padding=False,
+            dataset=dataset,
+            seed=47,
+        )
+    )
+
+    model, dataloader = setup_model(train_args, tokenizer, dataset, optimize_memory)
 
     # Get virtual memory statistics
     memory_info = psutil.virtual_memory()
+
+    # set device based off argument given
+    dev = torch.device(device)
 
     # Total RAM
     total_ram = memory_info.total / (1024**3)  # Convert to GB


### PR DESCRIPTION
The latest release of instructlab-training improves the usage for tokenizing datasets by removing the requirement of needing to always supply a chat template. This breaks the API for `setup_tokenizer` where in the past it needed to be passed some special objects only present in the training library. Now, it accepts only the model path and an optional template path. And given the scenario, it will automatically configure the tokenizer to the best of its abilities.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
