### PR TITLE
tests: improve nonexistent filename in config file test

### DIFF
--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -581,7 +581,7 @@ test_ilab_chat_server_logs(){
 
 test_ilab_help_without_config() {
     # Test the help without config file after the fix
-    result=$(ilab --config=test-test.yaml model evaluate --help)
+    result=$(ilab --config=nonexistent.yaml model evaluate --help)
     if echo "$result" | grep -F 'Usage: ilab model evaluate [OPTIONS]'; then
         echo "Test passed: ilab model evaluate help message found."
     else
@@ -589,7 +589,7 @@ test_ilab_help_without_config() {
         exit 1
     fi
 
-    result=$(ilab --config=test-test.yaml config show --help)
+    result=$(ilab --config=nonexistent.yaml config show --help)
     if echo "$result" | grep -F 'Usage: ilab config show [OPTIONS]'; then
         echo "Test passed: ilab config show help message found."
     else
@@ -599,9 +599,9 @@ test_ilab_help_without_config() {
 
     set +e
     # Test the command run without config file, and fail as expected
-    result=$(ilab --config=test-test.yaml config show 2>&1)
+    result=$(ilab --config=nonexistent.yaml config show 2>&1)
 
-    if echo "$result" | grep -F "Error: \`test-test.yaml\` does not exist or is not a readable file"; then
+    if echo "$result" | grep -F "Error: \`nonexistent.yaml\` does not exist or is not a readable file"; then
         echo "Test passed: ilab config show ran as expected with error message."
     else
         echo "Error: ilab config show did not output the expected error message."


### PR DESCRIPTION
The `test_ilab_help_without_config` functional test from #2795 asserts that `ilab` works correctly when a given configuration file does not exist.

To make the intent clearer in the code and test run output, use a filename that indicates that we do not expect this file to exist.