### PR TITLE
ci: don't trigger pull_request_target jobs on their own workflows

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -39,7 +39,6 @@ pull_request_rules:
           - files=scripts/e2e-ci.sh
           - files~=^scripts/test-data/
           - files~=^src/instructlab/profiles/
-          - files=.github/workflows/e2e-nvidia-l4-x1.yml
       - and:
         - -files~=\.py$
         - -files=pyproject.toml
@@ -47,7 +46,6 @@ pull_request_rules:
         - -files=scripts/e2e-ci.sh
         - -files~=^scripts/test-data/
         - -files~=^src/instructlab/profiles/
-        - -files=.github/workflows/e2e-nvidia-l4-x1.yml
 
     # small e2e workflow
     - or:
@@ -61,7 +59,6 @@ pull_request_rules:
           - files=scripts/e2e-ci.sh
           - files~=^scripts/test-data/
           - files~=^src/instructlab/profiles/
-          - files=.github/workflows/e2e-nvidia-t4-x1.yml
       - and:
         - -files~=\.py$
         - -files=pyproject.toml
@@ -69,7 +66,6 @@ pull_request_rules:
         - -files=scripts/e2e-ci.sh
         - -files~=^scripts/test-data/
         - -files~=^src/instructlab/profiles/
-        - -files=.github/workflows/e2e-nvidia-t4-x1.yml
 
     # test workflow
     - or:

--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -21,7 +21,6 @@ on:
       - 'scripts/e2e-ci.sh' # Used by this workflow
       - 'scripts/test-data/**'
       - 'src/instructlab/profiles/**'
-      - '.github/workflows/e2e-nvidia-l4-x1.yml' # This workflow
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/e2e-nvidia-t4-x1.yml
+++ b/.github/workflows/e2e-nvidia-t4-x1.yml
@@ -21,7 +21,6 @@ on:
       - 'scripts/e2e-ci.sh' # Used by this workflow
       - 'scripts/test-data/**'
       - 'src/instructlab/profiles/**'
-      - '.github/workflows/e2e-nvidia-t4-x1.yml' # This workflow
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
pull_request_target means that the workflow will be pulled from main, not from the PR under review; so it's a waste to run the workflows in this case.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
