### PR TITLE
fix(deps): Constrain `click<=8.1.8` temporarily

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,10 +138,12 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python }}
-          cache: pip
-          cache-dependency-path: |
-            **/pyproject.toml
-            **/requirements*.txt
+          ## Temporarily comment out these lines because of: https://stackoverflow.com/questions/65122957/resolving-new-pip-backtracking-runtime-issue
+          ## Undo the below commented config once this issue is resolved: https://github.com/instructlab/instructlab/issues/3368
+          # cache: pip
+          # cache-dependency-path: |
+          #   **/pyproject.toml
+          #   **/requirements*.txt
 
       - name: Remove llama-cpp-python from cache
         run: |
@@ -157,6 +159,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          ## Remove the below line once this issue is resolved: https://github.com/instructlab/instructlab/issues/3368
+          python -m pip install -r requirements-dev.txt -c constraints-dev.txt --use-deprecated=legacy-resolver
           python -m pip install tox tox-gh>=1.2
 
       # see https://github.com/instructlab/instructlab/issues/1886

--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -1,4 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# TODO: Remove constraint once this issue is resolved: https://github.com/instructlab/instructlab/issues/3368
+click<=8.1.8
+# Testing
+torchvision<=0.21.0
 torch<2.7.0
 vllm<0.9.0

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,8 @@ extras = cpu
 deps =
     -r requirements-dev.txt
     -c constraints-dev.txt
+# Use 'legacy-resolver' because of: https://stackoverflow.com/questions/65122957/resolving-new-pip-backtracking-runtime-issue
+install_command = python -I -m pip install --use-deprecated=legacy-resolver {opts} {packages}
 commands =
     ilab --version
     {envpython} -m instructlab --version


### PR DESCRIPTION

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.

Temporarily constrain `click<=8.1.8` to avoid consuming the latest breaking changes in our CI introduced in `click-8.2.0`. We will simultaneously work on allowing InstructLab to consume these latest changes.