### PR TITLE
chore: Bump ci-actions version to v0.2 + replace commit SHA in `constraints-update.yml`

### DIFF
--- a/.github/workflows/constraints-update.yml
+++ b/.github/workflows/constraints-update.yml
@@ -21,8 +21,7 @@ jobs:
         with:
           repository: instructlab/ci-actions
           path: ci-actions
-          # no tag that includes https://github.com/instructlab/ci-actions/pull/26, yet
-          ref: 88641ccaf122964eacdc1a82b18bda369b6f99bd # main
+          ref: v0.2.1
           sparse-checkout: |
             actions/update-constraints
 

--- a/.github/workflows/e2e-aws-custom.yml
+++ b/.github/workflows/e2e-aws-custom.yml
@@ -42,7 +42,7 @@ jobs:
           repository: instructlab/ci-actions
           # clone the "ci-actions" repo to a local directory called "ci-actions", instead of overwriting the current WORKDIR contents
           path: ci-actions
-          ref: release-v0.1
+          ref: v0.2.1
           sparse-checkout: |
             actions/launch-ec2-runner-with-fallback
 

--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -66,7 +66,7 @@ jobs:
           # clone the "ci-actions" repo to a local directory called "ci-actions", instead of
           # overwriting the current WORKDIR contents
           path: ci-actions
-          ref: release-v0.1
+          ref: v0.2.1
           sparse-checkout: |
             actions/launch-ec2-runner-with-fallback
 

--- a/.github/workflows/e2e-nvidia-l40s-x4-llama.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4-llama.yml
@@ -31,7 +31,7 @@ jobs:
           # clone the "ci-actions" repo to a local directory called "ci-actions", instead of
           # overwriting the current WORKDIR contents
           path: ci-actions
-          ref: release-v0.1
+          ref: v0.2.1
           sparse-checkout: |
             actions/launch-ec2-runner-with-fallback
 

--- a/.github/workflows/e2e-nvidia-l40s-x4-py312.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4-py312.yml
@@ -31,7 +31,7 @@ jobs:
           # clone the "ci-actions" repo to a local directory called "ci-actions", instead of
           # overwriting the current WORKDIR contents
           path: ci-actions
-          ref: release-v0.1
+          ref: v0.2.1
           sparse-checkout: |
             actions/launch-ec2-runner-with-fallback
 

--- a/.github/workflows/e2e-nvidia-l40s-x4-release.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4-release.yml
@@ -31,7 +31,7 @@ jobs:
           # clone the "ci-actions" repo to a local directory called "ci-actions", instead of
           # overwriting the current WORKDIR contents
           path: ci-actions
-          ref: release-v0.1
+          ref: v0.2.1
           sparse-checkout: |
             actions/launch-ec2-runner-with-fallback
 

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -31,7 +31,7 @@ jobs:
           # clone the "ci-actions" repo to a local directory called "ci-actions", instead of
           # overwriting the current WORKDIR contents
           path: ci-actions
-          ref: release-v0.1
+          ref: v0.2.1
           sparse-checkout: |
             actions/launch-ec2-runner-with-fallback
 

--- a/.github/workflows/e2e-nvidia-l40s-x8.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x8.yml
@@ -32,7 +32,7 @@ jobs:
           # clone the "ci-actions" repo to a local directory called "ci-actions", instead of
           # overwriting the current WORKDIR contents
           path: ci-actions
-          ref: release-v0.1
+          ref: v0.2.1
           sparse-checkout: |
             actions/launch-ec2-runner-with-fallback
 


### PR DESCRIPTION
**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.

We have a new Y-stream release: https://github.com/instructlab/ci-actions/releases

This PR bumps the minimum versions to consume the latest y-stream release's changes.

Note that we haven't made any changes to the `launch-ec2-runner-with-fallback` CI action in release v0.2, but I'm bumping the minimum version in case we do need to consume future bugfixes, etc. for that action.