### PR TITLE
fix: Use `env` instead of `GITHUB_ENV` in `test.yml` to define MacOS runner behavior

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,18 +122,6 @@ jobs:
           rm -rf "$GITHUB_WORKSPACE"/src/github.com/containers/skopeo
           skopeo --version
 
-        # deactivate MPS acceleration on Github CI for MacOS
-        # see https://github.com/actions/runner-images/issues/9918
-      - name: Disable MPS acceleration on MacOS
-        if: startsWith(matrix.platform, 'macos')
-        run: |
-          echo 'INSTRUCTLAB_DISABLE_GPU_ACCELERATION="true"' >> "$GITHUB_ENV"
-
-      - name: Enable MPS acceleration on non-MacOS runners
-        if: ! startsWith(matrix.platform, 'macos')
-        run: |
-          echo 'INSTRUCTLAB_DISABLE_GPU_ACCELERATION=' >> "$GITHUB_ENV"
-
       - name: Install tools on MacOS
         if: startsWith(matrix.platform, 'macos')
         run: |
@@ -176,7 +164,17 @@ jobs:
           mkdir -p ~/.local/share
           echo "not a directory" > ~/.local/share/instructlab
 
-      - name: Run unit and functional tests with tox
+      # deactivate MPS acceleration on Github CI for MacOS
+      # see https://github.com/actions/runner-images/issues/9918
+      - name: Run unit and functional tests with tox (MacOS runners only)
+        if: startsWith(matrix.platform, 'macos')
+        run: |
+          tox
+        env:
+          INSTRUCTLAB_DISABLE_GPU_ACCELERATION: "true"
+
+      - name: Run unit and functional tests with tox (non-MacOS runners)
+        if: ${{ ! startsWith(matrix.platform, 'macos') }}
         run: |
           tox
 


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
