### PR TITLE
ci: Use non-default token for constraints updates

### DIFF
--- a/.github/workflows/constraints-update.yml
+++ b/.github/workflows/constraints-update.yml
@@ -44,3 +44,4 @@ jobs:
           body: |
             This PR updates the constraints-dev.txt file using `tox -e constraints`.
           branch: update-constraints
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
If default token is used, workflows are not triggered to avoid DDoS.

See: https://github.com/orgs/community/discussions/52469

This results in posted PRs not getting CI treatment.

Hopefully, with a personal token, we'll see some jobs running.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
