### PR TITLE
Ignore mypy check for Haystack

### DIFF
--- a/src/instructlab/rag/haystack/document_store_ingestor.py
+++ b/src/instructlab/rag/haystack/document_store_ingestor.py
@@ -63,7 +63,7 @@ class HaystackDocumentStoreIngestor(DocumentStoreIngestor):
             )
             document_store = self._pipeline.get_component(
                 "document_writer"
-            ).document_store
+            ).document_store  # type: ignore [attr-defined]
             logger.info(f"count_documents: {document_store.count_documents()}")
 
             # Final step required for InMemory document store


### PR DESCRIPTION
This change adds and ignore directive to a line that mypy doesn't like relating to Haystack.  In general, Haystack doesn't have as much strong typing as mypy prefers, so it is important to tell mypy to accept Haystack constructs.  I tried running this locally and it seems to work fine so I think the ignore directive is fine.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
