### PR TITLE
chore: Reduce number of required reviews for Mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,7 +4,7 @@ pull_request_rules:
     automatic merge for main with >= 2 approved reviews,
     all requested reviews have given feedback, not held, and CI is successful
   conditions:
-    - "#approved-reviews-by>=2"
+    - "#approved-reviews-by>=1"
     - "#review-requested=0"
     - "#changes-requested-reviews-by=0"
     - or:
@@ -241,22 +241,6 @@ pull_request_rules:
     label:
       remove:
         - ci-failure
-
-- name: Apply 'one-approval' label if one of the maintainer approved the PR
-  conditions:
-      - "#approved-reviews-by=1"
-  actions:
-    label:
-      add:
-        - one-approval
-
-- name: Remove 'one-approval' label if the approval was reset
-  conditions:
-      - "#approved-reviews-by!=1"
-  actions:
-    label:
-      remove:
-        - one-approval
 
 - name: label-dependencies
   description: Automatically apply dependencies label


### PR DESCRIPTION
**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the
  [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/instructlab/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Functional tests have been added, if necessary.
- [ ] E2E Workflow tests have been added, if necessary.

I've recently reduced the number of required reviews in our repository from 2 to 1, but I forgot to reduce the requirements in Mergify's config as well. This commit removes the "one-approval" label logic and reduces the number of required reviews for automatic merging from 2 to 1.