### PR TITLE
fix: Correct ROCM Build Context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ HPU_DEPS = \
 	$(NULL)
 
 ROCM_CONTAINERFILE = $(CURDIR)/containers/rocm/Containerfile
-ROCM_CONTEXT_DIR = $(CURDIR)/containers/rocm
+ROCM_CONTEXT_DIR = $(CURDIR)
 ROCM_DEPS = \
 	$(ROCM_CONTAINERFILE) \
 	$(COMMON_DEPS) \
@@ -91,6 +91,7 @@ define build-rocm =
 		--build-arg INSTRUCTLAB_VERSION=$(INSTRUCTLAB_VERSION) \
 		-t $(CONTAINER_PREFIX):rocm-$(1) \
 		-t $(CONTAINER_PREFIX):rocm \
+		-f $(ROCM_CONTAINERFILE) \
 		$(ROCM_CONTEXT_DIR)
 endef
 


### PR DESCRIPTION
The Containerfile for building the ROCM toolbox assumes the full instructlab source code is present in the build context. This change provides the correct context to the container build and provides the path to the ROCM containerfile as input.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
