### PR TITLE
fix: Adding explanation of CLI behavior and expanding the error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,7 +813,7 @@ To limit training time, you can adjust the `num_epoch` paramater in the `config.
 - Train the model with your synthetic data with the `ilab model train` command:
 
    ```shell
-   ilab model train
+   ilab model train --data-path <path-to-sdg-dataset>
    ```
 
    ⏳ This step can potentially take **several hours** to complete depending on your computing resources. Please stop `ilab model chat` and `ilab model serve` first to free resources.

--- a/src/instructlab/cli/model/train.py
+++ b/src/instructlab/cli/model/train.py
@@ -454,7 +454,8 @@ def train(
     ) and not SupportedTrainingStrategies.has_strategy(strategy):
         if not os.path.isfile(data_path):
             ctx.fail(
-                f"Data path must be to a valid .jsonl file. Value given: {data_path}"
+                f"When using {pipeline} with {strategy}, it is necessary to specify path "
+                f"to a valid .jsonl file, rather than a directory. Value given: {data_path}"
             )
 
     # for simplicity, we only enable the `--model-id` path to training jobs

--- a/src/instructlab/configuration.py
+++ b/src/instructlab/configuration.py
@@ -567,7 +567,7 @@ class _train(BaseModel):
     )
     data_path: str = Field(
         default_factory=lambda: DEFAULTS.DATASETS_DIR,
-        description="For the training library (primary training method), this specifies the path to the dataset file. For legacy training (MacOS/Linux), this specifies the path to the directory.",
+        description="For the training library (pipelines 'full' or 'accelerated'), this must specify the path to the dataset '.jsonl' file. For legacy training (pipeline 'simple'), this specifies the path to the directory.",
     )
     ckpt_output_dir: str = Field(
         default_factory=lambda: DEFAULTS.CHECKPOINTS_DIR,


### PR DESCRIPTION
Existing documentation was amended to point to correct usage of `ilab model train` command. The help message of CLI argument `--data-path` was added to explain interaction with `--pipeline` argument. The error message was rewritten to explain the most likely cause of the problem.

Resolves #2257 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
