### PR TITLE
fix: allow unlimited runtime print

### DIFF
--- a/src/instructlab/process/process.py
+++ b/src/instructlab/process/process.py
@@ -479,7 +479,10 @@ def display_processes(uuid_list: List[str]):
         if local_uuid in uuid_list:
             hours, remainder = divmod(process.runtime.total_seconds(), 3600)
             minutes, seconds = divmod(remainder, 60)
+            days, hours = divmod(hours, 24)
             runtime_str = f"{hours:02}:{minutes:02}:{seconds:02}"
+            if days > 0:
+                runtime_str = f"{days}d {runtime_str}"
             display_list.append(
                 (
                     process.ptype,


### PR DESCRIPTION
Until now the process runtime print was limited to 100 hours. With this change, it can be unlimited, as once it's over 24, it will added days to the print.

Fixes #3086

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
