### PR TITLE
ci: add verbose logging to PyPI publishing

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -87,6 +87,7 @@ jobs:
               uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
               with:
                   repository-url: https://test.pypi.org/legacy/
+                  verbose: true
 
     # push to Production PyPI on
     # - a new GitHub release is published
@@ -136,3 +137,5 @@ jobs:
 
             - name: Upload to PyPI
               uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+              with:
+                verbose: true


### PR DESCRIPTION
we sometimes get failures with the pypi publish action

add verbose logging to make it easier to debug

see: https://github.com/pypa/gh-action-pypi-publish/tree/76f52bc884231f62b9a034ebfe128415bbaabdfc/?tab=readme-ov-file#for-debugging

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
