### PR TITLE
fix(#3511): temperature is float type in model chat OpenAI API call

### DIFF
--- a/src/instructlab/model/chat.py
+++ b/src/instructlab/model/chat.py
@@ -872,7 +872,7 @@ def chat_cli(
         prompt=not qq,
         vertical_overflow=("visible" if visible_overflow else "ellipsis"),
         loaded=loaded,
-        temperature=(temperature if temperature is not None else temperature),
+        temperature=(float(temperature) if temperature is not None else temperature),
         max_tokens=(max_tokens if max_tokens else max_tokens),
         max_ctx_size=max_ctx_size,
         backend_type=backend_type,


### PR DESCRIPTION
Bugfix - `temperature` is sent as `float` type in model chat OpenAI API POST call instead of `string` as OpenAI API specification requires `float`.

**Issue resolved by this Pull Request:**
Resolves #3511 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release - not updated as this is really small bugfix
- [x] Documentation has been updated, if necessary - not necessary
- [x] Unit tests have been added, if necessary - not necessary
- [x] Functional tests have been added, if necessary - not necessary
- [x] E2E Workflow tests have been added, if necessary - not necessary
