### PR TITLE
Bump llama_cpp_python to 0.3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ instructlab-quantize>=0.1.0
 instructlab-schema>=0.4.2
 instructlab-sdg>=0.7.3
 instructlab-training>=0.10.1
-llama_cpp_python[server]>=0.3.6
+llama_cpp_python[server]>=0.3.8
 mlx>=0.5.1,<0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 numpy>=1.26.4
 openai>=1.13.3


### PR DESCRIPTION
While running the installation we can hit the following error: Fail to install llama-cpp-python with error "error: ‘uint32_t’ does not name a type uint32_t read_u32() const

To workaround this issue we can use export CXX="g++ -include cstdint"

A fix was already provided to the llama.cpp ggml-org/llama.cpp@19b392d This was doing Feburary, so by bumping 0.3.8 we should be good, since it was released in March.

**Issue resolved by this Pull Request:**
Resolves #3474 