### PR TITLE
fix: respect global teacher id for generation

### DIFF
--- a/src/instructlab/cli/data/generate.py
+++ b/src/instructlab/cli/data/generate.py
@@ -241,14 +241,18 @@ def generate(
     if batch_size > 0:
         checkpoint_dir = os.path.join(output_dir, "checkpoints")
 
-    if teacher_model_id:
+    teacher_id = (
+        teacher_model_id
+        if teacher_model_id
+        else ctx.obj.config.general.teacher_model_id
+    )
+
+    if teacher_id:
         try:
-            teacher_model_config = resolve_model_id(
-                teacher_model_id, ctx.obj.config.models
-            )
+            teacher_model_config = resolve_model_id(teacher_id, ctx.obj.config.models)
             if not teacher_model_config:
                 raise ValueError(
-                    f"Teacher model with ID '{teacher_model_id}' not found in the configuration."
+                    f"Teacher model with ID '{teacher_id}' not found in the configuration."
                 )
             model_path = teacher_model_config.path
             model_family = model_family if model_family else teacher_model_config.family


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

missed adding logic to pick up teacher model id from config in earlier PR. This PR fixes that 

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
