### PR TITLE
fix: Removing torchscript from autoconfig

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -50,8 +50,26 @@ pull_request_rules:
         - -files=.github/workflows/e2e-nvidia-l4-x1.yml
 
     # small e2e workflow
-    # temporarily remove requirement for small job passing
-    # until https://github.com/instructlab/instructlab/issues/3289 is fixed
+    - or:
+      - and:
+        # note this should match the triggering criteria in 'e2e-nvidia-t4-x1.yml'
+        - check-success~=e2e-small-workflow-complete
+        - or:
+          - files~=\.py$
+          - files=pyproject.toml
+          - files~=^requirements.*\.txt$
+          - files=scripts/e2e-ci.sh
+          - files~=^scripts/test-data/
+          - files~=^src/instructlab/profiles/
+          - files=.github/workflows/e2e-nvidia-t4-x1.yml
+      - and:
+        - -files~=\.py$
+        - -files=pyproject.toml
+        - -files~=^requirements.*\.txt$
+        - -files=scripts/e2e-ci.sh
+        - -files~=^scripts/test-data/
+        - -files~=^src/instructlab/profiles/
+        - -files=.github/workflows/e2e-nvidia-t4-x1.yml
 
     # test workflow
     - or:

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -40,9 +40,6 @@ permissions:
 
 jobs:
   e2e-small-workflow-ready:
-    # temporarily disable this job on pull requests until
-    # https://github.com/instructlab/instructlab/issues/3289 is resolved
-    if: false
     permissions:
       checks: read
     uses: ./.github/workflows/status-checks.yml
@@ -55,9 +52,6 @@ jobs:
         lint-workflow-complete
 
   start-small-ec2-runner:
-    # temporarily disable this job on pull requests until
-    # https://github.com/instructlab/instructlab/issues/3289 is resolved
-    if: false
     needs:
       - e2e-small-workflow-ready
     runs-on: ubuntu-latest
@@ -92,9 +86,6 @@ jobs:
             ]
 
   e2e-small-test:
-    # temporarily disable this job on pull requests until
-    # https://github.com/instructlab/instructlab/issues/3289 is resolved
-    if: false
     needs:
       - start-small-ec2-runner
     runs-on: ${{ needs.start-small-ec2-runner.outputs.label }}
@@ -161,9 +152,7 @@ jobs:
       - start-small-ec2-runner
       - e2e-small-test
     runs-on: ubuntu-latest
-    # temporarily disable this job on pull requests until
-    # https://github.com/instructlab/instructlab/issues/3289 is resolved
-    if: ${{ always() && false }}
+    if: ${{ always() }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0

--- a/src/instructlab/train/linux_train.py
+++ b/src/instructlab/train/linux_train.py
@@ -211,9 +211,7 @@ def linux_train(
 
     # Loading the model
     print("LINUX_TRAIN.PY: LOADING THE BASE MODEL")
-    config = AutoConfig.from_pretrained(
-        model_name, torchscript=True, trust_remote_code=True
-    )
+    config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
 
     # https://huggingface.co/docs/transformers/en/model_doc/auto#transformers.AutoModelForCausalLM.from_pretrained
     model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
Simple pipeline hasn't been working for some time now, due to #3289 . I've tracked the issue down in [transformers utils.py](https://github.com/huggingface/transformers/blob/main/src/transformers/generation/utils.py#L3434 ).

It appears that usage of torchscript, is changing type of output from invocations of `GenerationMixin` objects. I'm not sure about the exact reason why is this happening. But the behavior is normalized by simply removing `torchscript` parameter from config.

Since purpose of  [Torchscript](https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html) is to improve performance, I can guess that merging this fix may cause the pipeline to run a bit slower. But at least it will run. 

Proper fix should be implemented in transformers, but I don't have enough experience with the code base to know what to look for. 

I'm also reverting https://github.com/instructlab/instructlab/pull/3290 since things should be working now.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Functional tests have been added, if necessary.
- [x] E2E Workflow tests have been added, if necessary.
