### PR TITLE
Enhance Hugging Face Repository Validation with URL Support

### DIFF
--- a/src/instructlab/utils.py
+++ b/src/instructlab/utils.py
@@ -635,11 +635,64 @@ def is_oci_repo(repo_url: str) -> bool:
     return True
 
 
+def extract_huggingface_repo_name(value: str) -> str:
+    """
+    Extracts the repository name from a Hugging Face URL or returns the original value.
+    
+    This allows users to input either a direct repository name (e.g., "user/model") 
+    or a full Hugging Face URL (e.g., "https://huggingface.co/user/model").
+    
+    Args:
+        value (str): The input string which could be a URL or a repository name
+        
+    Returns:
+        str: The extracted repository name or the original value if it's not a URL
+    """
+    if not value or not isinstance(value, str):
+        return value
+        
+    # Check if the value appears to be a Hugging Face URL
+    hf_url_pattern = r"https?://(?:www\.)?huggingface\.co/(.+)"
+    match = re.match(hf_url_pattern, value)
+    
+    if match:
+        return match.group(1)
+    
+    return value
+
+
 def is_huggingface_repo(repo_name: str) -> bool:
-    # allow alphanumerics, underscores, hyphens and periods in huggingface repo names
-    # repo name should be of the format <owner>/<model>
+    """
+    Validates if a repository name follows the Hugging Face format.
+    
+    The Hugging Face repository name should follow the pattern <owner>/<model> where both owner
+    and model can contain alphanumeric characters, underscores, hyphens, and periods.
+    
+    This function will attempt to extract a repository name from a URL if provided.
+    
+    Args:
+        repo_name (str): The repository name to validate
+        
+    Returns:
+        bool: True if the name is a valid Hugging Face repository name, False otherwise
+    """
+    if not repo_name or not isinstance(repo_name, str):
+        logger.debug(f"Invalid Hugging Face repository name: {repo_name} - Expected a non-empty string")
+        return False
+    
+    # If a URL was provided, extract the repository name
+    repo_name = extract_huggingface_repo_name(repo_name)
+        
+    # Allow alphanumerics, underscores, hyphens and periods in Hugging Face repo names
+    # Repo name should be of the format <owner>/<model>
+    # Neither owner nor model part should be empty
     pattern = r"^[\w.-]+\/[\w.-]+$"
-    return re.match(pattern, repo_name) is not None
+    is_valid = re.match(pattern, repo_name) is not None
+    
+    if not is_valid:
+        logger.debug(f"Invalid Hugging Face repository name format: {repo_name}")
+        
+    return is_valid
 
 
 def load_json(file_path: Path):

--- a/tests/test_huggingface_repo.py
+++ b/tests/test_huggingface_repo.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+import pytest
+
+# First Party
+from instructlab.utils import is_huggingface_repo, extract_huggingface_repo_name
+
+
+@pytest.mark.parametrize(
+    "repo_name,expected",
+    [
+        # Valid cases
+        ("user/model", True),
+        ("org/model-name", True),
+        ("user123/model_v1", True),
+        ("user-name/model.v1", True),
+        ("user_name/model-v1.2", True),
+        ("user.name/model_v1-2", True),
+        # URL cases - these should now be handled correctly
+        ("https://huggingface.co/user/model", True),
+        ("http://huggingface.co/org/model-name", True),
+        ("https://www.huggingface.co/user123/model_v1", True),
+        
+        # Invalid cases
+        (None, False),
+        ("", False),
+        ("model", False),  # Missing owner part
+        ("/model", False),  # Empty owner part
+        ("user/", False),  # Empty model part
+        ("user//model", False),  # Double slash
+        ("user model", False),  # Contains space
+        ("user@name/model", False),  # Invalid character in owner
+        ("user/model@v1", False),  # Invalid character in model
+        (123, False),  # Non-string input
+        ("https://example.com/user/model", False),  # Not a huggingface URL
+        ("huggingface.co/user/model", False),  # Missing http/https protocol
+    ],
+)
+def test_is_huggingface_repo(repo_name, expected):
+    """Test is_huggingface_repo function with various valid and invalid inputs."""
+    assert is_huggingface_repo(repo_name) == expected
+
+
+@pytest.mark.parametrize(
+    "input_value,expected",
+    [
+        # URL inputs
+        ("https://huggingface.co/user/model", "user/model"),
+        ("http://huggingface.co/org/model-name", "org/model-name"),
+        ("https://www.huggingface.co/user123/model_v1", "user123/model_v1"),
+        ("https://huggingface.co/org/model/tree/main", "org/model/tree/main"),
+        
+        # Non-URL inputs (should return original)
+        ("user/model", "user/model"),
+        ("", ""),
+        (None, None),
+        (123, 123),
+        
+        # Non-huggingface URLs (should return original)
+        ("https://example.com/user/model", "https://example.com/user/model"),
+        ("huggingface.co/user/model", "huggingface.co/user/model"),  # Missing protocol
+    ],
+)
+def test_extract_huggingface_repo_name(input_value, expected):
+    """Test extract_huggingface_repo_name function for both URL and non-URL inputs."""
+    assert extract_huggingface_repo_name(input_value) == expected
+
+
+def test_is_huggingface_repo_integration():
+    """Integration test with a real-world example from the download module."""
+    # Common real-world examples
+    assert is_huggingface_repo("instructlab/granite-7b-lab-GGUF")
+    assert is_huggingface_repo("TheBloke/Mistral-7B-Instruct-v0.2-GGUF")
+    assert is_huggingface_repo("prometheus-eval/prometheus-8x7b-v2.0")
+    
+    # With full URLs
+    assert is_huggingface_repo("https://huggingface.co/instructlab/granite-7b-lab-GGUF")
+    assert is_huggingface_repo("https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF")
+    assert is_huggingface_repo("https://huggingface.co/prometheus-eval/prometheus-8x7b-v2.0") 


### PR DESCRIPTION
This pull request improves the Hugging Face repository validation functionality with the following enhancements:
Added support for full Hugging Face URLs (e.g., https://huggingface.co/user/model) in addition to direct repository names
Created a new extract_huggingface_repo_name function to extract repository names from URLs
Improved input validation with better checks for empty strings and non-string inputs
Enhanced error handling with clear debug logging of validation failures
Added comprehensive test cases covering various scenarios (direct names, URLs, edge cases)
Improved documentation with detailed docstrings and examples
Maintained complete backward compatibility with existing code
These changes make the repository validation more user-friendly by allowing flexibility in how users specify Hugging Face repositories, while also making the code more robust and easier to maintain.