### PR TITLE
Fix issue 3375/spurious gobot references

### DIFF
--- a/.github/workflows/image-cuda.yml
+++ b/.github/workflows/image-cuda.yml
@@ -69,8 +69,8 @@ jobs:
           build-args: |
             GIT_TAG=main
           push: false
-          tags: ${{ steps.gobot_meta.outputs.tags }}
-          labels: ${{ steps.gobot_meta.outputs.labels }}
+          tags: ${{ steps.cuda_meta.outputs.tags }}
+          labels: ${{ steps.cuda_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: containers/cuda/Containerfile


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

**Issue resolved by this Pull Request:**
Resolves #3375

<!-- No dependent PRs needed, so removing Depends-On section -->
<!-- No Dev Docs related to this change, so removing that section -->

## Description
Updates incorrect "gotbot/gobot" references in the CUDA image workflow to properly reflect its purpose of building CUDA images. This is a documentation improvement that fixes copy-pasted terminology without changing functionality.

Changes:
- Renamed metadata step to reference CUDA image
- Updated step ID from `gobot_meta` to `cuda_meta`
- Fixed corresponding metadata references in workflow

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.