### PR TITLE
ci: Run -unitcov test flavor for all python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -159,3 +159,8 @@ commands =
 [gh]
 python =
     3.11 = py311-{unitcov, functional}
+    3.12 = py312-{unitcov, functional}
+    3.13 = py313-{unitcov, functional}
+    3.14 = py314-{unitcov, functional}
+    3.15 = py315-{unitcov, functional}
+    3.16 = py316-{unitcov, functional}


### PR DESCRIPTION
I've noticed that only py311 run uses `unitcov` flavor; others use
`unit`. Other flavors also run `ruff` and other unrelated checks that
are part of other CI jobs.

Looks like one has to list `[gh]` entries for each version of interest
to make it work as intended. I'm listing more versions to cover any
future python releases in the near future.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
