### PR TITLE
ci: temporarily disable macos workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,9 +66,8 @@ jobs:
           - "3.11"
         platform:
           - "ubuntu-latest"
-        include:
-          - python: "3.11"
-            platform: "macos-latest"
+        # temporarily remove MacOS testing workflow until MPS related issues can be resolved
+        # see https://github.com/instructlab/instructlab/issues/3273 for details
     steps:
       - name: "Harden Runner"
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

temporarily disable macOS workflow until it can be sufficiently debugged without blocking high priority PRs

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
