### PR TITLE
fix: Correct formatting in `test.yml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
           echo 'INSTRUCTLAB_DISABLE_GPU_ACCELERATION="true"' >> "$GITHUB_ENV"
 
       - name: Enable MPS acceleration on non-MacOS runners
-        if: ! startsWith(matrix.platform, 'macos')
+        if: ${{ ! startsWith(matrix.platform, 'macos') }}
         run: |
           echo 'INSTRUCTLAB_DISABLE_GPU_ACCELERATION=' >> "$GITHUB_ENV"
 


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.

## Overview

Currently, the `test.yml` workflow is not executing in PR builds because of slight formatting issues. This is the error we're seeing on PR builds right now:

```
[Invalid workflow file: .github/workflows/test.yml#L1](https://github.com/instructlab/instructlab/actions/runs/14341401024/workflow)
The workflow is not valid. .github/workflows/test.yml: (Line: 133, Col: 13, Idx: 4139) - (Line: 133, Col: 14, Idx: 4140): While parsing a tag, did not find expected tag URI.
```

[Example logs here](https://github.com/instructlab/instructlab/actions/runs/14341401024).

Upon analysis, it looks like the GitHub workflow "not" conditional needs to use a different syntax than we're using currently: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif

## Proposed Changes

Update the "not" conditional to use `${{ }}` syntax as suggested in the GitHub docs link above.