### PR TITLE
chore: don't yamllint .tox directory

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -10,6 +10,8 @@ rules:
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: false
     ignore:
+      # Don't fail on any violating yaml files in toxdir
+      - .tox/**
       # Skip workflow files where we have use for long lines (for commands posting long-ish comments using `gh`).
       - .github/workflows/*.yml
       # tests/test_lab_diff.py expects to fail on this file.


### PR DESCRIPTION
Without this patch, tox -e yamllint complains about problematic yaml
files under .tox directory, which is not part of the code under test.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
