### PR TITLE
chore: change to using dict instead of model_info class

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,9 +60,7 @@ nitpick_ignore = [
     ("py:class", "mx.array"),
     # TODO: Warning is thrown that:
     # py:class reference target not found: instructlab.training.config.DistributedBackend [ref.class]
-    # py:class reference target not found: instructlab.configuration.model_info [ref.class]
     ("py:class", "instructlab.training.config.DistributedBackend"),
-    ("py:class", "instructlab.configuration.model_info"),
     # stdlib
     ("py:class", "FrameType"),
     # pydantic auto-generated doc strings

--- a/src/instructlab/cli/data/generate.py
+++ b/src/instructlab/cli/data/generate.py
@@ -250,8 +250,10 @@ def generate(
                 raise ValueError(
                     f"Teacher model with ID '{teacher_model_id}' not found in the configuration."
                 )
-            model_path = teacher_model_config.path
-            model_family = model_family if model_family else teacher_model_config.family
+            model_path = teacher_model_config["path"]
+            model_family = (
+                model_family if model_family else teacher_model_config["family"]
+            )
         except ValueError as ve:
             click.secho(f"failed to locate teacher model by ID: {ve}", fg="red")
             raise click.exceptions.Exit(1)
@@ -313,7 +315,7 @@ def generate(
             click.secho(f"failed to locate student model by ID: {ve}", fg="red")
             raise click.exceptions.Exit(1)
 
-        system_prompt = student_model_config.system_prompt
+        system_prompt = student_model_config["system_prompt"]
         legacy_pretraining_format = (
             True  # just set this to true for testing. We need to fix this in SDG
         )

--- a/src/instructlab/cli/model/chat.py
+++ b/src/instructlab/cli/model/chat.py
@@ -190,8 +190,8 @@ def chat(
                 raise ValueError(
                     f"Model with ID '{model_id}' not found in the configuration."
                 )
-            model = model_config.path
-            model_family = model_config.family if model_config.family else model_family
+            model = model_config["path"]
+            model_family = model_family if model_family else model_config["family"]
         except ValueError as ve:
             click.secho(f"failed to locate model by ID: {ve}", fg="red")
             raise click.exceptions.Exit(1)

--- a/src/instructlab/cli/model/evaluate.py
+++ b/src/instructlab/cli/model/evaluate.py
@@ -257,8 +257,8 @@ def evaluate(
                 raise click.exceptions.BadParameter(
                     f"Base model with ID '{base_model_id}' not found in the configuration."
                 )
-            base_model = base_model_cfg.path
-            system_prompt = base_model_cfg.system_prompt
+            base_model = base_model_cfg["path"]
+            system_prompt = base_model_cfg["system_prompt"]
             logger.debug(
                 "detected `--base-model-id`, selecting custom model from config list."
             )
@@ -275,7 +275,7 @@ def evaluate(
                     f"Base model with ID '{judge_model_id}' not found in the configuration."
                 )
 
-            judge_model = judge_model_cfg.path
+            judge_model = judge_model_cfg["path"]
             logger.debug(
                 "detected `--judge-model-id`, selecting custom model from config list."
             )

--- a/src/instructlab/cli/model/serve.py
+++ b/src/instructlab/cli/model/serve.py
@@ -140,8 +140,8 @@ def serve(
                 raise ValueError(
                     f"Model with ID '{model_id}' not found in the configuration."
                 )
-            model_path = pathlib.Path(model_config.path)
-            model_family = model_family if model_family else model_config.family
+            model_path = pathlib.Path(model_config["path"])
+            model_family = model_family if model_family else model_config["family"]
         except ValueError as ve:
             click.secho(f"failed to locate model by ID: {ve}", fg="red")
             raise click.exceptions.Exit(1)

--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -605,7 +605,7 @@ def chat_model(
     logs_dir,
     vi_mode,
     visible_overflow,
-    models_config: List[cfg.model_info],
+    models_config: List[dict],
 ):
     """Runs a chat using the modified model"""
     if rag_enabled and not FeatureGating.feature_available(GatedFeatures.RAG):
@@ -627,7 +627,7 @@ def chat_model(
             logger.error(f"failed to load model from ID: {ve}")
             raise
 
-        model = model_cfg.path
+        model = model_cfg["path"]
 
         # if loading a specific model from the list, we should only be loading from the tokenizer config
         chat_template = CHAT_TEMPLATE_TOKENIZER

--- a/tests/test_lab_generate.py
+++ b/tests/test_lab_generate.py
@@ -7,7 +7,6 @@ from click.testing import CliRunner
 
 # First Party
 from instructlab import lab
-from instructlab.configuration import model_info
 
 # Local
 from . import common
@@ -37,12 +36,12 @@ def test_generate_with_teacher_model_id(
 ):
     fname = common.setup_test_models_config(
         models_list=[
-            model_info(
-                id="teacher_model",
-                path="teacher/model/path",
-                family="llama",
-                system_prompt="system prompt",
-            )
+            {
+                "id": "teacher_model",
+                "path": "teacher/model/path",
+                "family": "llama",
+                "system_prompt": "system prompt",
+            }
         ],
         dest=tmp_path,
     )
@@ -73,12 +72,12 @@ def test_generate_with_global_teacher_model_id(
 ):
     fname = common.setup_test_models_config(
         models_list=[
-            model_info(
-                id="teacher_model",
-                path="teacher/model/path",
-                family="llama",
-                system_prompt="system prompt",
-            )
+            {
+                "id": "teacher_model",
+                "path": "teacher/model/path",
+                "family": "llama",
+                "system_prompt": "system prompt",
+            }
         ],
         dest=tmp_path,
         global_teacher_id="teacher_model",

--- a/tests/test_model_chat.py
+++ b/tests/test_model_chat.py
@@ -12,7 +12,6 @@ import pytest
 
 # First Party
 from instructlab import lab
-from instructlab.configuration import model_info
 from instructlab.feature_gates import FeatureGating, FeatureScopes, GatedFeatures
 from instructlab.model.chat import ChatException, ConsoleChatBot
 from tests.test_feature_gates import dev_preview
@@ -142,12 +141,12 @@ def test_list_contexts_and_decoration():
 def test_chat_with_model_id(mock_chat_model, _, cli_runner: CliRunner, tmp_path: Path):
     fname = common.setup_test_models_config(
         models_list=[
-            model_info(
-                id="test_model",
-                path="teacher/model/path",
-                family="llama",
-                system_prompt="system prompt",
-            )
+            {
+                "id": "test_model",
+                "path": "teacher/model/path",
+                "family": "llama",
+                "system_prompt": "system prompt",
+            }
         ],
         dest=tmp_path,
     )


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

using a custom class `model_info` to represent 3rd party model info seems to not play well with ruamel yaml representation anytime the config object needs to be dumped either to file or stdout leading to a yaml representation error. 

```
ruamel.yaml.representer.RepresenterError: cannot represent an object: id='llama-3.3' family='meta-llama' path='/home/tmp/tmp.Gbn8Eel5PD/.cache/instructlab/models/meta-llama/Llama-3.3-70B-Instruct/' system_prompt=None
```
This seems to be happening because we load a list of model_info objects into memory rather than just the model_info object directly like for the other fields

It's easier to just work with a list of dicts instead 

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
