### PR TITLE
feat: add model family in cfg

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,9 +60,9 @@ nitpick_ignore = [
     ("py:class", "mx.array"),
     # TODO: Warning is thrown that:
     # py:class reference target not found: instructlab.training.config.DistributedBackend [ref.class]
-    # py:class reference target not found: instructlab.configuration._model_config [ref.class]
+    # py:class reference target not found: instructlab.configuration.model_info [ref.class]
     ("py:class", "instructlab.training.config.DistributedBackend"),
-    ("py:class", "instructlab.configuration._model_config"),
+    ("py:class", "instructlab.configuration.model_info"),
     # stdlib
     ("py:class", "FrameType"),
     # pydantic auto-generated doc strings

--- a/src/instructlab/cli/data/generate.py
+++ b/src/instructlab/cli/data/generate.py
@@ -241,6 +241,25 @@ def generate(
     if batch_size > 0:
         checkpoint_dir = os.path.join(output_dir, "checkpoints")
 
+    if teacher_model_id:
+        try:
+            teacher_model_config = resolve_model_id(
+                teacher_model_id, ctx.obj.config.models
+            )
+            if not teacher_model_config:
+                raise ValueError(
+                    f"Teacher model with ID '{teacher_model_id}' not found in the configuration."
+                )
+            model_path = teacher_model_config.path
+            model_family = (
+                teacher_model_config.family
+                if teacher_model_config.family
+                else model_family
+            )
+        except ValueError as ve:
+            click.secho(f"failed to locate teacher model by ID: {ve}", fg="red")
+            raise click.exceptions.Exit(1)
+
     serve_cfg = copy.deepcopy(ctx.obj.config.generate.teacher)
     serve_cfg.llama_cpp.llm_family = model_family or serve_cfg.llama_cpp.llm_family
     serve_cfg.vllm.llm_family = model_family or serve_cfg.vllm.llm_family
@@ -262,20 +281,6 @@ def generate(
             "tls_insecure": tls_insecure,
         }
     )
-
-    if teacher_model_id:
-        try:
-            teacher_model_config = resolve_model_id(
-                teacher_model_id, ctx.obj.config.models
-            )
-            if not teacher_model_config:
-                raise ValueError(
-                    f"Teacher model with ID '{teacher_model_id}' not found in the configuration."
-                )
-            model_path = teacher_model_config.path
-        except ValueError as ve:
-            click.secho(f"failed to locate teacher model by ID: {ve}", fg="red")
-            raise click.exceptions.Exit(1)
 
     # determine student model arch from train section of config and pick system prompt to
     # pass to SDG appropriately

--- a/src/instructlab/cli/data/generate.py
+++ b/src/instructlab/cli/data/generate.py
@@ -251,11 +251,7 @@ def generate(
                     f"Teacher model with ID '{teacher_model_id}' not found in the configuration."
                 )
             model_path = teacher_model_config.path
-            model_family = (
-                teacher_model_config.family
-                if teacher_model_config.family
-                else model_family
-            )
+            model_family = model_family if model_family else teacher_model_config.family
         except ValueError as ve:
             click.secho(f"failed to locate teacher model by ID: {ve}", fg="red")
             raise click.exceptions.Exit(1)

--- a/src/instructlab/cli/model/serve.py
+++ b/src/instructlab/cli/model/serve.py
@@ -141,7 +141,7 @@ def serve(
                     f"Model with ID '{model_id}' not found in the configuration."
                 )
             model_path = pathlib.Path(model_config.path)
-            model_family = model_config.family if model_config.family else model_family
+            model_family = model_family if model_family else model_config.family
         except ValueError as ve:
             click.secho(f"failed to locate model by ID: {ve}", fg="red")
             raise click.exceptions.Exit(1)

--- a/src/instructlab/cli/model/serve.py
+++ b/src/instructlab/cli/model/serve.py
@@ -10,7 +10,7 @@ import click
 
 # First Party
 from instructlab import clickext
-from instructlab.configuration import write_config
+from instructlab.configuration import resolve_model_id, write_config
 from instructlab.defaults import DEFAULTS
 from instructlab.model.backends import backends
 from instructlab.model.serve_backend import serve_backend, signal_handler
@@ -37,6 +37,11 @@ def warn_for_unsupported_backend_param(ctx):
     type=click.Path(path_type=pathlib.Path),
     cls=clickext.ConfigOption,
     required=True,  # default from config
+)
+@click.option(
+    "--model-id",
+    help="ID of the model to use for chatting from the config models list.",
+    default=None,
 )
 @click.option(
     "--gpu-layers",
@@ -104,6 +109,7 @@ def warn_for_unsupported_backend_param(ctx):
 def serve(
     ctx: click.Context,
     model_path: pathlib.Path,
+    model_id: str | None,
     gpu_layers: int,
     num_threads: int | None,
     max_ctx_size: int,
@@ -126,6 +132,19 @@ def serve(
         )
         ctx.obj.config.serve.server.current_max_ctx_size = max_ctx_size
         write_config(ctx.obj.config)
+
+    if model_id:
+        try:
+            model_config = resolve_model_id(model_id, ctx.obj.config.models)
+            if not model_config:
+                raise ValueError(
+                    f"Model with ID '{model_id}' not found in the configuration."
+                )
+            model_path = pathlib.Path(model_config.path)
+            model_family = model_config.family if model_config.family else model_family
+        except ValueError as ve:
+            click.secho(f"failed to locate model by ID: {ve}", fg="red")
+            raise click.exceptions.Exit(1)
 
     serve_backend(
         ctx,

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -685,7 +685,7 @@ class _train(BaseModel):
     )
 
 
-class _model_config(BaseModel):
+class model_info(BaseModel):
     """
     Class representing the configuration for a model.
 
@@ -779,7 +779,7 @@ class Config(BaseModel):
         description="Metadata pertaining to the specifics of the system which the Configuration is meant to be applied to.",
     )
     # List of user-defined models
-    models: List[_model_config] = Field(
+    models: List[model_info] = Field(
         default_factory=lambda: [],
         description="User-defined custom set of models. This allows people to use their own models for the InstructLab model customization process.",
     )
@@ -1323,8 +1323,8 @@ def get_model_family(family, model_path):
     family = MODEL_FAMILY_MAPPINGS.get(family, family)
     if family:
         if family.lower() not in MODEL_FAMILIES:
-            # raise ConfigException(f"Unknown model family: {family}")
-            logger.warning(f"Unknown model family: {family}.")
+            # not raising an error to allow users to specify any family name
+            logger.warning(f"Using unknown model family: {family} specified by user.")
 
         return family.lower()
 
@@ -1493,6 +1493,7 @@ def init(
 ) -> None:
     config_obj: Config
     error_msg: str | None = None
+
     if config_file == "DEFAULT":
         # if user passed --config DEFAULT we should ensure all proper dirs are created
         ensure_storage_directories_exist()
@@ -1666,9 +1667,7 @@ def configs_exist() -> bool:
     return os.path.exists(DEFAULTS.CONFIG_FILE)
 
 
-def resolve_model_id(
-    model_id: str, models: List[_model_config]
-) -> _model_config | None:
+def resolve_model_id(model_id: str, models: List[model_info]) -> model_info | None:
     """
     Given a `model_id`, returns the matching model config if one is found.
     When a model is found, the following validations happen:

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -698,9 +698,11 @@ class _model_config(BaseModel):
     id: str = Field(
         description="Internal ID referring to a particular model from the list.",
     )
-    path: str | None = Field(
+    family: str = Field(
+        description="Family the model belongs to.",
+    )
+    path: str = Field(
         description="Path to where the model can be found. Can either be a HF reference or local filepath.",
-        default=None,
     )
     system_prompt: str | None = Field(
         description='The initial message used to prompt the conversation with this model. E.g. "You are a helfpul AI assistant..."',
@@ -1321,7 +1323,8 @@ def get_model_family(family, model_path):
     family = MODEL_FAMILY_MAPPINGS.get(family, family)
     if family:
         if family.lower() not in MODEL_FAMILIES:
-            raise ConfigException(f"Unknown model family: {family}")
+            # raise ConfigException(f"Unknown model family: {family}")
+            logger.warning(f"Unknown model family: {family}.")
 
         return family.lower()
 

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -605,7 +605,7 @@ def chat_model(
     logs_dir,
     vi_mode,
     visible_overflow,
-    models_config: List[cfg._model_config],
+    models_config: List[cfg.model_info],
 ):
     """Runs a chat using the modified model"""
     if rag_enabled and not FeatureGating.feature_available(GatedFeatures.RAG):

--- a/tests/common.py
+++ b/tests/common.py
@@ -14,6 +14,16 @@ from instructlab import configuration, lab
 _CFG_FILE_NAME = "test-serve-config.yaml"
 
 
+def setup_test_models_config(models_list, dest=""):
+    _cfg_name = "test-models-config.yaml"
+    cfg = configuration.get_default_config()
+
+    cfg.models = models_list
+    with pathlib.Path(f"{dest}/{_cfg_name}").open("w", encoding="utf-8") as f:
+        yaml.dump(cfg.model_dump(), f)
+    return _cfg_name
+
+
 def setup_gpus_config(section_path="serve", gpus=None, tps=None, vllm_args=lambda: []):
     """Returns the name of the config file with the requested vllm config."""
     cfg = configuration.get_default_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -235,18 +235,10 @@ serve:
             # default empty value of model_family will use name of model in model path to guess model_family
             "": "granite",
         }
-        bad_cases = [
-            # unknown family
-            "unknown",
-        ]
         for model_name, expected_family in good_cases.items():
             model_path = os.path.join("models", f"{model_name}-7b-lab-Q4_K_M.gguf")
             assert config.get_model_family(model_name, model_path) == expected_family
             assert config.get_model_family(None, model_path) == expected_family
-        for model_name in bad_cases:
-            model_path = os.path.join("models", f"{model_name}-7b-lab-Q4_K_M.gguf")
-            with pytest.raises(config.ConfigException):
-                config.get_model_family(model_name, model_path)
 
     def test_config_modified_settings(self, tmp_path_home):
         config_path = tmp_path_home / "config.yaml"


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

adds the ability to pass a specific model-id to generate, chat and serve. This model id is then resolved out of the config if found, and details like the model-family, path etc are extracted and passed further 
This is required to support 3rd party models being used as students, teachers etc in an easy way. The model family value is passed into sdg and appropriate chat template is selected based on what is passed 

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
