### PR TITLE
[backport] fix: Update `model_generate` to output logits

### DIFF
--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -255,6 +255,7 @@ def linux_train(
             top_p=0.9,
             stopping_criteria=stopping_criteria,
             do_sample=True,
+            output_logits=True,
             **kwargs,
         )
         return tokenizer.batch_decode([o[:-1] for o in outputs])[0]


### PR DESCRIPTION
**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.

We need to force `moded_generate` to output logits so that `linux_train.py` can reference the `logits` attribute. Otherwise, we run into an issue in our sister repos, like `instructlab/sdg`. For example, see https://github.com/instructlab/sdg/pull/595 failing due to this issue: https://github.com/instructlab/sdg/actions/runs/14317698278/job/40169189831?pr=595

The following commit on `main` resolved the above issue: https://github.com/instructlab/instructlab/commit/8fe9bc62c055837757208c633cda6b08d1707c4c

Evidence that https://github.com/instructlab/sdg/pull/595 passed:
https://github.com/instructlab/sdg/pull/595