### PR TITLE
chore: Enable verbose output for tox

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,22 +53,22 @@ jobs:
         lint:
           - name: "ruff"
             commands: |
-              tox -e ruff
+              tox -vvv -e ruff
           - name: "pylint"
             commands: |
               echo "::add-matcher::.github/workflows/matchers/pylint.json"
-              tox -e fastlint
-              tox -e lint
+              tox -vvv -e fastlint
+              tox -vvv -e lint
           - name: "mypy"
             commands: |
               echo "::add-matcher::.github/workflows/matchers/mypy.json"
-              tox -e mypy
+              tox -vvv -e mypy
           - name: "tomllint"
             commands: |
-              tox -e tomllint
+              tox -vvv -e tomllint
           - name: "yamllint"
             commands: |
-              tox -e yamllint
+              tox -vvv -e yamllint
     steps:
       - name: "Harden Runner"
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ on:
 
 env:
   LC_ALL: en_US.UTF-8
+  TOX_VERBOSE: "-vvv"
 
 defaults:
   run:
@@ -173,7 +174,7 @@ jobs:
 
       - name: Run unit and functional tests with tox
         run: |
-          tox
+          tox ${{ env.TOX_VERBOSE }}
 
       - name: Remove llama-cpp-python from cache
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ CENGINE ?= podman
 CONTAINER_PREFIX ?= localhost/instructlab
 TOOLBOX ?= instructlab
 
+TOX_VERBOSE ?= -vvv
+
 NULL =
 COMMON_DEPS = \
 	$(CURDIR)/requirements.txt \
@@ -147,23 +149,23 @@ toolbox-rm: check-toolbox ## Stop and remove toolbox container
 
 .PHONY: tests
 tests: check-tox ## Run unit and type checks
-	tox -e py3-unit,mypy
+	tox ${TOX_VERBOSE} -e py3-unit,mypy
 
 .PHONY: regenerate-testdata
 regenerate-testdata: check-tox ## Run unit tests and regenerate test data
-	tox -e py3-unit -- --regenerate-testdata
+	tox ${TOX_VERBOSE} -e py3-unit -- --regenerate-testdata
 
 .PHONY: verify
 verify: check-tox ## Run linting and formatting checks via tox
-	tox p -m fastverify
+	tox ${TOX_VERBOSE} p -m fastverify
 
 .PHONY: fix
 fix: check-tox ## Fix formatting and linting violation with Ruff
-	tox -e fix
+	tox ${TOX_VERBOSE} -e fix
 
 .PHONY: docs
 docs: check-tox  ## Generate Sphinx docs and man pages
-	tox -e docs
+	tox ${TOX_VERBOSE} -e docs
 	@echo
 	@echo "Sphinx: docs/build/html/index.html"
 	@echo "man pages: man/"


### PR DESCRIPTION
If tox hangs for some reason while installing a package, it would help
to know which package it is hanging at. I hope enabling verbosity will
give us some clue.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
