### PR TITLE
e2e: collect more debug info about training process

### DIFF
--- a/scripts/e2e-ci.sh
+++ b/scripts/e2e-ci.sh
@@ -66,6 +66,8 @@ check_flags() {
 ########################################
 
 init_e2e_tests() {
+    . ./scripts/e2e-common-settings.sh
+
     E2E_TEST_DIR=$(mktemp -d)
     export HOME="${E2E_TEST_DIR}"  # update the HOME directory used to resolve paths
 

--- a/scripts/e2e-common-settings.sh
+++ b/scripts/e2e-common-settings.sh
@@ -8,6 +8,9 @@ export TORCH_DISTRIBUTED_DEBUG=INFO
 export NCCL_DEBUG=INFO
 export NCCL_DEBUG_SUBSYS=INIT,BOOTSTRAP,ENV
 
+# We don't run on nvlink-enabled ec2 runners
+export NCCL_IGNORE_DISABLED_P2P=1
+
 # Dump debug info, including full stack traces, on watchdog timeout and collective unsync
 export TORCH_NCCL_DUMP_ON_TIMEOUT=1
 export TORCH_SHOW_CPP_STACKTRACES=1

--- a/scripts/e2e-common-settings.sh
+++ b/scripts/e2e-common-settings.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Enable general torch debugging
+export TORCH_CPP_LOG_LEVEL=INFO
+export TORCH_DISTRIBUTED_DEBUG=INFO
+
+# NCCL backend
+export NCCL_DEBUG=INFO
+export NCCL_DEBUG_SUBSYS=INIT,BOOTSTRAP,ENV
+
+# Dump debug info, including full stack traces, on watchdog timeout and collective unsync
+export TORCH_NCCL_DUMP_ON_TIMEOUT=1
+export TORCH_SHOW_CPP_STACKTRACES=1

--- a/scripts/e2e-custom.sh
+++ b/scripts/e2e-custom.sh
@@ -64,6 +64,8 @@ export CONFIG_HOME
 #   None
 ########################################
 function init_e2e_tests() {
+    . ./scripts/e2e-common-settings.sh
+
     E2E_TEST_DIR=$(mktemp -d)
     HOME="${E2E_TEST_DIR}"  # update the HOME directory used to resolve paths
 


### PR DESCRIPTION
We experience watchdog timeouts for nccl in training library. We'd like
to collect more information during CI runs so that we have a chance to
understand how training fails, and not just the fact that it failed.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
