### PR TITLE
fix: add Granite 3.1 architecture to in-memory template mapping

### DIFF
--- a/src/instructlab/model/backends/common.py
+++ b/src/instructlab/model/backends/common.py
@@ -34,6 +34,12 @@ VLLM = "vllm"
 templates = [
     {
         "family": "granite",
+        "arch": SupportedModelArchitectures.GRANITE3_128K,
+        "template": granite.CHAT_TEMPLATE,
+        "special_tokens": granite.SPECIAL_TOKENS,
+    },
+    {
+        "family": "granite",
         "arch": SupportedModelArchitectures.GRANITE,
         "template": granite.CHAT_TEMPLATE,
         "special_tokens": granite.SPECIAL_TOKENS,


### PR DESCRIPTION
This change adds SupportedModelArchitectures.GRANITE3_128K to the in-memory templates list. Without this entry, models can default to the legacy Granite 7B-style chat template, which uses <|user|>/<|assistant|> tokens instead of the expected <|start_of_role|> and <|end_of_role|> format.

Adding the explicit mapping resolves the issue and ensures the correct template is used when model_arch resolves to granite_3.1.

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section with the Pull Requests needed by this change
Depends-On: <PR1 URL>
Depends-On: <PR2 URL>
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.
