### PR TITLE
docs: Updated CI documentation to include new pipelines, changes.

### DIFF
--- a/docs/maintainers/ci.md
+++ b/docs/maintainers/ci.md
@@ -6,7 +6,7 @@ The InstructLab continuous integration (CI) ecosystem:
 
 ## Unit tests
 
-Unit tests test specific components or features of InstructLab in isolation. InstructLab CI runs these tests on CPU-only Ubuntu runners using Python 3.11.
+Unit tests validate specific components or features of InstructLab in isolation. InstructLab CI runs these tests on CPU-only Ubuntu runners using Python 3.11.
 
 In general, all code changes should add a new unit test or modify an existing unit test.
 
@@ -14,7 +14,7 @@ Unit tests are stored in the `tests/` directory and are run with [pytest](https:
 
 ## Functional tests
 
-Functional tests test components or features of InstructLab in tandem, but not necessarily as part of a complex workflow. InstructLab CI runs these tests on CPU-only Ubuntu runners using Python 3.11.
+Functional tests validate components or features of InstructLab in tandem, but not necessarily as part of a complex workflow. InstructLab CI runs these tests on CPU-only Ubuntu runners using Python 3.11.
 
 New code may or may not need a functional test. However, contributors should strive to create functional tests where possible.
 
@@ -30,7 +30,7 @@ There are two E2E test scripts:
 
 The ["small" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-t4-x1.yml) and ["medium" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l4-x1.yml) run automatically on all pull requests and commits merged into the `main` branch and release branches. These jobs depend on the successful completion of any linting jobs.
 
-The ["large" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x4.yml) and ["X-large" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x8.yml) can be [triggered manually on the actions page](#triggering-an-e2e-job-via-github-web-ui). The "large" t-shirt size E2E job also runs automatically against the `main` branch at 11AM UTC every day.
+The ["large" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x4.yml) and ["X-large" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x8.yml) can be [triggered manually on the actions page](#triggering-an-e2e-job-via-the-github-web-user-interface). The "large" t-shirt size E2E job also runs automatically against the `main` branch at 11AM UTC every day.
 
 ### E2E Test Coverage Options
 
@@ -74,6 +74,7 @@ When running `e2e-custom.sh`, specify the following flags to test the correspond
 | [`e2e-nvidia-l40s-x4.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x4.yml) | Large | AWS |[`g6e.12xlarge`](https://aws.amazon.com/ec2/instance-types/g6e/) | CentOS Stream 9 | 4 x NVIDIA L40S w/ 48 GB VRAM (192 GB) | `e2e-ci.sh` | `l` | Manually by Maintainers, Automatically against `main` branch at 11AM UTC | Yes |
 | [`e2e-nvidia-l40s-x4-llama.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/`e2e-nvidia-l40s-x4-llama.yml`) | Large | AWS | [`g6e.12xlarge`](https://aws.amazon.com/ec2/instance-types/g6e/) | CentOS Stream 9 | 4 x NVIDIA L40S w/ 48 GB VRAM (192 GB) | `e2e-ci.sh` | `a` | Manually by Maintainers, Automatically against `main` branch at 11AM UTC | Yes |
 | [`e2e-nvidia-l40s-x4-py312.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/`e2e-nvidia-l40s-x4-py312.yml`) | Large | AWS | [`g6e.12xlarge`](https://aws.amazon.com/ec2/instance-types/g6e/) | CentOS Stream 9 | 4 x NVIDIA L40S w/ 48 GB VRAM (192 GB) | `e2e-ci.sh` | `a` | Manually by Maintainers, Automatically against `main` branch at 11AM UTC | Yes |
+| [`e2e-nvidia-l40s-x4-release.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/`e2e-nvidia-l40s-x4-release.yml`) | Large | AWS | [`g6e.12xlarge`](https://aws.amazon.com/ec2/instance-types/g6e/) | CentOS Stream 9 | 4 x NVIDIA L40S w/ 48 GB VRAM (192 GB) | `e2e-ci.sh` | `a` | Manually by Maintainers, Automatically against `main` branch at 11AM UTC | Yes |
 | [`e2e-nvidia-l40s-x8.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x8.yml) | X-Large | AWS |[`g6e.48xlarge`](https://aws.amazon.com/ec2/instance-types/g6e/) | CentOS Stream 9 | 8 x NVIDIA L40S w/ 192 GB VRAM (384 GB) | `e2e-ci.sh` | `x` | Manually by Maintainers, Automatically against `main` branch at 11AM UTC | Yes |
 
 ### E2E Test Coverage Matrix
@@ -93,15 +94,15 @@ Points of clarification (*):
 
 1. The `simple` training pipeline uses 4-bit-quantization. We cannot use the trained model here due to [#579](https://github.com/instructlab/instructlab/issues/579)
 2. `MMLU Branch` is not run as the `full` SDG pipeline does not create the needed files in the tasks directory when only training against a skill.
-3. Also applies to [`e2e-nvidia-l40s-x4-llama.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/`e2e-nvidia-l40s-x4-py312.yml`) and [`e2e-nvidia-l40s-x4-py312.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/`e2e-nvidia-l40s-x4-py312.yml`).
+3. Also applies to [`e2e-nvidia-l40s-x4-llama.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/`e2e-nvidia-l40s-x4-llama.yml`), [`e2e-nvidia-l40s-x4-py312.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/`e2e-nvidia-l40s-x4-py312.yml`), and [`e2e-nvidia-l40s-x4-release.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/`e2e-nvidia-l40s-x4-release.yml`).
 
 ### Discord reporting
 
-Upon completion, the `Son of Jeeves` bot sends the results of some E2E jobs to the channel `#e2e-ci-results` in Discord and Slack. See which jobs currently have reporting via the "Current E2E Jobs" table above.
+Upon completion, the `Son of Jeeves` bot sends the results of some E2E jobs to the channel `#e2e-ci-results` in Discord. See which jobs currently have reporting via the "Current E2E Jobs" table above.
 
 In Discord, we use [actions/actions-status-discord](https://github.com/sarisia/actions-status-discord) and the built-in channel webhooks feature.
 
-### Triggering an E2E job via GitHub Web user interface
+### Triggering an E2E job via the GitHub web user interface
 
 For the E2E jobs that can be launched manually, they take an input field that
 specifies the PR number or git branch to run them against. If you run them

--- a/docs/maintainers/ci.md
+++ b/docs/maintainers/ci.md
@@ -1,62 +1,56 @@
 # CI for InstructLab
 
+The InstructLab continuous integration (CI) ecosystem:
+
 ![InstructLab CI Ecosystem](images/instructlab-ci-ecosystem.png)
 
 ## Unit tests
 
-Unit tests are designed to test specific InstructLab components or features in isolation. In CI, these tests are run on Python 3.11 on CPU-only Ubuntu
-and MacOS runners. Generally, new code should be adding or modifying unit tests.
+Unit tests test specific components or features of InstructLab in isolation. InstructLab CI runs these tests on CPU-only Ubuntu runners using Python 3.11.
 
-All unit tests currently live in the `tests/` directory and are run with [pytest](https://docs.pytest.org/) via [tox](https://tox.wiki/).
+In general, all code changes should add a new unit test or modify an existing unit test.
+
+Unit tests are stored in the `tests/` directory and are run with [pytest](https://docs.pytest.org/) via [tox](https://tox.wiki/).
 
 ## Functional tests
 
-Functional tests are designed to test InstructLab components or features in tandem, but not necessarily as part of a complex workflow. In CI, these tests are run on
-Python 3.11 on CPU-only Ubuntu and MacOS runners. New code may or may not need a functional test but should strive to implement one if possible.
+Functional tests test components or features of InstructLab in tandem, but not necessarily as part of a complex workflow. InstructLab CI runs these tests on CPU-only Ubuntu runners using Python 3.11.
+
+New code may or may not need a functional test. However, contributors should strive to create functional tests where possible.
 
 The functional test script is Shell-based and can be found at `scripts/functional-tests.sh`.
 
 ## End-to-end (E2E) tests
 
-There are two E2E test scripts.
+There are two E2E test scripts:
 
-The first can be found at `scripts/e2e-ci.sh`. This script is designed to test the InstructLab workflow from end-to-end, mimicking real user behavior,
-across three different "t-shirt sizes" of systems. Most E2E CI jobs use this script.
+`scripts/e2e-ci.sh` - This script tests the InstructLab workflow from end to end, mimicking real user behavior across four "t-shirt sizes" of systems. Most E2E CI jobs use this script.
 
-The second can be found at `scripts/e2e-custom.sh`. This script takes arguments that control which features are used to allow
-varying test coverage based on the resources available on a given test runner. The
-["custom" E2E CI job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-aws-custom.yml) uses this script,
-though you can specify to use another script such as `e2e-ci.sh` if you want to test changes to a different code path that doesn't automatically run
-against a pull request.
+`scripts/e2e-custom.sh` - This script takes arguments that control which features are used to allow varying test coverage based on the resources available on a given test runner. The ["custom" E2E CI job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-aws-custom.yml) uses this script. However, you can specify another script such as `e2e-ci.sh` to test changes to a different code path that does not automatically run against a pull request.
 
-There is currently a ["small" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-t4-x1.yml) and a
-["medium" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l4-x1.yml).
-These jobs runs automatically on all PRs and after commits merge to `main` or release branches. They depend upon the successful completion of any linting type jobs.
+The ["small" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-t4-x1.yml) and ["medium" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l4-x1.yml) run automatically on all pull requests and commits merged into the `main` branch and release branches. These jobs depend on the successful completion of any linting jobs.
 
-There is also a ["large" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x4.yml) that can be
-[triggered manually on the actions page](#triggering-an-e2e-job-via-github-web-ui) for the repository.
-It also runs automatically against the `main` branch at 11AM UTC every day.
+The ["large" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x4.yml) and ["X-large" t-shirt size E2E job](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x8.yml) can be [triggered manually on the actions page](#triggering-an-e2e-job-via-github-web-ui). The "large" t-shirt size E2E job also runs automatically against the `main` branch at 11AM UTC every day.
 
 ### E2E Test Coverage Options
 
-You can specify the following flags to test the small, medium, and large t-shirt sizes with the `e2e-ci.sh`
-script.
+When running `e2e-ci.sh`, specify one of the following flags to run the corresponding test and optionally preserve the E2E_TEST_DIR:
 
 | Flag | Feature |
 | ---- | --- |
 | `s`  | Run the e2e workflow for the small t-shirt size of hardware |
 | `m`  | Run the e2e workflow for the medium t-shirt size of hardware |
 | `l`  | Run the e2e workflow for the large t-shirt size of hardware |
-| `x`  | Run the e2e workflow for the x-large t-shirt size of hardware |
+| `a`  | Run the e2e workflow for the large t-shirt size of hardware on a llama pipeline |
+| `x`  | Run the e2e workflow for the X-large t-shirt size of hardware |
 | `p`  | Preserve the E2E_TEST_DIR for debugging |
 
 > [!NOTE]
-> The DK-Bench evaluation requires OPENAI_API_KEY to be set before running in `e2e-ci.sh`.
-> This environment variable is set in the CI. Local users of `e2e-ci.sh` will find that the script will exit with a warning if that environment variable is not set.
-> If a user of the script does not have an OPENAI_API_KEY and wishes to run `e2e-ci.sh` without running DK-Bench they can set OPENAI_API_KEY='NO_API_KEY'.
+> To perform DK-Bench evaluation, you must set the OPENAI_API_KEY environment variable before running the script.
+> This environment variable is set in the CI. However, the script will exit with a warning if the environment variable is not set when running locally.
+> If you do not have an OPENAI_API_KEY, set OPENAI_API_KEY='NO_API_KEY' to run the script without running DK-Bench.
 
-You can specify the following flags to test various features of `ilab` with the
-`e2e-custom.sh` script.
+When running `e2e-custom.sh`, specify the following flags to test the corresponding features of `ilab`:
 
 | Flag | Feature |
 | --- | --- |
@@ -75,14 +69,16 @@ You can specify the following flags to test various features of `ilab` with the
 
 | Name | T-Shirt Size | Runner Host | Instance Type | OS | GPU Type | Script | Flags | Runs when? | Discord reporting? |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| [`e2e-nvidia-t4-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-t4-x1.yml) | Small | AWS | [`g4dn.2xlarge`](https://aws.amazon.com/ec2/instance-types/g4/) | CentOS Stream 9 | 1 x NVIDIA Tesla T4 w/ 16 GB VRAM | `e2e-ci.sh` | `s` | Pull Requests, Push to `main` or `release-*` branch | No |
-| [`e2e-nvidia-l4-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l4-x1.yml) | Medium | AWS |[`g6.8xlarge`](https://aws.amazon.com/ec2/instance-types/g5/) | CentOS Stream 9 | 1 x NVIDIA L4 w/ 24 GB VRAM | `e2e-ci.sh` | `m` | Pull Requests, Push to `main` or `release-*` branch | No |
+| [`e2e-nvidia-t4-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-t4-x1.yml) | Small | AWS | [`g4dn.2xlarge`](https://aws.amazon.com/ec2/instance-types/g4/) | CentOS Stream 9 | 1 x NVIDIA Tesla T4 w/ 16 GB VRAM | `e2e-ci.sh` | `s` | Pull requests, Push to `main` or `release-*` branch | No |
+| [`e2e-nvidia-l4-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l4-x1.yml) | Medium | AWS |[`g6.8xlarge`](https://aws.amazon.com/ec2/instance-types/g5/) | CentOS Stream 9 | 1 x NVIDIA L4 w/ 24 GB VRAM | `e2e-ci.sh` | `m` | Pull requests, Push to `main` or `release-*` branch | No |
 | [`e2e-nvidia-l40s-x4.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x4.yml) | Large | AWS |[`g6e.12xlarge`](https://aws.amazon.com/ec2/instance-types/g6e/) | CentOS Stream 9 | 4 x NVIDIA L40S w/ 48 GB VRAM (192 GB) | `e2e-ci.sh` | `l` | Manually by Maintainers, Automatically against `main` branch at 11AM UTC | Yes |
+| [`e2e-nvidia-l40s-x4-llama.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/`e2e-nvidia-l40s-x4-llama.yml`) | Large | AWS | [`g6e.12xlarge`](https://aws.amazon.com/ec2/instance-types/g6e/) | CentOS Stream 9 | 4 x NVIDIA L40S w/ 48 GB VRAM (192 GB) | `e2e-ci.sh` | `a` | Manually by Maintainers, Automatically against `main` branch at 11AM UTC | Yes |
+| [`e2e-nvidia-l40s-x4-py312.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/`e2e-nvidia-l40s-x4-py312.yml`) | Large | AWS | [`g6e.12xlarge`](https://aws.amazon.com/ec2/instance-types/g6e/) | CentOS Stream 9 | 4 x NVIDIA L40S w/ 48 GB VRAM (192 GB) | `e2e-ci.sh` | `a` | Manually by Maintainers, Automatically against `main` branch at 11AM UTC | Yes |
 | [`e2e-nvidia-l40s-x8.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x8.yml) | X-Large | AWS |[`g6e.48xlarge`](https://aws.amazon.com/ec2/instance-types/g6e/) | CentOS Stream 9 | 8 x NVIDIA L40S w/ 192 GB VRAM (384 GB) | `e2e-ci.sh` | `x` | Manually by Maintainers, Automatically against `main` branch at 11AM UTC | Yes |
 
 ### E2E Test Coverage Matrix
 
-| Area | Feature | [`e2e-nvidia-t4-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-t4-x1.yml) | [`e2e-nvidia-l4-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l4-x1.yml) | [`e2e-nvidia-l40s-x4.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x4.yml) | [`e2e-nvidia-l40s-x8.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x8.yml) |
+| Area | Feature | [`e2e-nvidia-t4-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-t4-x1.yml) | [`e2e-nvidia-l4-x1.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l4-x1.yml) | [`e2e-nvidia-l40s-x4.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x4.yml)(*3) | [`e2e-nvidia-l40s-x8.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/e2e-nvidia-l40s-x8.yml) |
 | --- | --- | --- | --- | --- | --- |
 | **Serving**  | llama-cpp                 |✅|✅|⎯|⎯|
 |              | vllm                      |⎯|✅|✅|✅|
@@ -97,36 +93,43 @@ Points of clarification (*):
 
 1. The `simple` training pipeline uses 4-bit-quantization. We cannot use the trained model here due to [#579](https://github.com/instructlab/instructlab/issues/579)
 2. `MMLU Branch` is not run as the `full` SDG pipeline does not create the needed files in the tasks directory when only training against a skill.
+3. Also applies to [`e2e-nvidia-l40s-x4-llama.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/`e2e-nvidia-l40s-x4-py312.yml`) and [`e2e-nvidia-l40s-x4-py312.yml`](https://github.com/instructlab/instructlab/blob/main/.github/workflows/`e2e-nvidia-l40s-x4-py312.yml`).
 
 ### Discord reporting
 
-Some E2E jobs send their results to the channel `#e2e-ci-results` via the `Son of Jeeves` bot in Discord. You can see which jobs currently have reporting via the "Current E2E Jobs" table above.
+Upon completion, the `Son of Jeeves` bot sends the results of some E2E jobs to the channel `#e2e-ci-results` in Discord and Slack. See which jobs currently have reporting via the "Current E2E Jobs" table above.
 
 In Discord, we use [actions/actions-status-discord](https://github.com/sarisia/actions-status-discord) and the built-in channel webhooks feature.
 
-### Triggering an E2E job via GitHub Web UI
+### Triggering an E2E job via GitHub Web user interface
 
 For the E2E jobs that can be launched manually, they take an input field that
 specifies the PR number or git branch to run them against. If you run them
 against a PR, they will automatically post a comment to the PR when the tests
 begin and end so it's easier for those involved in the PR to follow the results.
 
-1. Visit the [Actions tab](https://github.com/instructlab/instructlab/actions).
-2. Click on one of the E2E workflows on the left side of the page.
-3. Click on the `Run workflow` button on the right side of the page.
-4. Enter a branch name or a PR number in the input field.
-5. Click the green `Run workflow` button.
+1. In a web browser, navigate to [Actions](https://github.com/instructlab/instructlab/actions).
+2. Click the E2E workflow to run under `Actions`.
+3. Click `Run workflow` on the right side of the page.
+4. Enter a pull request number or branch name.
+5. Click `Run workflow`.
 
-Here is an example of using the GitHub Web UI to launch an E2E workflow:
+Here is an example of using the GitHub Web user interface to trigger an E2E workflow:
 
 ![GitHub Actions Run Workflow Example](images/github-actions-run-workflow-example.png)
 
-## Dependency on external Pull Requests
+## Dependency on external pull requests
 
-[depends-on-action](https://github.com/marketplace/actions/pr-dependency-management) is activated in the GitHub action workflows. To declare a dependency on an external PR, use the following syntax in the description of your Pull Request:
+[depends-on-action](https://github.com/marketplace/actions/pr-dependency-management) is activated in the GitHub action workflows. To declare a dependency on an external PR, use the following syntax in the description of your pull request:
 
 ```text
 Change to use the new library function
 
 Depends-On: https://github.com/org/library/pull/123
 ```
+
+## Reusable actions
+
+The [`ci-actions`](https://github.com/instructlab/ci-actions) repository contains reusable, in-house GitHub actions specific to the InstructLab organization.
+
+For more information on the actions included and how to integrate them into other jobs, see the [README](https://github.com/instructlab/ci-actions?tab=readme-ov-file#ci-actions) and documentation accompanying each action.

--- a/scripts/e2e-ci.sh
+++ b/scripts/e2e-ci.sh
@@ -529,6 +529,7 @@ usage() {
     echo "  -s  Run small t-shirt size job"
     echo "  -m  Run medium t-shirt size job"
     echo "  -l  Run large t-shirt size job"
+    echo "  -a  Run large T-shirt size job with llama pipeline."
     echo "  -x  Run extra large t-shirt size job"
     echo "  -p  Preserve the E2E_TEST_DIR for debugging"
     echo "  -h  Show this help text"


### PR DESCRIPTION
Makes the following changes to the CI documentation -

* Removes references to MacOS runners
* Adds a note regarding the '-a' flag on the e2e-ci.sh script and adds the same to the help output
* Adds mention of the new X-large t-shirt size and adds mention of the llama and p3.12 workflows
* Adds a new section on reusable CI actions
* General touch ups and edits

Further notes - 
* The cron job on the X-large job is currently disabled, so did not add mention of this
* The llama and p3.12 jobs appear to be of the same framework as the existing large workflow, so added a note to the table on 'simple', 'generation', etc. to note the same
* Didn't find any other changes to cron scheduling

**Issue resolved by this Pull Request:**
Resolves #3382 