### PR TITLE
Revert "chore: bump the training library to 0.8.0 and refactor tokenizer usage"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ instructlab-schema>=0.4.2
 instructlab-sdg>=0.7.2
 # XXX(osilkin): we need to pin this version for now while we improve tokenizer logic
 # see: https://github.com/instructlab/training/pull/428
-instructlab-training>=0.8.0
+instructlab-training>=0.7.0,<0.7.1
 llama_cpp_python[server]==0.3.6
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 numpy>=1.26.4,<2.0.0

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,2 +1,2 @@
 # Extra dependencies for NVIDIA CUDA
-instructlab-training[cuda]>=0.8.0
+instructlab-training[cuda]>=0.7.0,<0.7.1

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -10,4 +10,4 @@ habana_gpu_migration>=1.18.0
 #habana-torch-dataloader
 
 # Extra dependencies for Intel Gaudi cards
-instructlab-training[hpu]>=0.8.0
+instructlab-training[hpu]>=0.7.0,<0.7.1

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -1,2 +1,2 @@
 # Extra dependencies for AMD ROCm
-instructlab-training[rocm]>=0.8.0
+instructlab-training[rocm]>=0.7.0,<0.7.1


### PR DESCRIPTION
Reverts instructlab/instructlab#3250 because it was merged after https://github.com/instructlab/instructlab/pull/3254, which was reverted because the unit tests stopped running after that PR. There might not be anything wrong with this PR, but we need to re-validate this PR by forcing it to undergo unit + functional testing.