### PR TITLE
cap upper versions for instructlab 0.26 release series

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,11 @@ filelock
 gguf>=0.6.0
 GitPython>=3.1.42
 httpx>=0.25.0
-instructlab-eval>=0.5.1
+instructlab-eval>=0.5.1,<0.6.0
 instructlab-quantize>=0.1.0
 instructlab-schema>=0.4.2
-instructlab-sdg>=0.7.3
-instructlab-training>=0.10.1
+instructlab-sdg>=0.8.2,<0.9.0
+instructlab-training>=0.10.1,<0.11.0
 llama_cpp_python[server]==0.3.6
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 numpy>=1.26.4,<2.0.0


### PR DESCRIPTION
Bump the minimum version of SDG to [0.8.2](https://github.com/instructlab/sdg/releases/tag/v0.8.2) for the features and fixes in that library.

Constrain the upper version bounds for the three main instructlab libraries for our core 0.26 release series.
