### PR TITLE
feat: add configurable max retries for OpenAI client

### DIFF
--- a/src/instructlab/cli/data/generate.py
+++ b/src/instructlab/cli/data/generate.py
@@ -179,6 +179,13 @@ logger = logging.getLogger(__name__)
     type=click.STRING,
     show_default=True,
 )
+@click.option(
+    "--openai-client-max-retries",
+    type=click.INT,
+    default=DEFAULTS.OPENAI_CLIENT_MAX_RETRIES,
+    show_default=True,
+    help="Max retries for the openai client used to interact with teacher model.",
+)
 @click.pass_context
 @clickext.display_params
 def generate(
@@ -209,6 +216,7 @@ def generate(
     detached,
     student_model_id: str | None,
     teacher_model_id: str | None,
+    openai_client_max_retries: int,
 ):
     """Generates synthetic data to enhance your example data"""
 
@@ -363,6 +371,7 @@ def generate(
             legacy_pretraining_format,
             process_mode=process_mode,
             log_level=ctx.obj.config.general.log_level,
+            openai_client_max_retries=openai_client_max_retries,
         )
         if not detached:
             click.echo("ᕦ(òᴗóˇ)ᕤ Data generate completed successfully! ᕦ(òᴗóˇ)ᕤ")

--- a/src/instructlab/data/generate_data.py
+++ b/src/instructlab/data/generate_data.py
@@ -34,6 +34,7 @@ def gen_data(
     use_legacy_pretraining_format,
     process_mode,
     log_level,
+    openai_client_max_retries,
 ):
     """Generates synthetic data to enhance your example data"""
     # First Party
@@ -88,6 +89,7 @@ def gen_data(
         max_num_tokens=max_num_tokens,
         system_prompt=system_prompt,
         use_legacy_pretraining_format=use_legacy_pretraining_format,
+        openai_client_max_retries=openai_client_max_retries,
         # http_client_params=http_client_params,
     )
 
@@ -125,6 +127,7 @@ def create_server_and_generate(
     log_file,
     local_uuid,
     process_mode,
+    openai_client_max_retries,
 ):
     backend_instance = None
     # we need to use the instructlab logger so that the libraries inherit the config we set up.
@@ -191,7 +194,10 @@ def create_server_and_generate(
             batch_size = 0
 
     client = openai.OpenAI(
-        base_url=api_base, api_key=api_key, http_client=http_client(http_client_params)
+        base_url=api_base,
+        max_retries=openai_client_max_retries,
+        api_key=api_key,
+        http_client=http_client(http_client_params),
     )
     # Third Party
     from instructlab.sdg.generate_data import generate_data

--- a/src/instructlab/defaults.py
+++ b/src/instructlab/defaults.py
@@ -114,6 +114,7 @@ class _InstructlabDefaults:
     SDG_PIPELINE = "full"
     SDG_SCALE_FACTOR = 30
     SDG_MAX_NUM_TOKENS = 4096
+    OPENAI_CLIENT_MAX_RETRIES = 2
 
     # When otherwise unknown, ilab uses this as the default family
     MODEL_FAMILY = "granite"


### PR DESCRIPTION
Introduce a new option `--openai-client-max-retries` to control the maximum retry attempts for the OpenAI client.



<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  5. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->


Resolves #https://github.com/instructlab/instructlab/issues/3516

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Functional tests have been added, if necessary.
- [x] E2E Workflow tests have been added, if necessary.
