### PR TITLE
ci: Enable python 3.12 unit tests; cap <3.13 while submodlib-py enables support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
       matrix:
         python:
           - "3.11"
+          - "3.12"
         platform:
           - "ubuntu-latest"
         # temporarily remove MacOS testing workflow until MPS related issues can be resolved

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "InstructLab", email = "dev@instructlab.ai" }]
 description = "Core package for interacting with InstructLab"
 readme = "README.md"
 license = { text = "Apache-2.0 AND MIT" }
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.13"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",


### PR DESCRIPTION
- **ci: Enable python 3.12 unit testing**
- **ci: Restore python cap to <3.13**

Resolves: #3365

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
