### PR TITLE
ci: upload artifacts for debugging

### DIFF
--- a/.github/workflows/e2e-nvidia-l4-x1.yml
+++ b/.github/workflows/e2e-nvidia-l4-x1.yml
@@ -166,6 +166,14 @@ jobs:
         run: |
           df -h
 
+      - name: Upload instructlab dir to artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ~/.local/share/instructlab/**
+          retention-days: 1
+
   stop-medium-ec2-runner:
     needs:
       - start-medium-ec2-runner

--- a/.github/workflows/e2e-nvidia-l40s-x4.yml
+++ b/.github/workflows/e2e-nvidia-l40s-x4.yml
@@ -183,6 +183,15 @@ jobs:
         run: |
           df -h
 
+      - name: Upload instructlab dir to artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ~/.local/share/instructlab/**
+          retention-days: 1
+
+
       - name: Add comment to PR if the workflow failed
         if: failure() && steps.check_pr.outputs.is_pr == 'true'
         run: |


### PR DESCRIPTION
its currently impossible to debug why something fails during training because we don't have access to the phased logs in CI, add upload of the entire ~/.local/share/instructlab directory in as a mandatory step after testing. 
